### PR TITLE
fix(content): compute questionCount dynamically from cached questions

### DIFF
--- a/src/main/java/com/passtheo/content/controller/ContentController.java
+++ b/src/main/java/com/passtheo/content/controller/ContentController.java
@@ -43,7 +43,6 @@ import java.util.stream.Collectors;
 public class ContentController {
 
     private static final Logger LOG = LoggerFactory.getLogger(ContentController.class);
-    private static final String COUNT_LOCALE = "nl";
 
     private final StrapiContentCache strapiContentCache;
     private final DomainProgressRepository domainProgressRepository;
@@ -132,7 +131,7 @@ public class ContentController {
                                 p.examConfig().totalQuestions(),
                                 p.examConfig().timeLimitMinutes(),
                                 p.examConfig().passScore()) : null,
-                        p.domainCount(), strapiContentCache.getQuestionCount(p.code(), COUNT_LOCALE)))
+                        p.domainCount(), strapiContentCache.getQuestionCount(p.code(), locale)))
                 .toList();
         return ResponseEntity.ok(ApiResponse.success(products, MDC.get("traceId")));
     }
@@ -176,7 +175,7 @@ public class ContentController {
                     dp.getStrength() != null ? dp.getStrength().name() : "UNKNOWN")
                     : new DomainWithProgressDto.ProgressOverlay(0.0, 0.0, 0, "UNKNOWN");
 
-            int questionCount = strapiContentCache.getQuestionCountByDomain(d.code(), COUNT_LOCALE);
+            int questionCount = strapiContentCache.getQuestionCountByDomain(d.code(), locale);
 
             return new DomainWithProgressDto(
                     d.code(), d.name(), d.icon(), d.color(),
@@ -207,7 +206,7 @@ public class ContentController {
         var topics = strapiContentCache.getTopics(domainCode, locale).stream()
                 .map(t -> new TopicWithProgressDto(
                         t.code(), t.name(), t.difficulty(),
-                        strapiContentCache.getQuestionCountByTopic(t.code(), COUNT_LOCALE),
+                        strapiContentCache.getQuestionCountByTopic(t.code(), locale),
                         null))
                 .toList();
         return ResponseEntity.ok(ApiResponse.success(topics, MDC.get("traceId")));

--- a/src/main/java/com/passtheo/content/controller/ContentController.java
+++ b/src/main/java/com/passtheo/content/controller/ContentController.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 public class ContentController {
 
     private static final Logger LOG = LoggerFactory.getLogger(ContentController.class);
+    private static final String COUNT_LOCALE = "nl";
 
     private final StrapiContentCache strapiContentCache;
     private final DomainProgressRepository domainProgressRepository;
@@ -131,7 +132,7 @@ public class ContentController {
                                 p.examConfig().totalQuestions(),
                                 p.examConfig().timeLimitMinutes(),
                                 p.examConfig().passScore()) : null,
-                        p.domainCount(), strapiContentCache.getQuestionCount(p.code(), locale)))
+                        p.domainCount(), strapiContentCache.getQuestionCount(p.code(), COUNT_LOCALE)))
                 .toList();
         return ResponseEntity.ok(ApiResponse.success(products, MDC.get("traceId")));
     }
@@ -175,7 +176,7 @@ public class ContentController {
                     dp.getStrength() != null ? dp.getStrength().name() : "UNKNOWN")
                     : new DomainWithProgressDto.ProgressOverlay(0.0, 0.0, 0, "UNKNOWN");
 
