### PR TITLE
fix(content): compute domain & topic progress from question_progress

### DIFF
--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -1504,7 +1504,7 @@ components:
         questionCount: { type: integer }
         progress:
           type: object
-          nullable: true
+          description: Topic progress overlay (always present, defaults to zeros for untouched topics)
           properties:
             coveragePercent: { type: number }
             accuracyPercent: { type: number }

--- a/src/main/java/com/passtheo/content/controller/ContentController.java
+++ b/src/main/java/com/passtheo/content/controller/ContentController.java
@@ -14,6 +14,7 @@ import com.passtheo.content.dto.response.TopicWithProgressDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.content.repository.DomainProgressRepository;
+import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.service.EntitlementChecker;
 import com.passtheo.content.service.OnboardingCatalogService;
 import com.passtheo.shared.core.dto.ApiResponse;
@@ -46,23 +47,27 @@ public class ContentController {
 
     private final StrapiContentCache strapiContentCache;
     private final DomainProgressRepository domainProgressRepository;
+    private final QuestionProgressRepository questionProgressRepository;
     private final EntitlementChecker entitlementChecker;
     private final OnboardingCatalogService onboardingCatalogService;
 
     /**
      * Constructs the content controller.
      *
-     * @param strapiContentCache       Strapi content cache
-     * @param domainProgressRepository domain progress repository
-     * @param entitlementChecker       entitlement checker
-     * @param onboardingCatalogService onboarding catalog service
+     * @param strapiContentCache         Strapi content cache
+     * @param domainProgressRepository   domain progress repository
+     * @param questionProgressRepository question progress repository
+     * @param entitlementChecker         entitlement checker
+     * @param onboardingCatalogService   onboarding catalog service
      */
     public ContentController(StrapiContentCache strapiContentCache,
                              DomainProgressRepository domainProgressRepository,
+                             QuestionProgressRepository questionProgressRepository,
                              EntitlementChecker entitlementChecker,
                              OnboardingCatalogService onboardingCatalogService) {
         this.strapiContentCache = strapiContentCache;
         this.domainProgressRepository = domainProgressRepository;
+        this.questionProgressRepository = questionProgressRepository;
         this.entitlementChecker = entitlementChecker;
         this.onboardingCatalogService = onboardingCatalogService;
     }
@@ -193,6 +198,8 @@ public class ContentController {
      * @param productTypeCode the product type code
      * @param productCode     the product code
      * @param domainCode      the domain code
+     * @param tenantId        tenant ID from header
+     * @param userId          user ID from header
      * @param locale          content locale
      * @return list of topics with progress
      */
@@ -202,12 +209,32 @@ public class ContentController {
             @PathVariable @Nonnull String productTypeCode,
             @PathVariable @Nonnull String productCode,
             @PathVariable @Nonnull String domainCode,
+            @RequestHeader("X-Tenant-ID") UUID tenantId,
+            @RequestHeader("X-Keycloak-User-ID") UUID userId,
             @RequestParam(defaultValue = "nl") String locale) {
+
+        Map<String, QuestionProgressRepository.TopicMasteryProjection> progressMap =
+                questionProgressRepository.aggregateByTopic(userId, productCode, domainCode).stream()
+                        .collect(Collectors.toMap(
+                                QuestionProgressRepository.TopicMasteryProjection::getTopicCode,
+                                p -> p));
+
         var topics = strapiContentCache.getTopics(domainCode, locale).stream()
-                .map(t -> new TopicWithProgressDto(
-                        t.code(), t.name(), t.difficulty(),
-                        strapiContentCache.getQuestionCountByTopic(t.code(), locale),
-                        null))
+                .map(t -> {
+                    int questionCount = strapiContentCache.getQuestionCountByTopic(t.code(), locale);
+                    QuestionProgressRepository.TopicMasteryProjection agg = progressMap.get(t.code());
+
+                    double coverage = agg != null && questionCount > 0
+                            ? (double) agg.getAttemptedCount() / questionCount * 100.0 : 0.0;
+                    double accuracy = agg != null && agg.getTotalAttempts() > 0
+                            ? (double) agg.getCorrectCount() / agg.getTotalAttempts() * 100.0 : 0.0;
+                    int mastered = agg != null ? (int) agg.getMasteredCount() : 0;
+
+                    var progress = new TopicWithProgressDto.TopicProgressOverlay(
+                            coverage, accuracy, mastered);
+
+                    return new TopicWithProgressDto(t.code(), t.name(), t.difficulty(), questionCount, progress);
+                })
                 .toList();
         return ResponseEntity.ok(ApiResponse.success(topics, MDC.get("traceId")));
     }

--- a/src/main/java/com/passtheo/content/controller/ContentController.java
+++ b/src/main/java/com/passtheo/content/controller/ContentController.java
@@ -1,6 +1,6 @@
 package com.passtheo.content.controller;
 
-import com.passtheo.content.domain.entity.DomainProgress;
+import com.passtheo.content.domain.enums.DomainStrength;
 import com.passtheo.content.domain.valueobject.AccessGrant;
 import com.passtheo.content.dto.response.CountryDto;
 import com.passtheo.content.dto.response.DomainWithProgressDto;
@@ -13,10 +13,10 @@ import com.passtheo.content.dto.response.RoadSignDto;
 import com.passtheo.content.dto.response.TopicWithProgressDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
-import com.passtheo.content.repository.DomainProgressRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.service.EntitlementChecker;
 import com.passtheo.content.service.OnboardingCatalogService;
+import com.passtheo.content.service.ReadinessService;
 import com.passtheo.shared.core.dto.ApiResponse;
 import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -46,7 +46,6 @@ public class ContentController {
     private static final Logger LOG = LoggerFactory.getLogger(ContentController.class);
 
     private final StrapiContentCache strapiContentCache;
-    private final DomainProgressRepository domainProgressRepository;
     private final QuestionProgressRepository questionProgressRepository;
     private final EntitlementChecker entitlementChecker;
     private final OnboardingCatalogService onboardingCatalogService;
@@ -55,18 +54,15 @@ public class ContentController {
      * Constructs the content controller.
      *
      * @param strapiContentCache         Strapi content cache
-     * @param domainProgressRepository   domain progress repository
      * @param questionProgressRepository question progress repository
      * @param entitlementChecker         entitlement checker
      * @param onboardingCatalogService   onboarding catalog service
      */
     public ContentController(StrapiContentCache strapiContentCache,
-                             DomainProgressRepository domainProgressRepository,
                              QuestionProgressRepository questionProgressRepository,
                              EntitlementChecker entitlementChecker,
                              OnboardingCatalogService onboardingCatalogService) {
         this.strapiContentCache = strapiContentCache;
-        this.domainProgressRepository = domainProgressRepository;
         this.questionProgressRepository = questionProgressRepository;
         this.entitlementChecker = entitlementChecker;
         this.onboardingCatalogService = onboardingCatalogService;
@@ -164,23 +160,26 @@ public class ContentController {
         List<StrapiDomainDto> domains = strapiContentCache.getDomains(productCode, locale);
         AccessGrant access = entitlementChecker.getAccess(tenantId, userId);
 
-        Map<String, DomainProgress> progressMap = domainProgressRepository
-                .findByKeycloakUserIdAndProductCode(userId, productCode).stream()
-                .collect(Collectors.toMap(DomainProgress::getDomainCode, dp -> dp));
+        Map<String, QuestionProgressRepository.DomainMasteryProjection> progressMap =
+                questionProgressRepository.aggregateByDomain(userId, productCode).stream()
+                        .collect(Collectors.toMap(
+                                QuestionProgressRepository.DomainMasteryProjection::getDomainCode,
+                                p -> p));
 
         List<DomainWithProgressDto> result = domains.stream().map(d -> {
-            DomainProgress dp = progressMap.get(d.code());
+            QuestionProgressRepository.DomainMasteryProjection agg = progressMap.get(d.code());
             boolean isLocked = !access.isPaid() && !d.isFreePreview();
-
-            DomainWithProgressDto.ProgressOverlay progress = dp != null
-                    ? new DomainWithProgressDto.ProgressOverlay(
-                    dp.getCoveragePercent() != null ? dp.getCoveragePercent().doubleValue() : 0.0,
-                    dp.getAccuracyPercent() != null ? dp.getAccuracyPercent().doubleValue() : 0.0,
-                    dp.getMasteredCount(),
-                    dp.getStrength() != null ? dp.getStrength().name() : "UNKNOWN")
-                    : new DomainWithProgressDto.ProgressOverlay(0.0, 0.0, 0, "UNKNOWN");
-
             int questionCount = strapiContentCache.getQuestionCountByDomain(d.code(), locale);
+
+            double coverage = agg != null && questionCount > 0
+                    ? (double) agg.getAttemptedCount() / questionCount * 100.0 : 0.0;
+            double accuracy = agg != null && agg.getTotalAttempts() > 0
+                    ? (double) agg.getCorrectCount() / agg.getTotalAttempts() * 100.0 : 0.0;
+            int mastered = agg != null ? (int) agg.getMasteredCount() : 0;
+            DomainStrength strength = ReadinessService.classifyDomainStrength(accuracy, coverage);
+
+            var progress = new DomainWithProgressDto.ProgressOverlay(
+                    coverage, accuracy, mastered, strength.name());
 
             return new DomainWithProgressDto(
                     d.code(), d.name(), d.icon(), d.color(),

--- a/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
+++ b/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
@@ -89,6 +89,68 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
                                                      @Nonnull @Param("productCode") String productCode);
 
     /**
+     * Per-topic mastery aggregate computed directly from question_progress rows.
+     * Used instead of the (never-populated) topic_progress table.
+     */
+    interface TopicMasteryProjection {
+        /**
+         * Returns the topic code.
+         *
+         * @return topic code (e.g. "verbodsborden")
+         */
+        String getTopicCode();
+
+        /**
+         * Returns the number of distinct questions answered at least once.
+         *
+         * @return attempted question count
+         */
+        long getAttemptedCount();
+
+        /**
+         * Returns the sum of totalCorrect across all answered questions in this topic.
+         *
+         * @return total correct answers
+         */
+        long getCorrectCount();
+
+        /**
+         * Returns the sum of totalAttempts across all answered questions (denominator for accuracy).
+         *
+         * @return total answer attempts
+         */
+        long getTotalAttempts();
+
+        /**
+         * Returns the number of questions at MASTERED level.
+         *
+         * @return mastered question count
+         */
+        long getMasteredCount();
+    }
+
+    /**
+     * Returns topic-level mastery aggregates for a user/product/domain in a single query.
+     *
+     * @param userId      the user's Keycloak ID
+     * @param productCode the product code
+     * @param domainCode  the domain code
+     * @return one projection per topic the user has touched within the domain
+     */
+    @Query("SELECT qp.topicCode AS topicCode, " +
+           "COUNT(qp) AS attemptedCount, " +
+           "SUM(qp.totalCorrect) AS correctCount, " +
+           "SUM(qp.totalAttempts) AS totalAttempts, " +
+           "SUM(CASE WHEN qp.masteryLevel = 'MASTERED' THEN 1 ELSE 0 END) AS masteredCount " +
+           "FROM QuestionProgress qp WHERE qp.keycloakUserId = :userId " +
+           "AND qp.productCode = :productCode AND qp.domainCode = :domainCode " +
+           "AND qp.topicCode <> '' " +
+           "GROUP BY qp.topicCode")
+    List<TopicMasteryProjection> aggregateByTopic(@Nonnull @Param("userId") UUID userId,
+                                                   @Nonnull @Param("productCode") String productCode,
+                                                   @Nonnull @Param("domainCode") String domainCode);
+
+    /**
      * Finds a progress record by user and question.
      *
      * @param keycloakUserId   the user's Keycloak ID

--- a/src/test/java/com/passtheo/content/unit/ContentControllerListTopicsTest.java
+++ b/src/test/java/com/passtheo/content/unit/ContentControllerListTopicsTest.java
@@ -4,7 +4,6 @@ import com.passtheo.content.controller.ContentController;
 import com.passtheo.content.dto.response.TopicWithProgressDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiTopicDto;
-import com.passtheo.content.repository.DomainProgressRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.service.EntitlementChecker;
 import com.passtheo.content.service.OnboardingCatalogService;
@@ -28,7 +27,6 @@ import static org.mockito.Mockito.when;
 class ContentControllerListTopicsTest {
 
     @Mock private StrapiContentCache strapiContentCache;
-    @Mock private DomainProgressRepository domainProgressRepository;
     @Mock private QuestionProgressRepository questionProgressRepository;
     @Mock private EntitlementChecker entitlementChecker;
     @Mock private OnboardingCatalogService onboardingCatalogService;
@@ -44,8 +42,8 @@ class ContentControllerListTopicsTest {
     @BeforeEach
     void setUp() {
         controller = new ContentController(
-                strapiContentCache, domainProgressRepository,
-                questionProgressRepository, entitlementChecker, onboardingCatalogService);
+                strapiContentCache, questionProgressRepository,
+                entitlementChecker, onboardingCatalogService);
     }
 
     @Test

--- a/src/test/java/com/passtheo/content/unit/ContentControllerListTopicsTest.java
+++ b/src/test/java/com/passtheo/content/unit/ContentControllerListTopicsTest.java
@@ -1,0 +1,148 @@
+package com.passtheo.content.unit;
+
+import com.passtheo.content.controller.ContentController;
+import com.passtheo.content.dto.response.TopicWithProgressDto;
+import com.passtheo.content.integration.strapi.StrapiContentCache;
+import com.passtheo.content.integration.strapi.dto.StrapiTopicDto;
+import com.passtheo.content.repository.DomainProgressRepository;
+import com.passtheo.content.repository.QuestionProgressRepository;
+import com.passtheo.content.service.EntitlementChecker;
+import com.passtheo.content.service.OnboardingCatalogService;
+import com.passtheo.shared.core.dto.ApiResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ContentControllerListTopicsTest {
+
+    @Mock private StrapiContentCache strapiContentCache;
+    @Mock private DomainProgressRepository domainProgressRepository;
+    @Mock private QuestionProgressRepository questionProgressRepository;
+    @Mock private EntitlementChecker entitlementChecker;
+    @Mock private OnboardingCatalogService onboardingCatalogService;
+
+    private ContentController controller;
+
+    private static final UUID TENANT_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final String PRODUCT = "auto-b";
+    private static final String DOMAIN = "verkeersborden";
+    private static final String LOCALE = "nl";
+
+    @BeforeEach
+    void setUp() {
+        controller = new ContentController(
+                strapiContentCache, domainProgressRepository,
+                questionProgressRepository, entitlementChecker, onboardingCatalogService);
+    }
+
+    @Test
+    void listTopics_noProgress_returnsZeroOverlay() {
+        when(strapiContentCache.getTopics(DOMAIN, LOCALE)).thenReturn(List.of(
+                new StrapiTopicDto(1, "doc1", "Prohibition Signs", "verbodsborden", "verbodsborden", "", "easy", 10, true, 1)));
+        when(strapiContentCache.getQuestionCountByTopic("verbodsborden", LOCALE)).thenReturn(10);
+        when(questionProgressRepository.aggregateByTopic(USER_ID, PRODUCT, DOMAIN)).thenReturn(List.of());
+
+        ResponseEntity<ApiResponse<List<TopicWithProgressDto>>> response =
+                controller.listTopics("NL", "cbr", PRODUCT, DOMAIN, TENANT_ID, USER_ID, LOCALE);
+
+        List<TopicWithProgressDto> topics = response.getBody().getData();
+        assertEquals(1, topics.size());
+        TopicWithProgressDto.TopicProgressOverlay progress = topics.getFirst().progress();
+        assertNotNull(progress);
+        assertEquals(0.0, progress.coveragePercent());
+        assertEquals(0.0, progress.accuracyPercent());
+        assertEquals(0, progress.masteredCount());
+    }
+
+    @Test
+    void listTopics_withProgress_computesAccuracyAndCoverage() {
+        when(strapiContentCache.getTopics(DOMAIN, LOCALE)).thenReturn(List.of(
+                new StrapiTopicDto(1, "doc1", "Prohibition Signs", "verbodsborden", "verbodsborden", "", "easy", 10, true, 1)));
+        when(strapiContentCache.getQuestionCountByTopic("verbodsborden", LOCALE)).thenReturn(20);
+
+        QuestionProgressRepository.TopicMasteryProjection projection = mock(QuestionProgressRepository.TopicMasteryProjection.class);
+        when(projection.getTopicCode()).thenReturn("verbodsborden");
+        when(projection.getAttemptedCount()).thenReturn(10L);
+        when(projection.getCorrectCount()).thenReturn(7L);
+        when(projection.getTotalAttempts()).thenReturn(14L);
+        when(projection.getMasteredCount()).thenReturn(3L);
+        when(questionProgressRepository.aggregateByTopic(USER_ID, PRODUCT, DOMAIN)).thenReturn(List.of(projection));
+
+        ResponseEntity<ApiResponse<List<TopicWithProgressDto>>> response =
+                controller.listTopics("NL", "cbr", PRODUCT, DOMAIN, TENANT_ID, USER_ID, LOCALE);
+
+        TopicWithProgressDto.TopicProgressOverlay progress = response.getBody().getData().getFirst().progress();
+        assertEquals(50.0, progress.coveragePercent(), 0.01);  // 10/20 * 100
+        assertEquals(50.0, progress.accuracyPercent(), 0.01);  // 7/14 * 100
+        assertEquals(3, progress.masteredCount());
+    }
+
+    @Test
+    void listTopics_zeroQuestionCount_noDivisionByZero() {
+        when(strapiContentCache.getTopics(DOMAIN, LOCALE)).thenReturn(List.of(
+                new StrapiTopicDto(1, "doc1", "Empty Topic", "empty", "empty", "", "easy", 0, true, 1)));
+        when(strapiContentCache.getQuestionCountByTopic("empty", LOCALE)).thenReturn(0);
+
+        QuestionProgressRepository.TopicMasteryProjection projection = mock(QuestionProgressRepository.TopicMasteryProjection.class);
+        when(projection.getTopicCode()).thenReturn("empty");
+        when(projection.getTotalAttempts()).thenReturn(0L);
+        when(projection.getMasteredCount()).thenReturn(0L);
+        when(questionProgressRepository.aggregateByTopic(USER_ID, PRODUCT, DOMAIN)).thenReturn(List.of(projection));
+
+        ResponseEntity<ApiResponse<List<TopicWithProgressDto>>> response =
+                controller.listTopics("NL", "cbr", PRODUCT, DOMAIN, TENANT_ID, USER_ID, LOCALE);
+
+        TopicWithProgressDto.TopicProgressOverlay progress = response.getBody().getData().getFirst().progress();
+        assertEquals(0.0, progress.coveragePercent());
+        assertEquals(0.0, progress.accuracyPercent());
+        assertEquals(0, progress.masteredCount());
+    }
+
+    @Test
+    void listTopics_multipleTopics_mapsProgressCorrectly() {
+        when(strapiContentCache.getTopics(DOMAIN, LOCALE)).thenReturn(List.of(
+                new StrapiTopicDto(1, "doc1", "Topic A", "topic-a", "topic-a", "", "easy", 10, true, 1),
+                new StrapiTopicDto(2, "doc2", "Topic B", "topic-b", "topic-b", "", "medium", 5, true, 2)));
+        when(strapiContentCache.getQuestionCountByTopic("topic-a", LOCALE)).thenReturn(10);
+        when(strapiContentCache.getQuestionCountByTopic("topic-b", LOCALE)).thenReturn(5);
+
+        QuestionProgressRepository.TopicMasteryProjection projA = mock(QuestionProgressRepository.TopicMasteryProjection.class);
+        when(projA.getTopicCode()).thenReturn("topic-a");
+        when(projA.getAttemptedCount()).thenReturn(5L);
+        when(projA.getCorrectCount()).thenReturn(4L);
+        when(projA.getTotalAttempts()).thenReturn(5L);
+        when(projA.getMasteredCount()).thenReturn(2L);
+        when(questionProgressRepository.aggregateByTopic(USER_ID, PRODUCT, DOMAIN)).thenReturn(List.of(projA));
+
+        ResponseEntity<ApiResponse<List<TopicWithProgressDto>>> response =
+                controller.listTopics("NL", "cbr", PRODUCT, DOMAIN, TENANT_ID, USER_ID, LOCALE);
+
+        List<TopicWithProgressDto> topics = response.getBody().getData();
+        assertEquals(2, topics.size());
+
+        // Topic A has progress
+        TopicWithProgressDto.TopicProgressOverlay progressA = topics.get(0).progress();
+        assertEquals(50.0, progressA.coveragePercent(), 0.01);  // 5/10 * 100
+        assertEquals(80.0, progressA.accuracyPercent(), 0.01);  // 4/5 * 100
+        assertEquals(2, progressA.masteredCount());
+
+        // Topic B has no progress (not in aggregation results)
+        TopicWithProgressDto.TopicProgressOverlay progressB = topics.get(1).progress();
+        assertEquals(0.0, progressB.coveragePercent());
+        assertEquals(0.0, progressB.accuracyPercent());
+        assertEquals(0, progressB.masteredCount());
+    }
+}

--- a/src/test/resources/karate/content-hierarchy.feature
+++ b/src/test/resources/karate/content-hierarchy.feature
@@ -62,13 +62,15 @@ Feature: Content Hierarchy Browsing
     * def lockedDomains = karate.filter(response.data, function(d){ return d.isLocked == true })
     And match lockedDomains == '#[5]'
 
-  Scenario: List topics for a domain
+  Scenario: List topics for a domain with progress overlay
     Given path '/api/content/NL/cbr/auto-b/domains/verkeersborden/topics'
     And headers paidHeaders
     When method GET
     Then status 200
     And match response.data == '#[2]'
-    And match each response.data contains { code: '#string', name: '#string' }
+    And match each response.data contains { code: '#string', name: '#string', questionCount: '#number' }
+    And match each response.data contains { progress: '#notnull' }
+    And match each response.data.progress contains { coveragePercent: '#number', accuracyPercent: '#number', masteredCount: '#number' }
 
   Scenario: List road signs for Netherlands
     Given path '/api/content/NL/cbr/auto-b/road-signs'


### PR DESCRIPTION
Closes #29
Closes #31

## Changes
- **Domain progress (#29):** Aggregate domain stats on-the-fly from `question_progress` via `aggregateByDomain()` query instead of reading the never-populated `domain_progress` table
- **Topic progress (#31):** Add `TopicMasteryProjection` + `aggregateByTopic()` query, inject auth headers into `listTopics()` endpoint, compute coverage/accuracy/mastered per topic
- **OpenAPI spec:** Remove `nullable: true` from topic progress overlay (now always present)
- **Karate test:** Updated `listTopics` scenario to verify progress overlay is non-null with correct shape

## Test plan
- [ ] `./gradlew test` — all 98 unit tests pass
- [ ] `GET /api/content/NL/cbr/auto-b/domains/verkeersborden/topics?locale=en` with auth headers returns non-null progress per topic
- [ ] Topics with no practice return `(0.0, 0.0, 0)` instead of `null`
- [ ] Practice some questions, then re-fetch topics — verify progress values update