### PR TITLE
chore(content): add Claude Code configuration and CLAUDE.md

### DIFF
--- a/.claude/MEMORY.md
+++ b/.claude/MEMORY.md
@@ -1,0 +1,30 @@
+# Memory Index — passtheo-content-service
+
+> Auto-maintained by Claude Code. See CLAUDE.md for static rules.
+
+## Architectural Decisions
+
+<!-- 2026-03-30 | Seed -->
+- Outbox pattern: never call KafkaTemplate directly in service layer
+- Strapi content is always fetched via StrapiApiClient with circuit breaker — never call Strapi URL directly
+- Free tier enforcement is a subscription-service concern — content-service checks entitlements via SubscriptionServiceClient
+- @Transactional on service layer only — controllers have none
+
+## Known Gotchas
+
+<!-- 2026-03-30 | Seed -->
+- Redis DB 3 is for Strapi content cache only — do not store user data here
+- Circuit breaker for Strapi: on open, serve stale cache or return 503 — never fail silently
+- Streak logic uses UTC calendar day — practicing at 23:59 and 00:01 UTC counts as two streak days
+- Readiness snapshot is computed by scheduler, not in real-time per request
+- spring.flyway.clean-disabled=true — never run flyway:clean
+- 8 migrations — most entities in the platform
+
+## Test Patterns
+
+<!-- 2026-03-30 | Seed -->
+- Unit tests: @ExtendWith(MockitoExtension.class) — no @SpringBootTest
+- Test naming: methodName_scenario_expectedOutcome
+- RLS isolation tests mandatory
+- Mock StrapiApiClient in unit tests — it calls an external service
+- WireMock for Strapi API integration tests

--- a/.claude/memory/patterns.md
+++ b/.claude/memory/patterns.md
@@ -1,0 +1,9 @@
+# Patterns — passtheo-content-service
+
+> Detailed pattern notes added as Claude Code works in this repo.
+> Index is in MEMORY.md.
+
+## Patterns Discovered
+
+<!-- Claude Code will add entries here as it encounters patterns -->
+<!-- Format: date | task — pattern description -->

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew clean build:*)",
+      "Bash(./gradlew build:*)",
+      "Bash(./gradlew test:*)",
+      "Bash(./gradlew bootRun:*)",
+      "Bash(./gradlew bootJar:*)",
+      "Bash(./gradlew acceptanceTest:*)",
+      "Bash(./gradlew jacocoTestReport:*)",
+      "Bash(./gradlew checkstyleMain:*)",
+      "Bash(./gradlew dependencies:*)",
+      "Bash(./gradlew publishToMavenLocal:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git branch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh project:*)",
+      "Bash(ls:*)",
+      "Bash(find src:*)",
+      "Bash(docker compose:*)"
+    ],
+    "deny": [
+      "Bash(./gradlew flywayClean:*)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,6 @@
       "Bash(./gradlew jacocoTestReport:*)",
       "Bash(./gradlew checkstyleMain:*)",
       "Bash(./gradlew dependencies:*)",
-      "Bash(./gradlew publishToMavenLocal:*)",
       "Bash(git status:*)",
       "Bash(git log:*)",
       "Bash(git diff:*)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# Content Service — Claude Code Guide
+
+> Practice sessions, mock exams, progress tracking, streaks, achievements, study plans, Strapi integration.
+> See root CLAUDE.md for architecture rules, Git workflow, and platform conventions.
+
+## Identity
+
+| Property | Value |
+|----------|-------|
+| Port | 8087 |
+| Package | `com.passtheo.content` |
+| Database | `content_db` (public schema) |
+| Redis DB | 3 (Strapi content cache) |
+
+## Commands
+
+| Task | Command |
+|------|---------|
+| Build | `./gradlew clean build` |
+| Test | `./gradlew test` |
+| Run | `./gradlew bootRun` |
+
+## Source Layout
+
+```
+src/main/java/com/passtheo/content/
+├── controller/      # PracticeController, ExamController, ProgressController, StreakController, AchievementController, StudyPlanController, ContentBrowsingController
+├── service/         # PracticeSessionService, MockExamService, ProgressService, ReadinessService, StudyPlanService, StreakService, AchievementService, QuestionDifficultyService
+├── repository/      # StudySessionRepository, ExamAttemptRepository, StreakRepository, EarnedAchievementRepository, QuestionProgressRepository, DomainProgressRepository, TopicProgressRepository, ReadinessSnapshotRepository
+├── entity/          # StudySession, SessionAnswer, ExamAttempt, ExamAnswer, StudyPlan, Streak, EarnedAchievement, QuestionProgress, DomainProgress, TopicProgress, ReadinessSnapshot
+├── client/          # StrapiApiClient, StrapiApiClientConfig, SubscriptionServiceClient
+├── kafka/           # ContentEventProducer, OutboxPoller, UserEventConsumer, TenantEventConsumer, SubscriptionEventConsumer
+├── scheduler/       # StreakExpiryScheduler, ReadinessSnapshotScheduler, StudyPlanResetScheduler
+├── mapper/
+├── dto/
+└── config/
+```
+
+## Strapi Integration
+
+- `StrapiApiClient` fetches questions, lessons, exam configs, achievement definitions
+- All responses cached in Redis DB 3 — TTL: 1h for questions, 24h for static content
+- Circuit breaker wraps all Strapi calls — on open, serve from Redis cache or return 503
+- **Never cache user-specific data** in the Strapi cache layer
+
+## Domain Rules
+
+- **Readiness score:** rolling 7-day weighted average of correct answer rates per domain
+- **Streak:** incremented once per UTC calendar day when any study activity occurs
+- **Free tier limits:** checked against subscription-service — call `SubscriptionServiceClient.getEntitlements()`
+- **Question difficulty:** Elo-like algorithm in `QuestionDifficultyService` — updates after each answer
+
+## Kafka
+
+**Produces** (via outbox → `passtheo.content.events`):
+- `ExamCompletedEvent`, `AchievementEarnedEvent`, `StreakUpdatedEvent`, `ReadinessChangedEvent`
+
+**Consumes:**
+- `passtheo.user.events` — `UserCreatedEvent` → initialise user progress records
+- `passtheo.tenant.events` — `TenantCreatedEvent` → initialise tenant content config
+- `passtheo.subscription.events` — `SubscriptionActivatedEvent/ExpiredEvent` → update access tier
+
+## Database
+
+8 migrations in `src/main/resources/db/migration/`.
+Every `V{n}__*.sql` has a companion `U{n}__*.sql` undo script.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,9 @@
 |------|---------|
 | Build | `./gradlew clean build` |
 | Test | `./gradlew test` |
+| Coverage | `./gradlew jacocoTestReport` (target: 80%) |
 | Run | `./gradlew bootRun` |
+| Acceptance | `./gradlew acceptanceTest` |
 
 ## Source Layout
 


### PR DESCRIPTION
Closes #4

## Changes
- Added CLAUDE.md with service identity, commands, source layout, Kafka topics, key patterns
- Added .claude/settings.json with pre-approved build/test commands
- Added .claude/MEMORY.md seeded with architectural decisions and gotchas
- Added .claude/memory/patterns.md placeholder for accumulated pattern notes

## Test plan
- [ ] Open repo in Claude Code — verify CLAUDE.md is auto-loaded
- [ ] Run primary build command — verify no confirmation prompt