-            int questionCount = strapiContentCache.getQuestionCountByDomain(d.code(), locale);
+            int questionCount = strapiContentCache.getQuestionCountByDomain(d.code(), COUNT_LOCALE);
 
             return new DomainWithProgressDto(
                     d.code(), d.name(), d.icon(), d.color(),
@@ -206,7 +207,7 @@ public class ContentController {
         var topics = strapiContentCache.getTopics(domainCode, locale).stream()
                 .map(t -> new TopicWithProgressDto(
                         t.code(), t.name(), t.difficulty(),
-                        strapiContentCache.getQuestionCountByTopic(t.code(), locale),
+                        strapiContentCache.getQuestionCountByTopic(t.code(), COUNT_LOCALE),
                         null))
                 .toList();
         return ResponseEntity.ok(ApiResponse.success(topics, MDC.get("traceId")));

--- a/src/main/java/com/passtheo/content/controller/ContentController.java
+++ b/src/main/java/com/passtheo/content/controller/ContentController.java
@@ -131,7 +131,7 @@ public class ContentController {
                                 p.examConfig().totalQuestions(),
                                 p.examConfig().timeLimitMinutes(),
                                 p.examConfig().passScore()) : null,
-                        p.domainCount(), p.totalQuestions()))
+                        p.domainCount(), strapiContentCache.getQuestionCount(p.code(), locale)))
                 .toList();
         return ResponseEntity.ok(ApiResponse.success(products, MDC.get("traceId")));
     }
@@ -175,9 +175,7 @@ public class ContentController {
                     dp.getStrength() != null ? dp.getStrength().name() : "UNKNOWN")
                     : new DomainWithProgressDto.ProgressOverlay(0.0, 0.0, 0, "UNKNOWN");
 
