### PR TITLE
feat(content): wire WireMock contract stubs, fix SubscriptionClient paths

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,10 +105,33 @@ dependencies {
     testImplementation("org.springframework.kafka:spring-kafka-test")
     testImplementation("io.rest-assured:rest-assured:5.4.0")
     testImplementation("com.intuit.karate:karate-junit5:1.4.1")
+    testImplementation("org.wiremock:wiremock-standalone:3.12.1")
 }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
+tasks.test {
+    useJUnitPlatform {
+        excludeTags("acceptance")
+    }
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+val copyContracts by tasks.registering(Copy::class) {
+    description = "Copies contract stubs from the contracts repo into the build directory for use in tests"
+    group = "verification"
+    from("../contracts")
+    into(layout.buildDirectory.dir("contracts"))
+}
+
+val acceptanceTest by tasks.registering(Test::class) {
+    description = "Runs Karate acceptance tests against a booted Spring Boot context"
+    group = "verification"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    useJUnitPlatform {
+        includeTags("acceptance")
+    }
+    systemProperty("spring.profiles.active", "acceptance")
+    dependsOn(copyContracts)
 }
 
 tasks.withType<JavaCompile> {
@@ -184,10 +207,6 @@ tasks.jacocoTestCoverageVerification {
             )
         }
     }
-}
-
-tasks.test {
-    finalizedBy(tasks.jacocoTestReport)
 }
 
 tasks.check {

--- a/src/main/java/com/passtheo/content/integration/subscription/SubscriptionClient.java
+++ b/src/main/java/com/passtheo/content/integration/subscription/SubscriptionClient.java
@@ -6,7 +6,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -30,7 +32,8 @@ public class SubscriptionClient {
     }
 
     /**
-     * Increments the daily question usage counter for a free user.
+     * Increments the daily question usage counter for a user.
+     * Returns false when the 429 rate-limit response is received (daily limit reached).
      *
      * @param tenantId the tenant ID
      * @param userId   the user's Keycloak ID
@@ -38,14 +41,21 @@ public class SubscriptionClient {
      */
     public boolean incrementQuestionUsage(@Nonnull UUID tenantId, @Nonnull UUID userId) {
         try {
-            Boolean allowed = webClient.post()
-                    .uri("/internal/subscription/usage/increment-question")
+            webClient.post()
+                    .uri("/internal/subscriptions/usage/increment")
                     .header("X-Tenant-ID", tenantId.toString())
                     .header("X-Keycloak-User-ID", userId.toString())
+                    .bodyValue(Map.of("type", "QUESTION"))
                     .retrieve()
-                    .bodyToMono(Boolean.class)
+                    .bodyToMono(String.class)
                     .block();
-            return Boolean.TRUE.equals(allowed);
+            return true;
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode().value() == 429) {
+                return false;
+            }
+            LOG.error("Failed to increment question usage for user {}: {}", userId, e.getMessage());
+            return true;
         } catch (Exception e) {
             LOG.error("Failed to increment question usage for user {}: {}", userId, e.getMessage());
             return true;
@@ -53,7 +63,7 @@ public class SubscriptionClient {
     }
 
     /**
-     * Checks if a free user can start a mock exam (weekly limit).
+     * Checks if a user can start a mock exam (weekly limit check).
      *
      * @param tenantId the tenant ID
      * @param userId   the user's Keycloak ID
@@ -62,7 +72,10 @@ public class SubscriptionClient {
     public boolean canStartExam(@Nonnull UUID tenantId, @Nonnull UUID userId) {
         try {
             Boolean allowed = webClient.get()
-                    .uri("/internal/subscription/usage/can-start-exam")
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/internal/subscriptions/usage/can-use")
+                            .queryParam("type", "EXAM")
+                            .build())
                     .header("X-Tenant-ID", tenantId.toString())
                     .header("X-Keycloak-User-ID", userId.toString())
                     .retrieve()

--- a/src/test/java/com/passtheo/content/KarateRunner.java
+++ b/src/test/java/com/passtheo/content/KarateRunner.java
@@ -1,5 +1,7 @@
 package com.passtheo.content;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.intuit.karate.junit5.Karate;
 import com.passtheo.content.config.TestSchedulingConfig;
 import com.passtheo.content.integration.strapi.StrapiClient;
@@ -13,7 +15,9 @@ import com.passtheo.content.integration.strapi.dto.StrapiQuestionDto;
 import com.passtheo.content.integration.strapi.dto.StrapiRelationDto;
 import com.passtheo.content.integration.strapi.dto.StrapiTopicDto;
 import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -22,6 +26,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import javax.sql.DataSource;
@@ -41,7 +47,28 @@ import static org.mockito.Mockito.when;
 @ActiveProfiles("acceptance")
 @Import({TestSchedulingConfig.class})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag("acceptance")
 class KarateRunner {
+
+    private static final WireMockServer USER_SERVICE_MOCK = new WireMockServer(
+            WireMockConfiguration.wireMockConfig()
+                    .dynamicPort()
+                    .usingFilesUnderDirectory("../contracts/user-service")
+    );
+
+    private static final WireMockServer SUBSCRIPTION_SERVICE_MOCK = new WireMockServer(
+            WireMockConfiguration.wireMockConfig()
+                    .dynamicPort()
+                    .usingFilesUnderDirectory("../contracts/subscription-service")
+    );
+
+    @DynamicPropertySource
+    static void configureExternalServiceUrls(DynamicPropertyRegistry registry) {
+        USER_SERVICE_MOCK.start();
+        SUBSCRIPTION_SERVICE_MOCK.start();
+        registry.add("passtheo.user-service.base-url", USER_SERVICE_MOCK::baseUrl);
+        registry.add("passtheo.subscription-service.base-url", SUBSCRIPTION_SERVICE_MOCK::baseUrl);
+    }
 
     @LocalServerPort
     private int port;
@@ -55,6 +82,16 @@ class KarateRunner {
     @Autowired
     @Qualifier("actualDataSource")
     private DataSource rawDataSource;
+
+    @AfterAll
+    void stopWireMock() {
+        if (USER_SERVICE_MOCK.isRunning()) {
+            USER_SERVICE_MOCK.stop();
+        }
+        if (SUBSCRIPTION_SERVICE_MOCK.isRunning()) {
+            SUBSCRIPTION_SERVICE_MOCK.stop();
+        }
+    }
 
     @BeforeAll
     void setupAll() {


### PR DESCRIPTION
Closes #6

## Changes
- Fix `SubscriptionClient` endpoint paths: `/internal/subscription/...` → `/internal/subscriptions/...`
- Fix response parsing: increment returns `ApiResponse<DailyUsageDto>` (200=allowed, 429=denied)
- Fix `canStartExam`: `/can-start-exam` → `/can-use?type=EXAM` returning plain boolean
- Replace `@MockitoBean` UserServiceClient/SubscriptionClient with embedded WireMock in `KarateRunner`
- Start two WireMock servers (user-service + subscription-service) via `@DynamicPropertySource`
- Add `acceptanceTest` and `copyContracts` Gradle tasks
- Add `wiremock-standalone:3.12.1` test dependency

## Test plan
- [ ] `./gradlew test` — unit tests pass
- [ ] `./gradlew acceptanceTest` — Karate tests pass with WireMock serving contract stubs