### PR TITLE
feat(content): add xpReward to AchievementDto response

### DIFF
--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -1816,6 +1816,7 @@ components:
         triggerValue: { type: integer }
         currentProgress: { type: integer, description: "user's current value toward this trigger" }
         progressPercent: { type: number }
+        xpReward: { type: integer, description: "XP awarded when this achievement is earned" }
         productCode: { type: string, nullable: true, description: "null = platform-wide achievement" }
 
     EarnedAchievementDto:

--- a/src/main/java/com/passtheo/content/controller/AchievementController.java
+++ b/src/main/java/com/passtheo/content/controller/AchievementController.java
@@ -76,7 +76,7 @@ public class AchievementController {
                     isEarned ? def.icon() : def.lockedIcon(),
                     isEarned, isEarned ? earned.getEarnedAt() : null,
                     def.triggerType(), def.triggerValue(),
-                    currentProgress, progressPercent
+                    currentProgress, progressPercent, def.xpReward()
             );
         }).toList();
 

--- a/src/main/java/com/passtheo/content/dto/response/AchievementDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/AchievementDto.java
@@ -15,5 +15,6 @@ public record AchievementDto(
     String triggerType,
     int triggerValue,
     int currentProgress,
-    double progressPercent
+    double progressPercent,
+    int xpReward
 ) {}

--- a/src/test/resources/karate/progress-streaks-achievements.feature
+++ b/src/test/resources/karate/progress-streaks-achievements.feature
@@ -146,12 +146,15 @@ Feature: Progress, Readiness, Streaks, Achievements, and Study Plan
     When method GET
     Then status 200
     And match response.data == '#array'
+    # Check that all achievements have xpReward
+    * def first = response.data[0]
+    And match first.xpReward == '#number'
     # Check that earned achievements have earnedAt
     * def earned = karate.filter(response.data, function(a){ return a.isEarned == true })
-    * eval if (earned.length > 0) karate.match(earned[0], '{ earnedAt: "#string" }')
+    * eval if (earned.length > 0) karate.match(earned[0], '{ earnedAt: "#string", xpReward: "#number" }')
     # Check that locked achievements have progress
     * def locked = karate.filter(response.data, function(a){ return a.isEarned == false })
-    * eval if (locked.length > 0) karate.match(locked[0], '{ currentProgress: "#number", progressPercent: "#number" }')
+    * eval if (locked.length > 0) karate.match(locked[0], '{ currentProgress: "#number", progressPercent: "#number", xpReward: "#number" }')
 
   Scenario: Fresh user has zero achievements earned
     Given path '/api/achievements/me'


### PR DESCRIPTION
Closes #27

## Changes
- Added `xpReward: int` field to `AchievementDto` record
- Controller now includes `def.xpReward()` in DTO construction (from Strapi achievement definition)
- OpenAPI spec updated with `xpReward` field documentation
- Karate acceptance test updated to assert `xpReward` is present on all achievement responses

## Test plan
- [ ] `GET /api/achievements/me` response includes `xpReward` for every achievement
- [ ] `./gradlew test` passes