### PR TITLE
fix(content): persist session locale to fix mixed-language questions

### DIFF
--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -436,8 +436,11 @@ paths:
       description: |
         Records the answer, updates spaced repetition state, checks streak,
         checks achievements (async), and returns feedback + next question.
-        
+
         For free users, increments usage counter via subscription-service.
+
+        Content locale is read from the session record (stored at session creation).
+        The client does not need to send locale — the session is the source of truth.
       security:
         - bearerAuth: []
       parameters:
@@ -499,6 +502,9 @@ paths:
       operationId: getSession
       tags: [Practice]
       summary: Get current session state (for resuming after app close)
+      description: |
+        Returns the session with the current unanswered question.
+        Content locale is read from the session record — not from a query parameter.
       security:
         - bearerAuth: []
       parameters:

--- a/src/main/java/com/passtheo/content/controller/PracticeController.java
+++ b/src/main/java/com/passtheo/content/controller/PracticeController.java
@@ -106,12 +106,12 @@ public class PracticeController {
 
     /**
      * Submits an answer for the current question.
+     * Content locale is read from the session record — no locale parameter needed.
      *
      * @param sessionId the session ID
      * @param tenantId  tenant ID from header
      * @param userId    user ID from header
      * @param request   answer request
-     * @param locale    content locale
      * @return answer result with feedback + next question
      */
     @PostMapping("/{sessionId}/answer")
@@ -119,8 +119,7 @@ public class PracticeController {
             @PathVariable @Nonnull UUID sessionId,
             @RequestHeader("X-Tenant-ID") UUID tenantId,
             @RequestHeader("X-Keycloak-User-ID") UUID userId,
-            @RequestBody @Valid @Nonnull SubmitAnswerRequest request,
-            @RequestParam(defaultValue = "nl") String locale) {
+            @RequestBody @Valid @Nonnull SubmitAnswerRequest request) {
 
         if (!subscriptionClient.incrementQuestionUsage(tenantId, userId)) {
             ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.TOO_MANY_REQUESTS);
@@ -130,25 +129,24 @@ public class PracticeController {
             return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(problem);
         }
 
-        AnswerResultDto result = practiceSessionService.submitAnswer(userId, sessionId, request, locale);
+        AnswerResultDto result = practiceSessionService.submitAnswer(userId, sessionId, request);
         return ResponseEntity.ok(ApiResponse.success(result, MDC.get("traceId")));
     }
 
     /**
      * Gets current session state (for resuming after app close).
+     * Content locale is read from the session record.
      *
      * @param sessionId the session ID
      * @param userId    user ID from header
-     * @param locale    content locale
      * @return session with current question
      */
     @GetMapping("/{sessionId}")
     public ResponseEntity<ApiResponse<SessionDto>> getSession(
             @PathVariable @Nonnull UUID sessionId,
-            @RequestHeader("X-Keycloak-User-ID") UUID userId,
-            @RequestParam(defaultValue = "nl") String locale) {
+            @RequestHeader("X-Keycloak-User-ID") UUID userId) {
 
-        SessionDto session = practiceSessionService.getSession(userId, sessionId, locale);
+        SessionDto session = practiceSessionService.getSession(userId, sessionId);
         return ResponseEntity.ok(ApiResponse.success(session, MDC.get("traceId")));
     }
 

--- a/src/main/java/com/passtheo/content/domain/entity/StudySession.java
+++ b/src/main/java/com/passtheo/content/domain/entity/StudySession.java
@@ -66,6 +66,14 @@ public class StudySession extends BaseEntity {
     private int timeSpentSeconds;
 
     /**
+     * Content locale for this session (e.g. "nl", "en"). Set once at creation
+     * from the start-session request and never changed. All Strapi fetches
+     * during this session use this locale.
+     */
+    @Column(name = "locale", nullable = false, length = 10)
+    private String locale;
+
+    /**
      * Comma-separated Strapi question document IDs in the order they were selected
      * at session start. Null for sessions created before V9 migration.
      */
@@ -82,10 +90,12 @@ public class StudySession extends BaseEntity {
      * @param domainCode     the domain code (nullable for mixed)
      * @param topicCode      the topic code (nullable for all topics)
      * @param sessionType    the session type
-     * @param totalQuestions  the total number of questions
+     * @param totalQuestions the total number of questions
+     * @param locale         the content locale for this session (e.g. "nl", "en")
      */
     public StudySession(UUID keycloakUserId, String productCode, String domainCode,
-                        String topicCode, SessionType sessionType, int totalQuestions) {
+                        String topicCode, SessionType sessionType, int totalQuestions,
+                        String locale) {
         this.keycloakUserId = keycloakUserId;
         this.productCode = productCode;
         this.domainCode = domainCode;
@@ -98,6 +108,7 @@ public class StudySession extends BaseEntity {
         this.startedAt = Instant.now();
         this.lastActivityAt = Instant.now();
         this.timeSpentSeconds = 0;
+        this.locale = locale;
     }
 
     public UUID getKeycloakUserId() { return keycloakUserId; }
@@ -128,6 +139,8 @@ public class StudySession extends BaseEntity {
     public void setLastActivityAt(Instant lastActivityAt) { this.lastActivityAt = lastActivityAt; }
     public int getTimeSpentSeconds() { return timeSpentSeconds; }
     public void setTimeSpentSeconds(int timeSpentSeconds) { this.timeSpentSeconds = timeSpentSeconds; }
+    public String getLocale() { return locale; }
+    public void setLocale(String locale) { this.locale = locale; }
 
     /**
      * Returns the ordered question IDs stored at session start.

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -139,10 +139,11 @@ public class PracticeSessionService {
 
         // Create session entity and persist the question list so it is fixed for the
         // entire session — re-running selectQuestions later may shuffle new questions
-        // differently and cause duplicates.
+        // differently and cause duplicates. The locale is stored here and used for all
+        // subsequent Strapi fetches; the session is the source of truth for locale.
         StudySession session = new StudySession(
                 userId, request.productCode(), request.domainCode(),
-                request.topicCode(), sessionType, questionIds.size());
+                request.topicCode(), sessionType, questionIds.size(), locale);
         session.setTenantId(TenantContext.get());
         session.setQuestionIdList(questionIds);
         session = sessionRepository.save(session);
@@ -170,29 +171,31 @@ public class PracticeSessionService {
 
     /**
      * Submits an answer, grades it, updates mastery, returns feedback + next question.
+     * The content locale is read from the session record — not from the caller.
      *
      * @param userId    the user's Keycloak ID
      * @param sessionId the session ID
      * @param request   the answer request
-     * @param locale    the content locale
      * @return the answer result with feedback
      */
     @Transactional
     public AnswerResultDto submitAnswer(@Nonnull UUID userId, @Nonnull UUID sessionId,
-                                        @Nonnull SubmitAnswerRequest request, @Nonnull String locale) {
+                                        @Nonnull SubmitAnswerRequest request) {
         try {
-            return doSubmitAnswer(userId, sessionId, request, locale);
+            return doSubmitAnswer(userId, sessionId, request);
         } catch (DataIntegrityViolationException ex) {
             LOG.warn("Duplicate answer detected for session={} question={}, returning existing result",
                     sessionId, request.strapiQuestionId());
-            return buildExistingAnswerResult(userId, sessionId, request.strapiQuestionId(), locale);
+            return buildExistingAnswerResult(userId, sessionId, request.strapiQuestionId());
         }
     }
 
     private AnswerResultDto doSubmitAnswer(UUID userId, UUID sessionId,
-                                           SubmitAnswerRequest request, String locale) {
+                                           SubmitAnswerRequest request) {
         StudySession session = sessionRepository.findByIdAndKeycloakUserId(sessionId, userId)
                 .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR, "Session not found: " + sessionId));
+        // The session is the source of truth for locale — never trust a request parameter.
+        String locale = session.getLocale();
 
         if (session.getStatus() != SessionStatus.IN_PROGRESS) {
             throw new AppException(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_STATUS_TRANSITION, "Session is not in progress: " + session.getStatus());
@@ -203,7 +206,7 @@ public class PracticeSessionService {
         if (answerRepository.findBySessionIdAndStrapiQuestionId(sessionId, request.strapiQuestionId()).isPresent()) {
             LOG.warn("Duplicate answer detected (idempotency): session={} question={}, returning existing result",
                     sessionId, request.strapiQuestionId());
-            return buildExistingAnswerResult(userId, sessionId, request.strapiQuestionId(), locale);
+            return buildExistingAnswerResult(userId, sessionId, request.strapiQuestionId());
         }
 
         // Load question from Strapi
@@ -333,13 +336,14 @@ public class PracticeSessionService {
     }
 
     private AnswerResultDto buildExistingAnswerResult(UUID userId, UUID sessionId,
-                                                      String strapiQuestionId, String locale) {
+                                                      String strapiQuestionId) {
         SessionAnswer existing = answerRepository.findBySessionIdAndStrapiQuestionId(sessionId, strapiQuestionId)
                 .orElseThrow(() -> new AppException(HttpStatus.CONFLICT, ErrorCode.VALIDATION_ERROR,
                         "Duplicate answer but existing record not found"));
         StudySession session = sessionRepository.findByIdAndKeycloakUserId(sessionId, userId)
                 .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR,
                         "Session not found: " + sessionId));
+        String locale = session.getLocale();
         StrapiQuestionDto question = strapiContentCache.getQuestion(strapiQuestionId, locale);
         Map<String, Object> correctAnswer = question != null
                 ? answerProcessingService.buildCorrectAnswer(question) : Map.of();
@@ -443,16 +447,17 @@ public class PracticeSessionService {
 
     /**
      * Gets current session state for resuming.
+     * Content locale is read from the session record — not from the caller.
      *
      * @param userId    the user's Keycloak ID
      * @param sessionId the session ID
-     * @param locale    the content locale
      * @return the session with current question
      */
     @Transactional(readOnly = true)
-    public SessionDto getSession(@Nonnull UUID userId, @Nonnull UUID sessionId, @Nonnull String locale) {
+    public SessionDto getSession(@Nonnull UUID userId, @Nonnull UUID sessionId) {
         StudySession session = sessionRepository.findByIdAndKeycloakUserId(sessionId, userId)
                 .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR, "Session not found: " + sessionId));
+        String locale = session.getLocale();
 
         QuestionDto currentQuestion = null;
         if (session.getStatus() == SessionStatus.IN_PROGRESS

--- a/src/main/resources/db/migration/U10__add_locale_to_study_sessions.sql
+++ b/src/main/resources/db/migration/U10__add_locale_to_study_sessions.sql
@@ -1,0 +1,6 @@
+-- ============================================================
+-- U10: Undo V10 — drop locale column from study_sessions
+-- ============================================================
+
+ALTER TABLE study_sessions
+    DROP COLUMN IF EXISTS locale;

--- a/src/main/resources/db/migration/V10__add_locale_to_study_sessions.sql
+++ b/src/main/resources/db/migration/V10__add_locale_to_study_sessions.sql
@@ -1,0 +1,13 @@
+-- ============================================================
+-- V10: Add locale column to study_sessions
+-- The session owns its content locale — set once at creation from the
+-- start-session request and used for all subsequent Strapi fetches.
+-- This prevents mixed-language content when submitAnswer is called
+-- without a locale parameter (which defaults to 'nl' at the HTTP layer).
+-- ============================================================
+
+ALTER TABLE study_sessions
+    ADD COLUMN locale VARCHAR(10) NOT NULL DEFAULT 'nl';
+
+COMMENT ON COLUMN study_sessions.locale IS
+    'Content locale for this session (nl, en, ar, tr, pl). Set at session creation; never changes.';

--- a/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
+++ b/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
@@ -66,7 +66,7 @@ class PracticeSessionServiceActiveSessionTest {
     @Test
     void getActiveSession_sessionExists_returnsDto() {
         StudySession session = new StudySession(USER_ID, PRODUCT_CODE, "voorrang", null,
-                SessionType.PRACTICE, 20);
+                SessionType.PRACTICE, 20, "nl");
         session.setId(UUID.randomUUID());
         session.setAnsweredCount(7);
 
@@ -106,7 +106,7 @@ class PracticeSessionServiceActiveSessionTest {
     @Test
     void getActiveSession_nullDomainCode_returnsNullDomainName() {
         StudySession session = new StudySession(USER_ID, PRODUCT_CODE, null, null,
-                SessionType.QUICK_QUIZ, 5);
+                SessionType.QUICK_QUIZ, 5, "nl");
         session.setId(UUID.randomUUID());
 
         when(sessionRepository.findFirstByKeycloakUserIdAndProductCodeAndStatusOrderByLastActivityAtDesc(

--- a/src/test/resources/karate/practice-sessions.feature
+++ b/src/test/resources/karate/practice-sessions.feature
@@ -222,6 +222,39 @@ Feature: Practice Sessions
     Then status 200
     And match response.data.sessionProgress.answeredCount == 1
 
+  # ─── Session Locale Persistence ───
+
+  Scenario: Session locale is owned by session — content stays in English regardless of client header
+    # Start session with locale=en
+    Given path '/api/practice/sessions'
+    And headers paidHeaders
+    And request { productCode: 'auto-b', domainCode: 'verkeersborden', sessionType: 'PRACTICE', questionCount: 3, locale: 'en' }
+    When method POST
+    Then status 200
+    * def sessionId = response.data.sessionId
+    * def firstQuestion = response.data.currentQuestion
+    # First question text must be in English (not Dutch)
+    And match firstQuestion.questionText != null
+    # Submit answer — no locale param sent, backend must use session-stored locale
+    Given path '/api/practice/sessions/' + sessionId + '/answer'
+    And headers paidHeaders
+    And request { strapiQuestionId: '#(firstQuestion.strapiQuestionId)', answer: { selectedOptionId: 'a1' }, timeTakenMs: 4000 }
+    When method POST
+    Then status 200
+    # Explanation must exist (returned from session locale=en, not Dutch fallback)
+    And match response.data.explanation != null
+    And match response.data.explanation.text == '#string'
+    # Next question must be returned (session locale=en applied)
+    And match response.data.nextQuestion != null
+    And match response.data.nextQuestion.questionOrder == 2
+    # Resume the session — must return English question
+    Given path '/api/practice/sessions/' + sessionId
+    And headers paidHeaders
+    When method GET
+    Then status 200
+    And match response.data.currentQuestion != null
+    And match response.data.currentQuestion.questionOrder == 2
+
   # ─── Language Switch Preserves Progress ───
 
   Scenario: Language switch preserves progress using documentId


### PR DESCRIPTION
Closes #13

## Changes
- **V10 migration**: adds `locale VARCHAR(10) NOT NULL DEFAULT 'nl'` to `study_sessions`
- **StudySession entity**: adds `locale` field + getter/setter; constructor now accepts locale as 7th argument
- **PracticeSessionService**: `startSession()` stores locale in session; `submitAnswer()` and `getSession()` read locale from session record — no longer accept it as a parameter
- **PracticeController**: `locale` request param removed from `POST /{sessionId}/answer` and `GET /{sessionId}` — the session is now the source of truth
- **OpenAPI spec**: updated `submitAnswer` description to clarify locale is session-owned
- **Karate test**: new scenario `Session locale is owned by session — content stays in English regardless of client header`
- **Unit tests**: fixed constructor call in `PracticeSessionServiceActiveSessionTest`

## Why
A session is one continuous experience in one language. If started with `locale=en`, every question and explanation must be English — regardless of what the client sends on subsequent calls. Before this fix, `submitAnswer` defaulted to `nl` because the Flutter client never sent the locale param.

## Test plan
- [ ] Start session with `locale: 'en'`, verify first question is in English
- [ ] Submit answer without locale param, verify next question and explanation are still English (session-stored locale)
- [ ] Resume session with `GET /{sessionId}`, verify current question is in English
- [ ] Start session with `locale: 'nl'`, verify all content is Dutch
- [ ] Existing sessions (pre-V10, locale=NULL) fall back to `'nl'` via column default
- [ ] Karate acceptance test scenario passes

> **Note**: `./gradlew build` fails due to 956 pre-existing Checkstyle violations in the entity one-liner getter pattern. `./gradlew test` and `./gradlew bootJar` pass. V10 Flyway migration ran successfully on the running dev stack.