-            int questionCount = d.questionCount() != null
-                    ? d.questionCount()
-                    : strapiContentCache.getQuestionsByDomain(d.code(), locale).size();
+            int questionCount = strapiContentCache.getQuestionCountByDomain(d.code(), locale);
 
             return new DomainWithProgressDto(
                     d.code(), d.name(), d.icon(), d.color(),
@@ -208,8 +206,7 @@ public class ContentController {
         var topics = strapiContentCache.getTopics(domainCode, locale).stream()
                 .map(t -> new TopicWithProgressDto(
                         t.code(), t.name(), t.difficulty(),
-                        t.questionCount() != null ? t.questionCount()
-                                : strapiContentCache.getQuestionsByTopic(t.code(), locale).size(),
+                        strapiContentCache.getQuestionCountByTopic(t.code(), locale),
                         null))
                 .toList();
         return ResponseEntity.ok(ApiResponse.success(topics, MDC.get("traceId")));

--- a/src/main/java/com/passtheo/content/integration/strapi/StrapiClient.java
+++ b/src/main/java/com/passtheo/content/integration/strapi/StrapiClient.java
@@ -32,6 +32,7 @@ public class StrapiClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(StrapiClient.class);
     private static final String POPULATE_QUESTION = "populate[0]=answerOptions&populate[1]=explanation&populate[2]=imageRegions&populate[3]=dragTargets&populate[4]=image&populate[5]=video&populate[6]=domain&populate[7]=topic&populate[8]=roadSigns";
+    private static final String FILTER_ACTIVE_APPROVED = "&filters[isActive][$eq]=true&filters[reviewStatus][$eq]=APPROVED";
 
     private final WebClient webClient;
 
@@ -127,7 +128,7 @@ public class StrapiClient {
     public List<StrapiQuestionDto> getQuestionsByTopic(@Nonnull String topicCode, @Nonnull String locale) {
         LOG.debug("Fetching questions from Strapi, topic={}, locale={}", topicCode, locale);
         return fetchCollection("/api/questions?filters[topic][code][$eq]=" + topicCode
-                + "&filters[isActive][$eq]=true&" + POPULATE_QUESTION + "&locale=" + locale
+                + FILTER_ACTIVE_APPROVED + "&" + POPULATE_QUESTION + "&locale=" + locale
                 + "&pagination[pageSize]=100",
                 new ParameterizedTypeReference<StrapiResponse<StrapiQuestionDto>>() {
                 });
@@ -143,7 +144,7 @@ public class StrapiClient {
     public List<StrapiQuestionDto> getQuestionsByDomain(@Nonnull String domainCode, @Nonnull String locale) {
         LOG.debug("Fetching questions from Strapi, domain={}, locale={}", domainCode, locale);
         return fetchCollection("/api/questions?filters[topic][domain][code][$eq]=" + domainCode
-                + "&filters[isActive][$eq]=true&" + POPULATE_QUESTION + "&locale=" + locale
+                + FILTER_ACTIVE_APPROVED + "&" + POPULATE_QUESTION + "&locale=" + locale
                 + "&pagination[pageSize]=200",
                 new ParameterizedTypeReference<StrapiResponse<StrapiQuestionDto>>() {
                 });
@@ -159,7 +160,7 @@ public class StrapiClient {
     public List<StrapiQuestionDto> getQuestionsByProduct(@Nonnull String productCode, @Nonnull String locale) {
         LOG.debug("Fetching all questions from Strapi, product={}, locale={}", productCode, locale);
         return fetchCollection("/api/questions?filters[topic][domain][product][code][$eq]=" + productCode
-                + "&filters[isActive][$eq]=true&" + POPULATE_QUESTION + "&locale=" + locale
+                + FILTER_ACTIVE_APPROVED + "&" + POPULATE_QUESTION + "&locale=" + locale
                 + "&pagination[pageSize]=500",
                 new ParameterizedTypeReference<StrapiResponse<StrapiQuestionDto>>() {
                 });

--- a/src/main/java/com/passtheo/content/integration/strapi/StrapiContentCache.java
+++ b/src/main/java/com/passtheo/content/integration/strapi/StrapiContentCache.java
@@ -184,6 +184,28 @@ public class StrapiContentCache {
     }
 
     /**
+     * Gets total question count for a domain (active + approved + published).
+     *
+     * @param domainCode the domain code
+     * @param locale     the content locale
+     * @return question count for the domain
+     */
+    public int getQuestionCountByDomain(@Nonnull String domainCode, @Nonnull String locale) {
+        return getQuestionsByDomain(domainCode, locale).size();
+    }
+
+    /**
+     * Gets total question count for a topic (active + approved + published).
+     *
+     * @param topicCode the topic code
+     * @param locale    the content locale
+     * @return question count for the topic
+     */
+    public int getQuestionCountByTopic(@Nonnull String topicCode, @Nonnull String locale) {
+        return getQuestionsByTopic(topicCode, locale).size();
+    }
+
+    /**
      * Gets a single question by ID with caching.
      *
      * @param questionId the Strapi question ID

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -61,6 +61,7 @@ public class PracticeSessionService {
 
     private static final Logger LOG = LoggerFactory.getLogger(PracticeSessionService.class);
     private static final Logger AUDIT = LoggerFactory.getLogger("AUDIT");
+    private static final String COUNT_LOCALE = "nl";
 
     /** JSON representation of a skipped answer stored in session_answers.user_answer. */
     private static final String SKIP_ANSWER_JSON = "null";
@@ -600,7 +601,7 @@ public class PracticeSessionService {
                 .filter(StrapiDomainDto::isActive)
                 .sorted(Comparator.comparingInt(StrapiDomainDto::sortOrder))
                 .map(d -> {
-                    int totalQuestions = strapiContentCache.getQuestionCountByDomain(d.code(), locale);
+                    int totalQuestions = strapiContentCache.getQuestionCountByDomain(d.code(), COUNT_LOCALE);
                     boolean isLocked = !access.isPaid() && !d.isFreePreview();
                     DomainProgress dp = progressMap.get(d.code());
 

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -600,7 +600,7 @@ public class PracticeSessionService {
                 .filter(StrapiDomainDto::isActive)
                 .sorted(Comparator.comparingInt(StrapiDomainDto::sortOrder))
                 .map(d -> {
-                    int totalQuestions = d.questionCount() != null ? d.questionCount() : 0;
+                    int totalQuestions = strapiContentCache.getQuestionCountByDomain(d.code(), locale);
                     boolean isLocked = !access.isPaid() && !d.isFreePreview();
                     DomainProgress dp = progressMap.get(d.code());
 

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -61,7 +61,6 @@ public class PracticeSessionService {
 
     private static final Logger LOG = LoggerFactory.getLogger(PracticeSessionService.class);
     private static final Logger AUDIT = LoggerFactory.getLogger("AUDIT");
-    private static final String COUNT_LOCALE = "nl";
 
     /** JSON representation of a skipped answer stored in session_answers.user_answer. */
     private static final String SKIP_ANSWER_JSON = "null";
@@ -601,7 +600,7 @@ public class PracticeSessionService {
                 .filter(StrapiDomainDto::isActive)
                 .sorted(Comparator.comparingInt(StrapiDomainDto::sortOrder))
                 .map(d -> {
-                    int totalQuestions = strapiContentCache.getQuestionCountByDomain(d.code(), COUNT_LOCALE);
+                    int totalQuestions = strapiContentCache.getQuestionCountByDomain(d.code(), locale);
                     boolean isLocked = !access.isPaid() && !d.isFreePreview();
                     DomainProgress dp = progressMap.get(d.code());
 

--- a/src/test/java/com/passtheo/content/KarateRunner.java
+++ b/src/test/java/com/passtheo/content/KarateRunner.java
@@ -140,6 +140,12 @@ class KarateRunner {
                 .thenReturn(buildDomains());
         when(strapiClient.getTopics(anyString(), anyString()))
                 .thenReturn(buildTopics());
+        when(strapiClient.getQuestionsByTopic(eq("gebodsborden"), anyString()))
+                .thenReturn(buildQuestions("gebodsborden", 15));
+        when(strapiClient.getQuestionsByTopic(eq("verbodsborden"), anyString()))
+                .thenReturn(buildQuestions("verbodsborden", 15));
+        when(strapiClient.getQuestionsByTopic(anyString(), anyString()))
+                .thenReturn(buildQuestions("topic-generic", 10));
         when(strapiClient.getQuestionsByDomain(eq("verkeersborden"), anyString()))
                 .thenReturn(buildQuestions("verkeersborden", 20));
         when(strapiClient.getQuestionsByDomain(eq("snelheid"), anyString()))


### PR DESCRIPTION
Closes #15

## Changes
- Added `reviewStatus=APPROVED` filter to all Strapi question API calls (`getQuestionsByTopic`, `getQuestionsByDomain`, `getQuestionsByProduct`) — non-approved questions no longer enter the cache
- Extracted `FILTER_ACTIVE_APPROVED` constant in `StrapiClient` for DRY filter strings
- Added `getQuestionCountByDomain()` and `getQuestionCountByTopic()` convenience methods to `StrapiContentCache`
- Replaced static `d.questionCount()` / `t.questionCount()` / `p.totalQuestions()` with dynamic cache counts in:
  - `ContentController.listDomains()` — per-domain count
  - `ContentController.listTopics()` — per-topic count
  - `ContentController.listProducts()` — per-product total
  - `PracticeSessionService.listPracticeDomains()` — mastery stat calculations

## Deployment note
Flush Redis `strapi:questions:*` keys on deploy so stale cache entries (which may contain unapproved questions) expire immediately rather than persisting for up to 1 hour.

## Test plan
- [ ] `./gradlew test` — all unit tests pass
- [ ] Verify `GET /api/content/NL/cbr/auto-b/domains` returns `questionCount` matching actual active+approved questions in Strapi
- [ ] Verify `GET /api/content/NL/cbr/auto-b/domains/{dc}/topics` returns dynamic counts
- [ ] Verify `GET /api/content/onboarding-catalog` shows correct `totalQuestions` per product
- [ ] Disable a question in Strapi, wait for cache TTL (or flush), verify count decreases
- [ ] Reject a question's `reviewStatus` in Strapi, verify it's excluded from counts and practice sessions