### PR TITLE
perf(content): add DB indexes, limit unbounded queries, update subscription-service port

### DIFF
--- a/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
+++ b/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 
 /**
  * Repository for QuestionProgress entities — core spaced repetition data.
@@ -48,7 +49,8 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
             @Param("userId") UUID keycloakUserId,
             @Param("productCode") String productCode,
             @Param("domainCode") String domainCode,
-            @Param("now") Instant now);
+            @Param("now") Instant now,
+            Pageable pageable);
 
     /**
      * Finds weak questions (LEARNING with low consecutive correct).
@@ -68,7 +70,8 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
             @Param("userId") UUID keycloakUserId,
             @Param("productCode") String productCode,
             @Param("domainCode") String domainCode,
-            @Param("maxConsecutive") int maxConsecutive);
+            @Param("maxConsecutive") int maxConsecutive,
+            Pageable pageable);
 
     /**
      * Finds IDs of questions the user has already seen.
@@ -102,7 +105,8 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
     List<QuestionProgress> findFamiliarSorted(
             @Param("userId") UUID keycloakUserId,
             @Param("productCode") String productCode,
-            @Param("domainCode") String domainCode);
+            @Param("domainCode") String domainCode,
+            Pageable pageable);
 
     /**
      * Counts total questions attempted by a user for a product.

--- a/src/main/java/com/passtheo/content/service/QuestionSelectionService.java
+++ b/src/main/java/com/passtheo/content/service/QuestionSelectionService.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.Pageable;
 
 /**
  * Selects optimal questions for practice sessions using a modified SM-2 algorithm.
@@ -64,7 +65,7 @@ public class QuestionSelectionService {
 
         // Priority 1: Due reviews (nextReviewAt < now) — most overdue first
         List<QuestionProgress> dueReviews = progressRepository
-                .findDueReviews(userId, productCode, domainCode, Instant.now());
+                .findDueReviews(userId, productCode, domainCode, Instant.now(), Pageable.ofSize(count));
         dueReviews.sort(Comparator.comparing(QuestionProgress::getNextReviewAt));
         LOG.debug("Question selection P1 due-reviews: user={}, available={}", userId, dueReviews.size());
         for (QuestionProgress qp : dueReviews) {
@@ -78,7 +79,7 @@ public class QuestionSelectionService {
         // Priority 2: Weak questions (LEARNING with consecutiveCorrect < threshold)
         if (selected.size() < count) {
             List<QuestionProgress> weak = progressRepository
-                    .findWeak(userId, productCode, domainCode, WEAK_CONSECUTIVE_THRESHOLD);
+                    .findWeak(userId, productCode, domainCode, WEAK_CONSECUTIVE_THRESHOLD, Pageable.ofSize(count));
             LOG.debug("Question selection P2 weak: user={}, available={}", userId, weak.size());
             for (QuestionProgress qp : weak) {
                 if (selected.size() >= count) {
@@ -116,7 +117,7 @@ public class QuestionSelectionService {
         // Priority 4: Fill with FAMILIAR questions closest to review date
         if (selected.size() < count) {
             List<QuestionProgress> familiar = progressRepository
-                    .findFamiliarSorted(userId, productCode, domainCode);
+                    .findFamiliarSorted(userId, productCode, domainCode, Pageable.ofSize(count));
             LOG.debug("Question selection P4 familiar-fill: user={}, available={}", userId, familiar.size());
             for (QuestionProgress qp : familiar) {
                 if (selected.size() >= count) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,7 +16,7 @@ passtheo:
   strapi:
     base-url: http://localhost:1337
   subscription-service:
-    base-url: http://localhost:8083
+    base-url: http://localhost:8084
 
 logging:
   level:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -20,7 +20,7 @@ passtheo:
   strapi:
     base-url: http://localhost:1337
   subscription-service:
-    base-url: http://localhost:8083
+    base-url: http://localhost:8084
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -106,7 +106,7 @@ passtheo:
     base-url: ${STRAPI_BASE_URL:http://localhost:1337}
     api-token: ${STRAPI_API_TOKEN:strapi-api-token}
   subscription-service:
-    base-url: ${SUBSCRIPTION_SERVICE_URL:http://localhost:8083}
+    base-url: ${SUBSCRIPTION_SERVICE_URL:http://localhost:8084}
   user-service:
     base-url: ${USER_SERVICE_URL:http://localhost:8082}
   content-cache:

--- a/src/main/resources/db/migration/U11__drop_answer_date_and_exam_recent_indexes.sql
+++ b/src/main/resources/db/migration/U11__drop_answer_date_and_exam_recent_indexes.sql
@@ -1,0 +1,4 @@
+-- U11: Undo V11 - drop performance indexes added for date-range queries
+
+DROP INDEX IF EXISTS idx_answer_date;
+DROP INDEX IF EXISTS idx_exam_user_recent;

--- a/src/main/resources/db/migration/V11__add_answer_date_and_exam_recent_indexes.sql
+++ b/src/main/resources/db/migration/V11__add_answer_date_and_exam_recent_indexes.sql
@@ -5,9 +5,10 @@
 --
 -- idx_exam_user_recent: supports ExamAttemptRepository.countRecentExams() which
 --   adds a completedAt > cutoff filter to the existing idx_exam_user index.
---   The existing index covers (tenant_id, keycloak_user_id, product_code) but
---   does not include completed_at, forcing a heap filter after the index scan.
+--   The existing idx_exam_user covers (tenant_id, keycloak_user_id, product_code)
+--   but does not include completed_at, forcing a heap filter after the index scan.
+--   Both indexes include tenant_id as leading column for efficient RLS filtering.
 
-CREATE INDEX idx_answer_date ON session_answers(answered_at);
+CREATE INDEX idx_answer_date ON session_answers(tenant_id, answered_at);
 
-CREATE INDEX idx_exam_user_recent ON exam_attempts(keycloak_user_id, product_code, completed_at DESC);
+CREATE INDEX idx_exam_user_recent ON exam_attempts(tenant_id, keycloak_user_id, product_code, completed_at DESC);

--- a/src/main/resources/db/migration/V11__add_answer_date_and_exam_recent_indexes.sql
+++ b/src/main/resources/db/migration/V11__add_answer_date_and_exam_recent_indexes.sql
@@ -1,0 +1,13 @@
+-- V11: Add performance indexes for date-range queries
+--
+-- idx_answer_date: supports StreakService.findStudyDatesBetween() which filters
+--   session_answers by answered_at date range to compute 7-day study activity.
+--
+-- idx_exam_user_recent: supports ExamAttemptRepository.countRecentExams() which
+--   adds a completedAt > cutoff filter to the existing idx_exam_user index.
+--   The existing index covers (tenant_id, keycloak_user_id, product_code) but
+--   does not include completed_at, forcing a heap filter after the index scan.
+
+CREATE INDEX idx_answer_date ON session_answers(answered_at);
+
+CREATE INDEX idx_exam_user_recent ON exam_attempts(keycloak_user_id, product_code, completed_at DESC);

--- a/src/test/java/com/passtheo/content/unit/QuestionSelectionServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/QuestionSelectionServiceTest.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.springframework.data.domain.Pageable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -49,9 +50,9 @@ class QuestionSelectionServiceTest {
 
     @Test
     void new_user_gets_unseen_questions() {
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new java.util.ArrayList<>());
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt()))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
         when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN))
                 .thenReturn(Set.of());
@@ -66,9 +67,9 @@ class QuestionSelectionServiceTest {
     @Test
     void due_reviews_are_prioritized_first() {
         QuestionProgress dueQ = buildProgress("q-due-1", Instant.now().minus(1, ChronoUnit.DAYS));
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new java.util.ArrayList<>(List.of(dueQ)));
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt()))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
         when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN))
                 .thenReturn(Set.of("q-due-1"));
@@ -85,9 +86,9 @@ class QuestionSelectionServiceTest {
     void weak_questions_fill_when_no_due_reviews() {
         QuestionProgress weak = buildProgress("q-weak-1", null);
         weak.setConsecutiveCorrect(1);
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new java.util.ArrayList<>());
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt()))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of(weak));
         when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN))
                 .thenReturn(Set.of("q-weak-1"));
@@ -103,9 +104,9 @@ class QuestionSelectionServiceTest {
     void no_duplicate_questions_in_selection() {
         QuestionProgress dueQ = buildProgress("q-1", Instant.now().minus(1, ChronoUnit.DAYS));
         QuestionProgress weakQ = buildProgress("q-1", null);
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new java.util.ArrayList<>(List.of(dueQ)));
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt()))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of(weakQ));
         when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN))
                 .thenReturn(Set.of("q-1"));
@@ -120,9 +121,9 @@ class QuestionSelectionServiceTest {
 
     @Test
     void mixed_session_null_domain_uses_product_questions() {
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(null), any(Instant.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(null), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new java.util.ArrayList<>());
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(null), anyInt()))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(null), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
         when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, null))
                 .thenReturn(Set.of());
@@ -136,15 +137,15 @@ class QuestionSelectionServiceTest {
 
     @Test
     void returns_empty_when_no_questions_exist() {
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new java.util.ArrayList<>());
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt()))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
         when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN))
                 .thenReturn(Set.of());
         when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
                 .thenReturn(List.of());
-        when(progressRepository.findFamiliarSorted(USER_ID, PRODUCT, DOMAIN))
+        when(progressRepository.findFamiliarSorted(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Pageable.class)))
                 .thenReturn(List.of());
 
         List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, 5, LOCALE);
@@ -155,15 +156,15 @@ class QuestionSelectionServiceTest {
     @Test
     void familiar_questions_used_as_last_resort_fill() {
         QuestionProgress familiar = buildProgress("q-familiar-1", Instant.now().plus(3, ChronoUnit.DAYS));
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new ArrayList<>());
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt()))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
         when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN))
                 .thenReturn(Set.of());
         when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
                 .thenReturn(List.of());
-        when(progressRepository.findFamiliarSorted(USER_ID, PRODUCT, DOMAIN))
+        when(progressRepository.findFamiliarSorted(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Pageable.class)))
                 .thenReturn(List.of(familiar));
 
         List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, 1, LOCALE);

--- a/src/test/resources/application-acceptance.yml
+++ b/src/test/resources/application-acceptance.yml
@@ -61,7 +61,7 @@ passtheo:
     base-url: http://localhost:1337
     api-token: test-token
   subscription-service:
-    base-url: http://localhost:8083
+    base-url: http://localhost:8084
   content-cache:
     ttl-seconds: 60
   free-tier:


### PR DESCRIPTION
Closes #25

## Changes

### Task 1.3 — Missing DB indexes (V11 migration)
- Added `idx_answer_date` on `session_answers(answered_at)` — supports `StreakService.findStudyDatesBetween()` date-range filter
- Added `idx_exam_user_recent` on `exam_attempts(keycloak_user_id, product_code, completed_at DESC)` — supports `countRecentExams()` time-window filter for free-tier weekly limit checks

### Task 1.5 — Unbounded query fix
- Added `Pageable pageable` parameter to `findDueReviews`, `findWeak`, `findFamiliarSorted` in `QuestionProgressRepository` — Spring Data JPA auto-injects LIMIT into the generated SQL
- Updated `QuestionSelectionService` to pass `Pageable.ofSize(count)` to all three queries
- Updated `QuestionSelectionServiceTest` mock matchers to include `any(Pageable.class)`

### Task 1.6 — Subscription-service URL port update
- Updated default subscription-service URL from port 8083 to 8084 in `application.yml`, `application-dev.yml`, `application-test.yml`, `application-acceptance.yml`

## Test plan
- [x] `./gradlew test` passes (all 7 QuestionSelectionServiceTest cases pass)
- [ ] V11 migration applies cleanly against a real PostgreSQL instance
- [ ] `EXPLAIN ANALYZE` on `findStudyDatesBetween` shows Index Scan on `idx_answer_date`
- [ ] `EXPLAIN ANALYZE` on `countRecentExams` shows index use on `idx_exam_user_recent`

## Related
- passtheo/subscription-service#22 — source of the port change (8083→8084)