### PR TITLE
fix(content): compute domain progress stats from question_progress

### DIFF
--- a/src/main/java/com/passtheo/content/integration/strapi/StrapiContentCache.java
+++ b/src/main/java/com/passtheo/content/integration/strapi/StrapiContentCache.java
@@ -329,6 +329,28 @@ public class StrapiContentCache {
     }
 
     /**
+     * Resolves the domain code for a given topic code by iterating the cached domain/topic tree.
+     * Used when a question's domain relation is null (Strapi does not set domain directly on questions).
+     *
+     * @param topicCode   the topic code
+     * @param productCode the product code
+     * @param locale      the content locale
+     * @return the domain code, or null if not found
+     */
+    public String getDomainCodeForTopic(@Nonnull String topicCode,
+                                        @Nonnull String productCode,
+                                        @Nonnull String locale) {
+        for (StrapiDomainDto domain : getDomains(productCode, locale)) {
+            List<StrapiTopicDto> topics = getTopics(domain.code(), locale);
+            if (topics.stream().anyMatch(t -> topicCode.equals(t.code()))) {
+                return domain.code();
+            }
+        }
+        LOG.warn("Could not resolve domain for topic={}, product={}, locale={}", topicCode, productCode, locale);
+        return null;
+    }
+
+    /**
      * Flushes all Strapi content cache entries.
      */
     public void flushAll() {

--- a/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
+++ b/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
@@ -22,6 +22,72 @@ import org.springframework.data.domain.Pageable;
 public interface QuestionProgressRepository extends JpaRepository<QuestionProgress, UUID> {
 
     /**
+     * Per-domain mastery aggregate computed directly from question_progress rows.
+     * Used instead of the (never-populated) domain_progress table.
+     */
+    interface DomainMasteryProjection {
+        /**
+         * Returns the domain code.
+         *
+         * @return domain code (e.g. "verkeersborden")
+         */
+        String getDomainCode();
+
+        /**
+         * Returns the number of distinct questions answered at least once.
+         *
+         * @return attempted question count
+         */
+        long getAttemptedCount();
+
+        /**
+         * Returns the sum of totalCorrect across all answered questions in this domain.
+         *
+         * @return total correct answers
+         */
+        long getCorrectCount();
+
+        /**
+         * Returns the sum of totalAttempts across all answered questions (denominator for accuracy).
+         *
+         * @return total answer attempts
+         */
+        long getTotalAttempts();
+
+        /**
+         * Returns the number of questions at MASTERED level.
+         *
+         * @return mastered question count
+         */
+        long getMasteredCount();
+
+        /**
+         * Returns the number of questions at LEARNING or FAMILIAR level.
+         *
+         * @return learning question count
+         */
+        long getLearningCount();
+    }
+
+    /**
+     * Returns domain-level mastery aggregates for a user/product in a single query.
+     *
+     * @param userId      the user's Keycloak ID
+     * @param productCode the product code
+     * @return one projection per domain the user has touched
+     */
+    @Query("SELECT qp.domainCode AS domainCode, " +
+           "COUNT(qp) AS attemptedCount, " +
+           "SUM(qp.totalCorrect) AS correctCount, " +
+           "SUM(qp.totalAttempts) AS totalAttempts, " +
+           "SUM(CASE WHEN qp.masteryLevel = 'MASTERED' THEN 1 ELSE 0 END) AS masteredCount, " +
+           "SUM(CASE WHEN qp.masteryLevel IN ('LEARNING', 'FAMILIAR') THEN 1 ELSE 0 END) AS learningCount " +
+           "FROM QuestionProgress qp WHERE qp.keycloakUserId = :userId " +
+           "AND qp.productCode = :productCode GROUP BY qp.domainCode")
+    List<DomainMasteryProjection> aggregateByDomain(@Param("userId") UUID userId,
+                                                     @Param("productCode") String productCode);
+
+    /**
      * Finds a progress record by user and question.
      *
      * @param keycloakUserId   the user's Keycloak ID

--- a/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
+++ b/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
@@ -83,9 +83,10 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
            "SUM(CASE WHEN qp.masteryLevel = 'MASTERED' THEN 1 ELSE 0 END) AS masteredCount, " +
            "SUM(CASE WHEN qp.masteryLevel IN ('LEARNING', 'FAMILIAR') THEN 1 ELSE 0 END) AS learningCount " +
            "FROM QuestionProgress qp WHERE qp.keycloakUserId = :userId " +
-           "AND qp.productCode = :productCode GROUP BY qp.domainCode")
-    List<DomainMasteryProjection> aggregateByDomain(@Param("userId") UUID userId,
-                                                     @Param("productCode") String productCode);
+           "AND qp.productCode = :productCode AND qp.domainCode <> '' " +
+           "GROUP BY qp.domainCode")
+    List<DomainMasteryProjection> aggregateByDomain(@Nonnull @Param("userId") UUID userId,
+                                                     @Nonnull @Param("productCode") String productCode);
 
     /**
      * Finds a progress record by user and question.

--- a/src/main/java/com/passtheo/content/service/AchievementService.java
+++ b/src/main/java/com/passtheo/content/service/AchievementService.java
@@ -9,7 +9,6 @@ import com.passtheo.shared.outbox.entity.OutboxStatus;
 import com.passtheo.content.dto.response.EarnedAchievementDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiAchievementDefDto;
-import com.passtheo.content.repository.DomainProgressRepository;
 import com.passtheo.content.repository.EarnedAchievementRepository;
 import com.passtheo.content.repository.ExamAttemptRepository;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
@@ -41,37 +40,36 @@ public class AchievementService {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
+    /** Default locale used when computing domain mastery (content-agnostic — counts don't differ by locale). */
+    private static final String DEFAULT_LOCALE = "nl";
+
     private final EarnedAchievementRepository achievementRepository;
     private final QuestionProgressRepository progressRepository;
     private final StreakRepository streakRepository;
     private final ExamAttemptRepository examAttemptRepository;
-    private final DomainProgressRepository domainProgressRepository;
     private final StrapiContentCache strapiContentCache;
     private final OutboxEventRepository outboxEventRepository;
 
     /**
      * Constructs the achievement service.
      *
-     * @param achievementRepository    earned achievement repository
-     * @param progressRepository       question progress repository
-     * @param streakRepository         streak repository
-     * @param examAttemptRepository    exam attempt repository
-     * @param domainProgressRepository domain progress repository
-     * @param strapiContentCache       Strapi content cache
-     * @param outboxEventRepository    outbox event repository
+     * @param achievementRepository earned achievement repository
+     * @param progressRepository    question progress repository
+     * @param streakRepository      streak repository
+     * @param examAttemptRepository exam attempt repository
+     * @param strapiContentCache    Strapi content cache
+     * @param outboxEventRepository outbox event repository
      */
     public AchievementService(EarnedAchievementRepository achievementRepository,
                               QuestionProgressRepository progressRepository,
                               StreakRepository streakRepository,
                               ExamAttemptRepository examAttemptRepository,
-                              DomainProgressRepository domainProgressRepository,
                               StrapiContentCache strapiContentCache,
                               OutboxEventRepository outboxEventRepository) {
         this.achievementRepository = achievementRepository;
         this.progressRepository = progressRepository;
         this.streakRepository = streakRepository;
         this.examAttemptRepository = examAttemptRepository;
-        this.domainProgressRepository = domainProgressRepository;
         this.strapiContentCache = strapiContentCache;
         this.outboxEventRepository = outboxEventRepository;
     }
@@ -152,8 +150,16 @@ public class AchievementService {
             case "exams_passed" -> (int) examAttemptRepository
                     .countByKeycloakUserIdAndProductCodeAndPassedTrue(userId, productCode);
             case "perfect_exam" -> (int) examAttemptRepository.countPerfect(userId, productCode);
-            case "domain_mastered" -> (int) domainProgressRepository
-                    .countByKeycloakUserIdAndProductCodeAndStrength(userId, productCode, DomainStrength.MASTERED);
+            case "domain_mastered" -> (int) progressRepository.aggregateByDomain(userId, productCode).stream()
+                    .filter(agg -> {
+                        int total = strapiContentCache.getQuestionCountByDomain(agg.getDomainCode(), DEFAULT_LOCALE);
+                        double accuracy = agg.getTotalAttempts() > 0
+                                ? (double) agg.getCorrectCount() / agg.getTotalAttempts() * 100.0 : 0.0;
+                        double coverage = total > 0
+                                ? (double) agg.getAttemptedCount() / total * 100.0 : 0.0;
+                        return ReadinessService.classifyDomainStrength(accuracy, coverage) == DomainStrength.MASTERED;
+                    })
+                    .count();
             case "readiness_score" -> 0; // calculated separately to avoid circular dependency
             case "fast_correct" -> 0; // tracked inline during answer processing
             default -> {

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -220,10 +220,17 @@ public class PracticeSessionService {
         QuestionProgress progress = progressRepository
                 .findByKeycloakUserIdAndStrapiQuestionId(userId, request.strapiQuestionId())
                 .orElseGet(() -> {
+                    // Strapi does not set domain directly on questions — resolve from topic cache.
+                    String resolvedDomain = question.domain() != null ? question.domain().code() : null;
+                    if ((resolvedDomain == null || resolvedDomain.isBlank())
+                            && question.topic() != null && question.topic().code() != null) {
+                        resolvedDomain = strapiContentCache.getDomainCodeForTopic(
+                                question.topic().code(), session.getProductCode(), locale);
+                    }
                     QuestionProgress qp = new QuestionProgress(
                             userId, request.strapiQuestionId(),
                             session.getProductCode(),
-                            question.domain() != null ? question.domain().code() : "",
+                            resolvedDomain != null ? resolvedDomain : "",
                             question.topic() != null ? question.topic().code() : "");
                     qp.setTenantId(TenantContext.get());
                     return qp;

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -15,7 +15,6 @@ import com.passtheo.content.dto.request.StartSessionRequest;
 import com.passtheo.content.dto.request.SubmitAnswerRequest;
 import com.passtheo.content.dto.response.ActiveSessionDto;
 import com.passtheo.content.dto.response.AnswerResultDto;
-import com.passtheo.content.domain.entity.DomainProgress;
 import com.passtheo.content.domain.valueobject.AccessGrant;
 import com.passtheo.content.dto.response.AnsweredQuestionSummaryDto;
 import com.passtheo.content.dto.response.DomainSummaryDto;
@@ -26,7 +25,6 @@ import com.passtheo.content.dto.response.SessionSummaryDto;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiQuestionDto;
-import com.passtheo.content.repository.DomainProgressRepository;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.repository.SessionAnswerRepository;
@@ -68,7 +66,6 @@ public class PracticeSessionService {
     private final StudySessionRepository sessionRepository;
     private final SessionAnswerRepository answerRepository;
     private final QuestionProgressRepository progressRepository;
-    private final DomainProgressRepository domainProgressRepository;
     private final QuestionSelectionService questionSelectionService;
     private final AnswerProcessingService answerProcessingService;
     private final StreakService streakService;
@@ -83,7 +80,6 @@ public class PracticeSessionService {
      * @param sessionRepository        study session repository
      * @param answerRepository         session answer repository
      * @param progressRepository       question progress repository
-     * @param domainProgressRepository domain progress repository
      * @param questionSelectionService question selection (spaced repetition)
      * @param answerProcessingService  answer grading + mastery update
      * @param streakService            streak management
@@ -95,7 +91,6 @@ public class PracticeSessionService {
     public PracticeSessionService(StudySessionRepository sessionRepository,
                                   SessionAnswerRepository answerRepository,
                                   QuestionProgressRepository progressRepository,
-                                  DomainProgressRepository domainProgressRepository,
                                   QuestionSelectionService questionSelectionService,
                                   AnswerProcessingService answerProcessingService,
                                   StreakService streakService,
@@ -106,7 +101,6 @@ public class PracticeSessionService {
         this.sessionRepository = sessionRepository;
         this.answerRepository = answerRepository;
         this.progressRepository = progressRepository;
-        this.domainProgressRepository = domainProgressRepository;
         this.questionSelectionService = questionSelectionService;
         this.answerProcessingService = answerProcessingService;
         this.streakService = streakService;
@@ -591,9 +585,11 @@ public class PracticeSessionService {
 
         List<StrapiDomainDto> domains = strapiContentCache.getDomains(productCode, locale);
 
-        Map<String, DomainProgress> progressMap = userId != null
-                ? domainProgressRepository.findByKeycloakUserIdAndProductCode(userId, productCode).stream()
-                        .collect(java.util.stream.Collectors.toMap(DomainProgress::getDomainCode, dp -> dp))
+        // Aggregate mastery stats from question_progress — domain_progress table is never populated
+        Map<String, QuestionProgressRepository.DomainMasteryProjection> progressMap = userId != null
+                ? progressRepository.aggregateByDomain(userId, productCode).stream()
+                        .collect(java.util.stream.Collectors.toMap(
+                                QuestionProgressRepository.DomainMasteryProjection::getDomainCode, p -> p))
                 : Map.of();
 
         return domains.stream()
@@ -602,18 +598,17 @@ public class PracticeSessionService {
                 .map(d -> {
                     int totalQuestions = strapiContentCache.getQuestionCountByDomain(d.code(), locale);
                     boolean isLocked = !access.isPaid() && !d.isFreePreview();
-                    DomainProgress dp = progressMap.get(d.code());
+                    QuestionProgressRepository.DomainMasteryProjection agg = progressMap.get(d.code());
 
                     int masteredCount = 0;
                     int learningCount = 0;
                     int newCount = totalQuestions;
                     double masteryPercent = 0.0;
 
-                    if (dp != null) {
-                        masteredCount = dp.getMasteredCount();
-                        int attemptedCount = dp.getAttemptedCount();
-                        learningCount = Math.max(0, attemptedCount - masteredCount);
-                        newCount = Math.max(0, totalQuestions - attemptedCount);
+                    if (agg != null) {
+                        masteredCount = (int) agg.getMasteredCount();
+                        learningCount = (int) agg.getLearningCount();
+                        newCount = Math.max(0, totalQuestions - masteredCount - learningCount);
                         masteryPercent = totalQuestions > 0
                                 ? (double) masteredCount / totalQuestions * 100.0 : 0.0;
                     }

--- a/src/main/java/com/passtheo/content/service/ProgressService.java
+++ b/src/main/java/com/passtheo/content/service/ProgressService.java
@@ -1,6 +1,5 @@
 package com.passtheo.content.service;
 
-import com.passtheo.content.domain.entity.DomainProgress;
 import com.passtheo.content.domain.entity.ReadinessSnapshot;
 import com.passtheo.content.domain.enums.DomainStrength;
 import com.passtheo.content.domain.enums.MasteryLevel;
@@ -9,7 +8,6 @@ import com.passtheo.content.dto.response.MasteryStatsDto;
 import com.passtheo.content.dto.response.ReadinessSnapshotDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
-import com.passtheo.content.repository.DomainProgressRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.repository.ReadinessSnapshotRepository;
 import jakarta.annotation.Nonnull;
@@ -33,57 +31,64 @@ public class ProgressService {
     private static final Logger LOG = LoggerFactory.getLogger(ProgressService.class);
 
     private final QuestionProgressRepository progressRepository;
-    private final DomainProgressRepository domainProgressRepository;
     private final ReadinessSnapshotRepository snapshotRepository;
     private final StrapiContentCache strapiContentCache;
 
     /**
      * Constructs the progress service.
      *
-     * @param progressRepository       question progress repository
-     * @param domainProgressRepository domain progress repository
-     * @param snapshotRepository       readiness snapshot repository
-     * @param strapiContentCache       Strapi content cache
+     * @param progressRepository question progress repository
+     * @param snapshotRepository readiness snapshot repository
+     * @param strapiContentCache Strapi content cache
      */
     public ProgressService(QuestionProgressRepository progressRepository,
-                           DomainProgressRepository domainProgressRepository,
                            ReadinessSnapshotRepository snapshotRepository,
                            StrapiContentCache strapiContentCache) {
         this.progressRepository = progressRepository;
-        this.domainProgressRepository = domainProgressRepository;
         this.snapshotRepository = snapshotRepository;
         this.strapiContentCache = strapiContentCache;
     }
 
     /**
      * Gets domain progress breakdown for a user/product.
+     * Stats are computed on-the-fly from question_progress (domain_progress is never populated).
      *
      * @param userId      the user's Keycloak ID
      * @param productCode the product code
      * @param locale      content locale
-     * @return list of domain progress DTOs
+     * @return list of domain progress DTOs (one per active domain, including unstarted)
      */
     @Transactional(readOnly = true)
     public List<DomainProgressDto> getDomainProgress(@Nonnull UUID userId, @Nonnull String productCode,
                                                       @Nonnull String locale) {
-        List<DomainProgress> progressList = domainProgressRepository
-                .findByKeycloakUserIdAndProductCode(userId, productCode);
+        Map<String, QuestionProgressRepository.DomainMasteryProjection> aggregates =
+                progressRepository.aggregateByDomain(userId, productCode).stream()
+                        .collect(Collectors.toMap(
+                                QuestionProgressRepository.DomainMasteryProjection::getDomainCode,
+                                p -> p));
 
-        Map<String, String> domainNames = strapiContentCache.getDomains(productCode, locale).stream()
-                .collect(Collectors.toMap(StrapiDomainDto::code, StrapiDomainDto::name));
-
-        return progressList.stream()
-                .map(dp -> new DomainProgressDto(
-                        dp.getDomainCode(),
-                        domainNames.getOrDefault(dp.getDomainCode(), dp.getDomainCode()),
-                        dp.getTotalQuestions(),
-                        dp.getAttemptedCount(),
-                        dp.getCorrectCount(),
-                        dp.getMasteredCount(),
-                        dp.getAccuracyPercent() != null ? dp.getAccuracyPercent().doubleValue() : 0.0,
-                        dp.getCoveragePercent() != null ? dp.getCoveragePercent().doubleValue() : 0.0,
-                        dp.getStrength() != null ? dp.getStrength().name() : DomainStrength.UNKNOWN.name()
-                ))
+        return strapiContentCache.getDomains(productCode, locale).stream()
+                .filter(StrapiDomainDto::isActive)
+                .map(d -> {
+                    QuestionProgressRepository.DomainMasteryProjection agg = aggregates.get(d.code());
+                    int totalQuestions = strapiContentCache.getQuestionCountByDomain(d.code(), locale);
+                    if (agg == null) {
+                        return new DomainProgressDto(
+                                d.code(), d.name(), totalQuestions, 0, 0, 0,
+                                0.0, 0.0, DomainStrength.UNKNOWN.name());
+                    }
+                    double accuracy = agg.getTotalAttempts() > 0
+                            ? (double) agg.getCorrectCount() / agg.getTotalAttempts() * 100.0 : 0.0;
+                    double coverage = totalQuestions > 0
+                            ? (double) agg.getAttemptedCount() / totalQuestions * 100.0 : 0.0;
+                    DomainStrength strength = ReadinessService.classifyDomainStrength(accuracy, coverage);
+                    return new DomainProgressDto(
+                            d.code(), d.name(), totalQuestions,
+                            (int) agg.getAttemptedCount(),
+                            (int) agg.getCorrectCount(),
+                            (int) agg.getMasteredCount(),
+                            accuracy, coverage, strength.name());
+                })
                 .toList();
     }
 

--- a/src/main/java/com/passtheo/content/service/ReadinessService.java
+++ b/src/main/java/com/passtheo/content/service/ReadinessService.java
@@ -1,14 +1,12 @@
 package com.passtheo.content.service;
 
 import com.passtheo.shared.core.client.UserServiceInternalClient;
-import com.passtheo.content.domain.entity.DomainProgress;
 import com.passtheo.content.domain.enums.DomainStrength;
 import com.passtheo.content.domain.enums.ReadinessLabel;
 import com.passtheo.content.domain.valueobject.ReadinessScore;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.content.integration.strapi.dto.StrapiExamConfigDto;
-import com.passtheo.content.repository.DomainProgressRepository;
 import com.passtheo.content.repository.ExamAttemptRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.shared.core.context.TenantContext;
@@ -53,7 +51,6 @@ public class ReadinessService {
     private static final double DAILY_PROGRESS_ESTIMATE = 0.5;
 
     private final QuestionProgressRepository progressRepository;
-    private final DomainProgressRepository domainProgressRepository;
     private final ExamAttemptRepository examAttemptRepository;
     private final StrapiContentCache strapiContentCache;
     private final UserServiceInternalClient userServiceClient;
@@ -61,19 +58,16 @@ public class ReadinessService {
     /**
      * Constructs the readiness service.
      *
-     * @param progressRepository       question progress repository
-     * @param domainProgressRepository domain progress repository
-     * @param examAttemptRepository    exam attempt repository
-     * @param strapiContentCache       Strapi content cache
-     * @param userServiceClient        user-service client for exam date
+     * @param progressRepository    question progress repository
+     * @param examAttemptRepository exam attempt repository
+     * @param strapiContentCache    Strapi content cache
+     * @param userServiceClient     user-service client for exam date
      */
     public ReadinessService(QuestionProgressRepository progressRepository,
-                            DomainProgressRepository domainProgressRepository,
                             ExamAttemptRepository examAttemptRepository,
                             StrapiContentCache strapiContentCache,
                             UserServiceInternalClient userServiceClient) {
         this.progressRepository = progressRepository;
-        this.domainProgressRepository = domainProgressRepository;
         this.examAttemptRepository = examAttemptRepository;
         this.strapiContentCache = strapiContentCache;
         this.userServiceClient = userServiceClient;
@@ -116,21 +110,35 @@ public class ReadinessService {
 
         ReadinessLabel label = classifyReadiness(readiness);
 
-        // Per-domain breakdown
-        List<DomainProgress> domainProgressList = domainProgressRepository
-                .findByKeycloakUserIdAndProductCode(userId, productCode);
+        // Per-domain breakdown — computed directly from question_progress (domain_progress is never populated)
+        Map<String, QuestionProgressRepository.DomainMasteryProjection> domainAggregates =
+                progressRepository.aggregateByDomain(userId, productCode).stream()
+                        .collect(Collectors.toMap(
+                                QuestionProgressRepository.DomainMasteryProjection::getDomainCode,
+                                p -> p));
 
-        Map<String, String> domainNames = strapiContentCache.getDomains(productCode, locale).stream()
-                .collect(Collectors.toMap(StrapiDomainDto::code, StrapiDomainDto::name));
+        Map<String, StrapiDomainDto> strapiDomains = strapiContentCache.getDomains(productCode, locale).stream()
+                .collect(Collectors.toMap(StrapiDomainDto::code, d -> d));
 
-        List<ReadinessScore.DomainStrengthValue> domainStrengths = domainProgressList.stream()
-                .map(dp -> new ReadinessScore.DomainStrengthValue(
-                        dp.getDomainCode(),
-                        domainNames.getOrDefault(dp.getDomainCode(), dp.getDomainCode()),
-                        dp.getAccuracyPercent() != null ? dp.getAccuracyPercent().doubleValue() : 0.0,
-                        dp.getCoveragePercent() != null ? dp.getCoveragePercent().doubleValue() : 0.0,
-                        dp.getStrength() != null ? dp.getStrength().name() : DomainStrength.UNKNOWN.name()
-                ))
+        List<ReadinessScore.DomainStrengthValue> domainStrengths = strapiDomains.entrySet().stream()
+                .filter(e -> e.getValue().isActive())
+                .map(e -> {
+                    String code = e.getKey();
+                    String name = e.getValue().name();
+                    QuestionProgressRepository.DomainMasteryProjection agg = domainAggregates.get(code);
+                    if (agg == null) {
+                        return new ReadinessScore.DomainStrengthValue(
+                                code, name, 0.0, 0.0, DomainStrength.UNKNOWN.name());
+                    }
+                    int domainTotal = strapiContentCache.getQuestionCountByDomain(code, locale);
+                    double domainAccuracy = agg.getTotalAttempts() > 0
+                            ? (double) agg.getCorrectCount() / agg.getTotalAttempts() * 100.0 : 0.0;
+                    double domainCoverage = domainTotal > 0
+                            ? (double) agg.getAttemptedCount() / domainTotal * 100.0 : 0.0;
+                    DomainStrength strength = classifyDomainStrength(domainAccuracy, domainCoverage);
+                    return new ReadinessScore.DomainStrengthValue(
+                            code, name, domainAccuracy, domainCoverage, strength.name());
+                })
                 .toList();
 
         LOG.debug("Readiness calculated: user={}, product={}, score={}, label={}, coverage={}, accuracy={}, exam={}",
@@ -184,7 +192,7 @@ public class ReadinessService {
      * @param coverage coverage percentage
      * @return the domain strength
      */
-    public DomainStrength classifyDomainStrength(double accuracy, double coverage) {
+    public static DomainStrength classifyDomainStrength(double accuracy, double coverage) {
         if (accuracy < WEAK_ACCURACY_THRESHOLD) {
             return DomainStrength.WEAK;
         }

--- a/src/test/java/com/passtheo/content/unit/AchievementServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/AchievementServiceTest.java
@@ -1,11 +1,9 @@
 package com.passtheo.content.unit;
 
 import com.passtheo.content.domain.entity.EarnedAchievement;
-import com.passtheo.content.domain.enums.DomainStrength;
 import com.passtheo.content.dto.response.EarnedAchievementDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiAchievementDefDto;
-import com.passtheo.content.repository.DomainProgressRepository;
 import com.passtheo.content.repository.EarnedAchievementRepository;
 import com.passtheo.content.repository.ExamAttemptRepository;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
@@ -29,6 +27,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,7 +39,6 @@ class AchievementServiceTest {
     @Mock private QuestionProgressRepository progressRepository;
     @Mock private StreakRepository streakRepository;
     @Mock private ExamAttemptRepository examAttemptRepository;
-    @Mock private DomainProgressRepository domainProgressRepository;
     @Mock private StrapiContentCache strapiContentCache;
     @Mock private OutboxEventRepository outboxEventRepository;
 
@@ -55,7 +53,7 @@ class AchievementServiceTest {
         TenantContext.set(TENANT_ID);
         achievementService = new AchievementService(
                 achievementRepository, progressRepository, streakRepository,
-                examAttemptRepository, domainProgressRepository, strapiContentCache, outboxEventRepository);
+                examAttemptRepository, strapiContentCache, outboxEventRepository);
     }
 
     @AfterEach
@@ -147,19 +145,54 @@ class AchievementServiceTest {
     }
 
     @Test
-    void domain_mastered_achievement_uses_domain_progress_repository() {
+    void domain_mastered_achievement_uses_question_progress_aggregation() {
+        // A domain where accuracy >= 85% AND coverage >= 80% qualifies as MASTERED strength
         StrapiAchievementDefDto def = new StrapiAchievementDefDto(
                 1, null, "Domeinmeester", "domain_mastered", "desc", "🎓", "🔒",
                 "domain_mastered", 1, 75, true, 1, null);
         when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
         when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
-        when(domainProgressRepository.countByKeycloakUserIdAndProductCodeAndStrength(
-                USER_ID, PRODUCT, DomainStrength.MASTERED)).thenReturn(2L);
+
+        // Domain with accuracy 90% and coverage 90% → MASTERED strength
+        QuestionProgressRepository.DomainMasteryProjection agg =
+                mock(QuestionProgressRepository.DomainMasteryProjection.class);
+        when(agg.getDomainCode()).thenReturn("verkeersborden");
+        when(agg.getAttemptedCount()).thenReturn(27L);   // 27/30 = 90% coverage
+        when(agg.getCorrectCount()).thenReturn(27L);
+        when(agg.getTotalAttempts()).thenReturn(30L);    // 27/30 = 90% accuracy
+
+        when(progressRepository.aggregateByDomain(USER_ID, PRODUCT)).thenReturn(List.of(agg));
+        when(strapiContentCache.getQuestionCountByDomain("verkeersborden", "nl")).thenReturn(30);
         when(achievementRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
 
         assertEquals(1, result.size());
+        assertEquals("domain_mastered", result.get(0).code());
+    }
+
+    @Test
+    void domain_mastered_achievement_not_earned_if_no_mastered_domains() {
+        StrapiAchievementDefDto def = new StrapiAchievementDefDto(
+                1, null, "Domeinmeester", "domain_mastered", "desc", "🎓", "🔒",
+                "domain_mastered", 1, 75, true, 1, null);
+        when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
+        when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
+
+        // Domain with low coverage → not MASTERED
+        QuestionProgressRepository.DomainMasteryProjection agg =
+                mock(QuestionProgressRepository.DomainMasteryProjection.class);
+        when(agg.getDomainCode()).thenReturn("verkeersborden");
+        when(agg.getAttemptedCount()).thenReturn(10L);   // 10/30 = 33% coverage — too low
+        when(agg.getCorrectCount()).thenReturn(7L);
+        when(agg.getTotalAttempts()).thenReturn(15L);
+
+        when(progressRepository.aggregateByDomain(USER_ID, PRODUCT)).thenReturn(List.of(agg));
+        when(strapiContentCache.getQuestionCountByDomain("verkeersborden", "nl")).thenReturn(30);
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertTrue(result.isEmpty());
     }
 
     @Test

--- a/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
+++ b/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
@@ -7,7 +7,6 @@ import com.passtheo.content.domain.enums.SessionType;
 import com.passtheo.content.dto.response.ActiveSessionDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
-import com.passtheo.content.repository.DomainProgressRepository;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.repository.SessionAnswerRepository;
@@ -39,7 +38,6 @@ class PracticeSessionServiceActiveSessionTest {
     @Mock private StudySessionRepository sessionRepository;
     @Mock private SessionAnswerRepository answerRepository;
     @Mock private QuestionProgressRepository progressRepository;
-    @Mock private DomainProgressRepository domainProgressRepository;
     @Mock private QuestionSelectionService questionSelectionService;
     @Mock private AnswerProcessingService answerProcessingService;
     @Mock private StreakService streakService;
@@ -56,8 +54,7 @@ class PracticeSessionServiceActiveSessionTest {
     void setUp() {
         service = new PracticeSessionService(
                 sessionRepository, answerRepository, progressRepository,
-                domainProgressRepository, questionSelectionService,
-                answerProcessingService, streakService,
+                questionSelectionService, answerProcessingService, streakService,
                 achievementService, strapiContentCache, outboxEventRepository,
                 new ObjectMapper()
         );

--- a/src/test/java/com/passtheo/content/unit/ProgressServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/ProgressServiceTest.java
@@ -7,7 +7,6 @@ import com.passtheo.content.dto.response.MasteryStatsDto;
 import com.passtheo.content.dto.response.ReadinessSnapshotDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
-import com.passtheo.content.repository.DomainProgressRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.repository.ReadinessSnapshotRepository;
 import com.passtheo.content.service.ProgressService;
@@ -34,7 +33,6 @@ import static org.mockito.Mockito.when;
 class ProgressServiceTest {
 
     @Mock private QuestionProgressRepository progressRepository;
-    @Mock private DomainProgressRepository domainProgressRepository;
     @Mock private ReadinessSnapshotRepository snapshotRepository;
     @Mock private StrapiContentCache strapiContentCache;
 
@@ -46,16 +44,13 @@ class ProgressServiceTest {
 
     @BeforeEach
     void setUp() {
-        progressService = new ProgressService(
-                progressRepository, domainProgressRepository, snapshotRepository, strapiContentCache);
+        progressService = new ProgressService(progressRepository, snapshotRepository, strapiContentCache);
     }
 
     @Test
     void getDomainProgress_returns_empty_for_new_user() {
-        when(domainProgressRepository.findByKeycloakUserIdAndProductCode(USER_ID, PRODUCT))
-                .thenReturn(List.of());
-        when(strapiContentCache.getDomains(eq(PRODUCT), eq(LOCALE)))
-                .thenReturn(List.of());
+        when(progressRepository.aggregateByDomain(USER_ID, PRODUCT)).thenReturn(List.of());
+        when(strapiContentCache.getDomains(eq(PRODUCT), eq(LOCALE))).thenReturn(List.of());
 
         List<DomainProgressDto> result = progressService.getDomainProgress(USER_ID, PRODUCT, LOCALE);
 
@@ -63,38 +58,50 @@ class ProgressServiceTest {
     }
 
     @Test
-    void getDomainProgress_maps_domain_names_from_strapi() {
-        com.passtheo.content.domain.entity.DomainProgress dp =
-                buildDomainProgress("verkeersborden", 50, 25, 20, 5, 80.0, 50.0, DomainStrength.STRONG);
-        when(domainProgressRepository.findByKeycloakUserIdAndProductCode(USER_ID, PRODUCT))
-                .thenReturn(List.of(dp));
-        when(strapiContentCache.getDomains(eq(PRODUCT), eq(LOCALE)))
-                .thenReturn(List.of(new StrapiDomainDto(
-                        1, null, "Verkeersborden", "verkeersborden", "verkeersborden",
-                        "desc", null, "#E63946", 50, true, true, 1)));
+    void getDomainProgress_computes_stats_from_question_progress() {
+        StrapiDomainDto domain = new StrapiDomainDto(
+                1, null, "Verkeersborden", "verkeersborden", "verkeersborden",
+                "desc", null, "#E63946", 30, true, true, 1);
+
+        QuestionProgressRepository.DomainMasteryProjection agg = buildProjection(
+                "verkeersborden", 25L, 22L, 30L, 5L);
+
+        when(progressRepository.aggregateByDomain(USER_ID, PRODUCT)).thenReturn(List.of(agg));
+        when(strapiContentCache.getDomains(eq(PRODUCT), eq(LOCALE))).thenReturn(List.of(domain));
+        when(strapiContentCache.getQuestionCountByDomain(eq("verkeersborden"), eq(LOCALE))).thenReturn(30);
 
         List<DomainProgressDto> result = progressService.getDomainProgress(USER_ID, PRODUCT, LOCALE);
 
         assertEquals(1, result.size());
-        assertEquals("verkeersborden", result.get(0).domainCode());
-        assertEquals("Verkeersborden", result.get(0).domainName());
-        assertEquals(50, result.get(0).totalQuestions());
-        assertEquals(25, result.get(0).attemptedCount());
-        assertEquals(80.0, result.get(0).accuracyPercent(), 0.01);
+        DomainProgressDto dto = result.get(0);
+        assertEquals("verkeersborden", dto.domainCode());
+        assertEquals("Verkeersborden", dto.domainName());
+        assertEquals(30, dto.totalQuestions());
+        assertEquals(25, dto.attemptedCount());
+        assertEquals(5, dto.masteredCount());
+        // accuracy = 22/30*100 ≈ 73.3%
+        assertEquals(73.3, dto.accuracyPercent(), 0.1);
+        // coverage = 25/30*100 ≈ 83.3%
+        assertEquals(83.3, dto.coveragePercent(), 0.1);
+        // accuracy 73.3% >= 70%, coverage 83.3% >= 60% → STRONG
+        assertEquals(DomainStrength.STRONG.name(), dto.strength());
     }
 
     @Test
-    void getDomainProgress_uses_domain_code_as_fallback_name() {
-        com.passtheo.content.domain.entity.DomainProgress dp =
-                buildDomainProgress("unknown-domain", 10, 5, 4, 1, 80.0, 50.0, DomainStrength.MODERATE);
-        when(domainProgressRepository.findByKeycloakUserIdAndProductCode(USER_ID, PRODUCT))
-                .thenReturn(List.of(dp));
-        when(strapiContentCache.getDomains(eq(PRODUCT), eq(LOCALE)))
-                .thenReturn(List.of());
+    void getDomainProgress_returns_unknown_strength_for_domain_with_no_progress() {
+        StrapiDomainDto domain = new StrapiDomainDto(
+                1, null, "Verkeersborden", "verkeersborden", "verkeersborden",
+                "desc", null, "#E63946", 30, true, true, 1);
+
+        when(progressRepository.aggregateByDomain(USER_ID, PRODUCT)).thenReturn(List.of());
+        when(strapiContentCache.getDomains(eq(PRODUCT), eq(LOCALE))).thenReturn(List.of(domain));
+        when(strapiContentCache.getQuestionCountByDomain(eq("verkeersborden"), eq(LOCALE))).thenReturn(30);
 
         List<DomainProgressDto> result = progressService.getDomainProgress(USER_ID, PRODUCT, LOCALE);
 
-        assertEquals("unknown-domain", result.get(0).domainName());
+        assertEquals(1, result.size());
+        assertEquals(0, result.get(0).attemptedCount());
+        assertEquals(DomainStrength.UNKNOWN.name(), result.get(0).strength());
     }
 
     @Test
@@ -177,20 +184,16 @@ class ProgressServiceTest {
 
     // ─── Helpers ───
 
-    private com.passtheo.content.domain.entity.DomainProgress buildDomainProgress(
-            String domainCode, int total, int attempted, int correct, int mastered,
-            double accuracy, double coverage, DomainStrength strength) {
-        com.passtheo.content.domain.entity.DomainProgress dp =
-                mock(com.passtheo.content.domain.entity.DomainProgress.class);
-        when(dp.getDomainCode()).thenReturn(domainCode);
-        when(dp.getTotalQuestions()).thenReturn(total);
-        when(dp.getAttemptedCount()).thenReturn(attempted);
-        when(dp.getCorrectCount()).thenReturn(correct);
-        when(dp.getMasteredCount()).thenReturn(mastered);
-        when(dp.getAccuracyPercent()).thenReturn(BigDecimal.valueOf(accuracy));
-        when(dp.getCoveragePercent()).thenReturn(BigDecimal.valueOf(coverage));
-        when(dp.getStrength()).thenReturn(strength);
-        return dp;
+    private QuestionProgressRepository.DomainMasteryProjection buildProjection(
+            String domainCode, long attempted, long correct, long totalAttempts, long mastered) {
+        QuestionProgressRepository.DomainMasteryProjection p =
+                mock(QuestionProgressRepository.DomainMasteryProjection.class);
+        when(p.getDomainCode()).thenReturn(domainCode);
+        when(p.getAttemptedCount()).thenReturn(attempted);
+        when(p.getCorrectCount()).thenReturn(correct);
+        when(p.getTotalAttempts()).thenReturn(totalAttempts);
+        when(p.getMasteredCount()).thenReturn(mastered);
+        return p;
     }
 
     private com.passtheo.content.domain.entity.ReadinessSnapshot buildReadinessSnapshot(

--- a/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
@@ -5,8 +5,8 @@ import com.passtheo.content.domain.enums.DomainStrength;
 import com.passtheo.content.domain.enums.ReadinessLabel;
 import com.passtheo.content.domain.valueobject.ReadinessScore;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
+import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.content.integration.strapi.dto.StrapiExamConfigDto;
-import com.passtheo.content.repository.DomainProgressRepository;
 import com.passtheo.content.repository.ExamAttemptRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.service.ReadinessService;
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -35,7 +36,6 @@ import static org.mockito.Mockito.when;
 class ReadinessServiceTest {
 
     @Mock private QuestionProgressRepository progressRepository;
-    @Mock private DomainProgressRepository domainProgressRepository;
     @Mock private ExamAttemptRepository examAttemptRepository;
     @Mock private StrapiContentCache strapiContentCache;
     @Mock private UserServiceInternalClient userServiceClient;
@@ -51,8 +51,7 @@ class ReadinessServiceTest {
     void setUp() {
         TenantContext.set(TENANT_ID);
         org.mockito.Mockito.lenient().when(userServiceClient.getProfile(any(), any())).thenReturn(Optional.empty());
-        service = new ReadinessService(progressRepository, domainProgressRepository,
-                examAttemptRepository, strapiContentCache, userServiceClient);
+        service = new ReadinessService(progressRepository, examAttemptRepository, strapiContentCache, userServiceClient);
     }
 
     @AfterEach
@@ -166,31 +165,68 @@ class ReadinessServiceTest {
         assertThat(result.questionsAttempted()).isEqualTo(100);
     }
 
+    @Test
+    void calculate_domainStrengths_computedFromQuestionProgress() {
+        // Domain "verkeersborden": 30 total questions, 25 attempted, 22 correct, 5 mastered
+        StrapiDomainDto domain = new StrapiDomainDto(
+                1, null, "Verkeersborden", "verkeersborden", "verkeersborden",
+                "desc", null, "#E63946", 30, true, true, 1);
+
+        QuestionProgressRepository.DomainMasteryProjection agg = mock(
+                QuestionProgressRepository.DomainMasteryProjection.class);
+        when(agg.getDomainCode()).thenReturn("verkeersborden");
+        when(agg.getAttemptedCount()).thenReturn(25L);
+        when(agg.getCorrectCount()).thenReturn(22L);
+        when(agg.getTotalAttempts()).thenReturn(30L);
+
+        when(progressRepository.aggregateByDomain(eq(USER_ID), eq(PRODUCT_CODE)))
+                .thenReturn(List.of(agg));
+        when(strapiContentCache.getDomains(eq(PRODUCT_CODE), eq(LOCALE)))
+                .thenReturn(List.of(domain));
+        when(strapiContentCache.getQuestionCountByDomain(eq("verkeersborden"), eq(LOCALE)))
+                .thenReturn(30);
+        when(strapiContentCache.getQuestionCount(eq(PRODUCT_CODE), eq(LOCALE))).thenReturn(30);
+        when(progressRepository.countAttempted(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(25);
+        when(progressRepository.countCorrect(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(22);
+        when(examAttemptRepository.findBestScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
+        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE)))
+                .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, 44, null, null, true, false, null, null, false));
+        when(userServiceClient.getProfile(any(), any())).thenReturn(Optional.empty());
+
+        ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
+
+        assertThat(result.domainStrengths()).hasSize(1);
+        ReadinessScore.DomainStrengthValue dsv = result.domainStrengths().get(0);
+        assertThat(dsv.domainCode()).isEqualTo("verkeersborden");
+        // accuracy = 22/30*100 ≈ 73.3%, coverage = 25/30*100 ≈ 83.3% → STRONG
+        assertThat(dsv.strength()).isEqualTo(DomainStrength.STRONG.name());
+    }
+
     // ─── DOMAIN STRENGTH CLASSIFICATION ───
 
     @Test
     void classifyDomainStrength_belowFiftyAccuracy_isWeak() {
-        assertThat(service.classifyDomainStrength(45.0, 80.0)).isEqualTo(DomainStrength.WEAK);
+        assertThat(ReadinessService.classifyDomainStrength(45.0, 80.0)).isEqualTo(DomainStrength.WEAK);
     }
 
     @Test
     void classifyDomainStrength_fiftyToSeventy_isModerate() {
-        assertThat(service.classifyDomainStrength(65.0, 50.0)).isEqualTo(DomainStrength.MODERATE);
+        assertThat(ReadinessService.classifyDomainStrength(65.0, 50.0)).isEqualTo(DomainStrength.MODERATE);
     }
 
     @Test
     void classifyDomainStrength_aboveEightyFiveWithHighCoverage_isMastered() {
-        assertThat(service.classifyDomainStrength(90.0, 85.0)).isEqualTo(DomainStrength.MASTERED);
+        assertThat(ReadinessService.classifyDomainStrength(90.0, 85.0)).isEqualTo(DomainStrength.MASTERED);
     }
 
     @Test
     void classifyDomainStrength_seventyToEightyFiveWithGoodCoverage_isStrong() {
-        assertThat(service.classifyDomainStrength(78.0, 65.0)).isEqualTo(DomainStrength.STRONG);
+        assertThat(ReadinessService.classifyDomainStrength(78.0, 65.0)).isEqualTo(DomainStrength.STRONG);
     }
 
     @Test
     void classifyDomainStrength_highAccuracyLowCoverage_isModerate() {
-        assertThat(service.classifyDomainStrength(88.0, 30.0)).isEqualTo(DomainStrength.MODERATE);
+        assertThat(ReadinessService.classifyDomainStrength(88.0, 30.0)).isEqualTo(DomainStrength.MODERATE);
     }
 
     // ─── HELPERS ───
@@ -203,8 +239,7 @@ class ReadinessServiceTest {
         when(examAttemptRepository.findBestScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(bestExam);
         when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE)))
                 .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, passScore, null, null, true, false, null, null, false));
-        when(domainProgressRepository.findByKeycloakUserIdAndProductCode(eq(USER_ID), eq(PRODUCT_CODE)))
-                .thenReturn(List.of());
+        when(progressRepository.aggregateByDomain(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(List.of());
         when(strapiContentCache.getDomains(eq(PRODUCT_CODE), eq(LOCALE))).thenReturn(List.of());
     }
 }


### PR DESCRIPTION
Closes #29

## Root cause

The `domain_progress` table was designed as a materialized aggregate but nothing ever wrote to it. All four consumers read from this always-empty table and fell back to zeros, so `masteredCount=0, learningCount=0, newCount=30` was returned for every domain regardless of how many questions the user had answered.

## Changes

- **`QuestionProgressRepository`** — Added `DomainMasteryProjection` interface and `aggregateByDomain()` JPQL query that computes mastery counts per domain in a single `GROUP BY` query from `question_progress`. Uses the existing `idx_progress_domain` index.
- **`PracticeSessionService.listPracticeDomains()`** — Replaced `domainProgressRepository` reads with `progressRepository.aggregateByDomain()`. Now returns correct `masteredCount`, `learningCount`, and `newCount`.
- **`ProgressService.getDomainProgress()`** — Same replacement. Also iterates over all Strapi domains so unstarted domains appear with zeros rather than being absent.
- **`ReadinessService.calculate()`** — Domain strength breakdown now computed from real question progress. `classifyDomainStrength()` made `static` so it can be called from sibling services.
- **`AchievementService`** — `domain_mastered` trigger now counts domains with accuracy ≥ 85% AND coverage ≥ 80%, instead of querying the never-populated `domain_progress` table (which meant this achievement could never fire).
- No schema migration needed — `domain_progress` table is kept only for the GDPR deletion path.

## Test plan

- [x] All 95 unit tests pass (`./gradlew test`)
- [x] Docker image builds successfully
- [ ] Start the service locally, complete a practice session, then call `GET /api/practice/domains?productCode=auto-b&locale=en` — verify non-zero mastered/learning/new counts
- [ ] Call `GET /api/progress/domains?productCode=auto-b` — verify accuracy, coverage, strength fields
- [ ] Call `GET /api/progress/readiness?productCode=auto-b` — verify domain strengths in response