### PR TITLE
fix(content): fix streaks 500 and wire daily question limit

### DIFF
--- a/src/main/java/com/passtheo/content/controller/PracticeController.java
+++ b/src/main/java/com/passtheo/content/controller/PracticeController.java
@@ -6,6 +6,7 @@ import com.passtheo.content.dto.response.ActiveSessionDto;
 import com.passtheo.content.dto.response.AnswerResultDto;
 import com.passtheo.content.dto.response.SessionDto;
 import com.passtheo.content.dto.response.SessionSummaryDto;
+import com.passtheo.content.integration.subscription.SubscriptionClient;
 import com.passtheo.content.service.EntitlementChecker;
 import com.passtheo.content.service.PracticeSessionService;
 import com.passtheo.shared.core.dto.ApiResponse;
@@ -40,17 +41,21 @@ public class PracticeController {
 
     private final PracticeSessionService practiceSessionService;
     private final EntitlementChecker entitlementChecker;
+    private final SubscriptionClient subscriptionClient;
 
     /**
      * Constructs the practice controller.
      *
      * @param practiceSessionService practice session service
      * @param entitlementChecker     entitlement checker
+     * @param subscriptionClient     subscription client for usage tracking
      */
     public PracticeController(PracticeSessionService practiceSessionService,
-                              EntitlementChecker entitlementChecker) {
+                              EntitlementChecker entitlementChecker,
+                              SubscriptionClient subscriptionClient) {
         this.practiceSessionService = practiceSessionService;
         this.entitlementChecker = entitlementChecker;
+        this.subscriptionClient = subscriptionClient;
     }
 
     /**
@@ -106,15 +111,24 @@ public class PracticeController {
      * @param tenantId  tenant ID from header
      * @param userId    user ID from header
      * @param request   answer request
+     * @param locale    content locale
      * @return answer result with feedback + next question
      */
     @PostMapping("/{sessionId}/answer")
-    public ResponseEntity<ApiResponse<AnswerResultDto>> submitAnswer(
+    public ResponseEntity<?> submitAnswer(
             @PathVariable @Nonnull UUID sessionId,
             @RequestHeader("X-Tenant-ID") UUID tenantId,
             @RequestHeader("X-Keycloak-User-ID") UUID userId,
             @RequestBody @Valid @Nonnull SubmitAnswerRequest request,
             @RequestParam(defaultValue = "nl") String locale) {
+
+        if (!subscriptionClient.incrementQuestionUsage(tenantId, userId)) {
+            ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.TOO_MANY_REQUESTS);
+            problem.setTitle("Daily question limit reached");
+            problem.setDetail("You have reached your daily question limit. Upgrade to continue practicing.");
+            problem.setType(URI.create("about:blank"));
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(problem);
+        }
 
         AnswerResultDto result = practiceSessionService.submitAnswer(userId, sessionId, request, locale);
         return ResponseEntity.ok(ApiResponse.success(result, MDC.get("traceId")));

--- a/src/main/java/com/passtheo/content/repository/SessionAnswerRepository.java
+++ b/src/main/java/com/passtheo/content/repository/SessionAnswerRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -63,7 +64,7 @@ public interface SessionAnswerRepository extends JpaRepository<SessionAnswer, UU
               AND sa.answered_at < :endDate
             ORDER BY 1
             """, nativeQuery = true)
-    List<java.sql.Date> findStudyDatesBetween(
+    List<LocalDate> findStudyDatesBetween(
             @Param("userId") UUID userId,
             @Param("productCode") String productCode,
             @Param("startDate") Instant startDate,

--- a/src/main/java/com/passtheo/content/service/StreakService.java
+++ b/src/main/java/com/passtheo/content/service/StreakService.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * Manages daily study streaks and freeze slots.
@@ -45,11 +44,10 @@ public class StreakService {
     private static final int FREEZE_AWARD_14 = 2;
     private static final int FREEZE_AWARD_30 = 3;
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
     private final StreakRepository streakRepository;
     private final SessionAnswerRepository sessionAnswerRepository;
     private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
 
     /**
      * Constructs the streak service.
@@ -57,13 +55,16 @@ public class StreakService {
      * @param streakRepository        the streak repository
      * @param sessionAnswerRepository the session answer repository
      * @param outboxEventRepository   the outbox event repository
+     * @param objectMapper            the Jackson object mapper (with JSR-310 module)
      */
     public StreakService(StreakRepository streakRepository,
                         SessionAnswerRepository sessionAnswerRepository,
-                        OutboxEventRepository outboxEventRepository) {
+                        OutboxEventRepository outboxEventRepository,
+                        ObjectMapper objectMapper) {
         this.streakRepository = streakRepository;
         this.sessionAnswerRepository = sessionAnswerRepository;
         this.outboxEventRepository = outboxEventRepository;
+        this.objectMapper = objectMapper;
     }
 
     /**
@@ -195,11 +196,8 @@ public class StreakService {
         Instant startDate = sixDaysAgo.atStartOfDay(ZoneOffset.UTC).toInstant();
         Instant endDate = today.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
 
-        Set<LocalDate> studyDates = sessionAnswerRepository
-                .findStudyDatesBetween(userId, productCode, startDate, endDate)
-                .stream()
-                .map(java.sql.Date::toLocalDate)
-                .collect(Collectors.toSet());
+        Set<LocalDate> studyDates = Set.copyOf(
+                sessionAnswerRepository.findStudyDatesBetween(userId, productCode, startDate, endDate));
 
         List<Boolean> result = new ArrayList<>(7);
         for (int i = 0; i < 7; i++) {
@@ -217,7 +215,7 @@ public class StreakService {
             outbox.setTenantId(tenantId);
             outbox.setEventType(event.eventType());
             outbox.setTopic(KafkaTopic.CONTENT_EVENTS);
-            outbox.setPayload(OBJECT_MAPPER.writeValueAsString(event));
+            outbox.setPayload(objectMapper.writeValueAsString(event));
             outbox.setStatus(OutboxStatus.PENDING);
             outbox.setPartitionKey(userId.toString());
             outboxEventRepository.save(outbox);

--- a/src/test/java/com/passtheo/content/unit/StreakServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/StreakServiceTest.java
@@ -1,5 +1,6 @@
 package com.passtheo.content.unit;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.passtheo.content.domain.entity.Streak;
 import com.passtheo.content.domain.valueobject.StreakResult;
 import com.passtheo.content.repository.OutboxEventRepository;
@@ -34,6 +35,7 @@ class StreakServiceTest {
     @Mock private StreakRepository streakRepository;
     @Mock private SessionAnswerRepository sessionAnswerRepository;
     @Mock private OutboxEventRepository outboxEventRepository;
+    @Mock private ObjectMapper objectMapper;
 
     private StreakService service;
 
@@ -43,7 +45,7 @@ class StreakServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new StreakService(streakRepository, sessionAnswerRepository, outboxEventRepository);
+        service = new StreakService(streakRepository, sessionAnswerRepository, outboxEventRepository, objectMapper);
         TenantContext.set(TENANT_ID);
     }
 
@@ -179,10 +181,10 @@ class StreakServiceTest {
     @Test
     void computeLastSevenDays_threeDaysStudied_correctBooleanArray() {
         LocalDate today = LocalDate.now(ZoneOffset.UTC);
-        List<java.sql.Date> studyDates = List.of(
-                java.sql.Date.valueOf(today),
-                java.sql.Date.valueOf(today.minusDays(1)),
-                java.sql.Date.valueOf(today.minusDays(4))
+        List<LocalDate> studyDates = List.of(
+                today,
+                today.minusDays(1),
+                today.minusDays(4)
         );
         when(sessionAnswerRepository.findStudyDatesBetween(any(), any(), any(Instant.class), any(Instant.class)))
                 .thenReturn(studyDates);
@@ -203,9 +205,9 @@ class StreakServiceTest {
     @Test
     void computeLastSevenDays_allDaysStudied_allTrue() {
         LocalDate today = LocalDate.now(ZoneOffset.UTC);
-        List<java.sql.Date> studyDates = new java.util.ArrayList<>();
+        List<LocalDate> studyDates = new java.util.ArrayList<>();
         for (int i = 0; i < 7; i++) {
-            studyDates.add(java.sql.Date.valueOf(today.minusDays(i)));
+            studyDates.add(today.minusDays(i));
         }
         when(sessionAnswerRepository.findStudyDatesBetween(any(), any(), any(Instant.class), any(Instant.class)))
                 .thenReturn(studyDates);


### PR DESCRIPTION
Closes #11

## Changes
- **Bug 1 (Streaks 500):** Replaced static `ObjectMapper` (missing JavaTimeModule) with Spring-managed instance via constructor injection. Fixed `SessionAnswerRepository.findStudyDatesBetween` return type from `java.sql.Date` to `LocalDate` to match PostgreSQL JDBC driver behavior.
- **Bug 2 (Daily limit):** Wired `SubscriptionClient.incrementQuestionUsage()` into `PracticeController.submitAnswer()`. Free-tier users now get 429 when exceeding daily question limit (10).
- Updated `StreakServiceTest` for new constructor signature and `LocalDate` return type.

## Test plan
- [x] `GET /api/streaks/me` returns 200 after practice (was 500)
- [x] Free-tier user gets 429 after 10 questions in a day
- [x] All 12 streak unit tests pass
- [x] Full API flow test: 342/345 pass (3 remaining are separate issues)