### PR TITLE
fix(content): readiness accuracy formula and minimum session questions

### DIFF
--- a/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
+++ b/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
@@ -260,6 +260,17 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
     int countCorrect(@Param("userId") UUID keycloakUserId, @Param("productCode") String productCode);
 
     /**
+     * Sums total answer attempts by a user for a product (across all questions).
+     *
+     * @param keycloakUserId the user's Keycloak ID
+     * @param productCode    the product code
+     * @return sum of all attempts
+     */
+    @Query("SELECT COALESCE(SUM(qp.totalAttempts), 0) FROM QuestionProgress qp WHERE qp.keycloakUserId = :userId " +
+           "AND qp.productCode = :productCode")
+    int countTotalAttempts(@Param("userId") UUID keycloakUserId, @Param("productCode") String productCode);
+
+    /**
      * Counts questions at each mastery level.
      *
      * @param keycloakUserId the user's Keycloak ID

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -122,6 +122,16 @@ public class PracticeSessionService {
         SessionType sessionType = SessionType.valueOf(request.sessionType());
         String locale = request.locale() != null ? request.locale() : "nl";
 
+        // Check minimum question pool before selection — domains with < 5 questions
+        // produce broken navigator grids in Flutter
+        int availableCount = (request.domainCode() != null && !request.domainCode().isBlank())
+                ? strapiContentCache.getQuestionCountByDomain(request.domainCode(), locale)
+                : strapiContentCache.getQuestionCount(request.productCode(), locale);
+        if (availableCount < 5) {
+            throw new AppException(HttpStatus.BAD_REQUEST, ErrorCode.VALIDATION_ERROR,
+                    "Not enough questions available for this domain. At least 5 required.");
+        }
+
         // Select questions using spaced repetition
         List<String> questionIds = questionSelectionService.selectQuestions(
                 userId, request.productCode(), request.domainCode(),

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -123,7 +123,9 @@ public class PracticeSessionService {
         String locale = request.locale() != null ? request.locale() : "nl";
 
         // Check minimum question pool before selection — domains with < 5 questions
-        // produce broken navigator grids in Flutter
+        // produce broken navigator grids in Flutter.
+        // Note: checks domain-level count only. If topic-level filtering is added to
+        // QuestionSelectionService in the future, this check needs updating.
         int availableCount = (request.domainCode() != null && !request.domainCode().isBlank())
                 ? strapiContentCache.getQuestionCountByDomain(request.domainCode(), locale)
                 : strapiContentCache.getQuestionCount(request.productCode(), locale);

--- a/src/main/java/com/passtheo/content/service/ReadinessService.java
+++ b/src/main/java/com/passtheo/content/service/ReadinessService.java
@@ -85,17 +85,18 @@ public class ReadinessService {
     public ReadinessScore calculate(@Nonnull UUID userId, @Nonnull String productCode,
                                     @Nonnull String locale) {
         int totalQuestions = strapiContentCache.getQuestionCount(productCode, locale);
-        int attempted = progressRepository.countAttempted(userId, productCode);
-        int correct = progressRepository.countCorrect(userId, productCode);
+        int questionsAttempted = progressRepository.countAttempted(userId, productCode);
+        int totalCorrect = progressRepository.countCorrect(userId, productCode);
+        int totalAttempts = progressRepository.countTotalAttempts(userId, productCode);
         Integer bestExamScore = examAttemptRepository.findBestScore(userId, productCode);
 
         StrapiExamConfigDto examConfig = strapiContentCache.getExamConfig(productCode);
         int passScore = examConfig != null ? examConfig.passScore() : 44;
 
         double coverage = totalQuestions > 0
-                ? (double) attempted / totalQuestions * 100.0 : 0.0;
-        double accuracy = attempted > 0
-                ? (double) correct / attempted * 100.0 : 0.0;
+                ? (double) questionsAttempted / totalQuestions * 100.0 : 0.0;
+        double accuracy = totalAttempts > 0
+                ? (double) totalCorrect / totalAttempts * 100.0 : 0.0;
         double exam = 0.0;
         if (bestExamScore != null && passScore > 0) {
             exam = Math.min(100.0, (double) bestExamScore / passScore * 100.0);
@@ -161,7 +162,7 @@ public class ReadinessService {
 
         return new ReadinessScore(
                 readiness, coverage, accuracy, exam, label,
-                attempted, totalQuestions, bestExamScore, passScore,
+                questionsAttempted, totalQuestions, bestExamScore, passScore,
                 domainStrengths, examCountdownDays, predictedReadyDate
         );
     }

--- a/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
@@ -203,6 +203,27 @@ class ReadinessServiceTest {
         assertThat(dsv.strength()).isEqualTo(DomainStrength.STRONG.name());
     }
 
+    @Test
+    void calculate_accuracyNeverExceeds100_whenQuestionsAnsweredMultipleTimes() {
+        // 10 questions attempted, each answered ~3 times (30 total), 20 total correct.
+        // Old bug: accuracy = 20/10 = 200%.  Fixed: accuracy = 20/30 ≈ 66.7%.
+        when(strapiContentCache.getQuestionCount(eq(PRODUCT_CODE), eq(LOCALE))).thenReturn(500);
+        when(progressRepository.countAttempted(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(10);
+        when(progressRepository.countCorrect(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(20);
+        when(progressRepository.countTotalAttempts(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(30);
+        when(examAttemptRepository.findBestScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
+        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE)))
+                .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, 44, null, null, true, false, null, null, false));
+        when(progressRepository.aggregateByDomain(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(List.of());
+        when(strapiContentCache.getDomains(eq(PRODUCT_CODE), eq(LOCALE))).thenReturn(List.of());
+
+        ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
+
+        assertThat(result.accuracyScore()).isCloseTo(66.67, within(0.1));
+        assertThat(result.accuracyScore()).isLessThanOrEqualTo(100.0);
+        assertThat(result.readinessScore()).isLessThanOrEqualTo(100.0);
+    }
+
     // ─── DOMAIN STRENGTH CLASSIFICATION ───
 
     @Test

--- a/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
@@ -188,6 +188,7 @@ class ReadinessServiceTest {
         when(strapiContentCache.getQuestionCount(eq(PRODUCT_CODE), eq(LOCALE))).thenReturn(30);
         when(progressRepository.countAttempted(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(25);
         when(progressRepository.countCorrect(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(22);
+        when(progressRepository.countTotalAttempts(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(30);
         when(examAttemptRepository.findBestScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
         when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE)))
                 .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, 44, null, null, true, false, null, null, false));
@@ -236,6 +237,7 @@ class ReadinessServiceTest {
         when(strapiContentCache.getQuestionCount(eq(PRODUCT_CODE), eq(LOCALE))).thenReturn(totalQuestions);
         when(progressRepository.countAttempted(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(attempted);
         when(progressRepository.countCorrect(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(correct);
+        when(progressRepository.countTotalAttempts(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(attempted);
         when(examAttemptRepository.findBestScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(bestExam);
         when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE)))
                 .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, passScore, null, null, true, false, null, null, false));

--- a/src/test/resources/karate/practice-sessions.feature
+++ b/src/test/resources/karate/practice-sessions.feature
@@ -46,9 +46,10 @@ Feature: Practice Sessions
     And match response.data.status == 'IN_PROGRESS'
 
   Scenario: Domain with fewer than 5 questions returns 400
+    # Uses a non-existent domain code — Strapi cache returns 0 questions, which is < 5
     Given path '/api/practice/sessions'
     And headers paidHeaders
-    And request { productCode: 'auto-b', domainCode: 'tiny-domain', sessionType: 'PRACTICE', questionCount: 10, locale: 'nl' }
+    And request { productCode: 'auto-b', domainCode: 'nonexistent-empty-domain', sessionType: 'PRACTICE', questionCount: 10, locale: 'nl' }
     When method POST
     Then status 400
     And match response.detail contains 'At least 5 required'

--- a/src/test/resources/karate/practice-sessions.feature
+++ b/src/test/resources/karate/practice-sessions.feature
@@ -45,6 +45,14 @@ Feature: Practice Sessions
     Then status 200
     And match response.data.status == 'IN_PROGRESS'
 
+  Scenario: Domain with fewer than 5 questions returns 400
+    Given path '/api/practice/sessions'
+    And headers paidHeaders
+    And request { productCode: 'auto-b', domainCode: 'tiny-domain', sessionType: 'PRACTICE', questionCount: 10, locale: 'nl' }
+    When method POST
+    Then status 400
+    And match response.detail contains 'At least 5 required'
+
   Scenario: Free user blocked from locked domain
     Given path '/api/practice/sessions'
     And headers freeHeaders

--- a/src/test/resources/karate/readiness-with-exam.feature
+++ b/src/test/resources/karate/readiness-with-exam.feature
@@ -13,6 +13,7 @@ Feature: Readiness score includes exam countdown and predicted ready date
     Then status 200
     And match response.success == true
     And match response.data.readinessScore == '#number'
+    And assert response.data.readinessScore >= 0 && response.data.readinessScore <= 100
     And match response.data.readinessLabel == '#string'
     And match response.data.examCountdownDays == '##number'
     And match response.data.predictedReadyDate == '##string'


### PR DESCRIPTION
Closes #33

## Changes
- **Readiness accuracy fix:** Added `countTotalAttempts()` repository method returning `SUM(totalAttempts)`. Changed `ReadinessService.calculate()` to use `totalCorrect / totalAttempts` (same formula as domain accuracy) instead of `totalCorrect / distinctQuestionsAttempted` which could exceed 100%.
- **Minimum session questions:** Added pre-check in `PracticeSessionService.startSession()` that queries total available questions from Strapi cache. Returns 400 if domain/product has fewer than 5 questions, before question selection runs.
- **Karate tests:** Added scenario for `< 5 questions` 400 response. Added `readinessScore <= 100` assertion on readiness endpoint.

## Test plan
- [ ] `./gradlew test` — all unit tests pass
- [ ] Karate `practice-sessions.feature` — "Domain with fewer than 5 questions returns 400" scenario
- [ ] Karate `readiness-with-exam.feature` — readiness score bounded 0-100
- [ ] Manual: answer same question 10+ times, verify readiness accuracy stays ≤ 100%

## Files changed
| File | Change |
|---|---|
| `QuestionProgressRepository.java` | Added `countTotalAttempts()` — `SUM(totalAttempts)` |
| `ReadinessService.java` | Accuracy: `totalCorrect / totalAttempts` |
| `PracticeSessionService.java` | Pre-check: domain must have ≥ 5 questions |
| `ReadinessServiceTest.java` | Mock `countTotalAttempts` |
| `practice-sessions.feature` | Scenario: domain with < 5 questions |
| `readiness-with-exam.feature` | Assert score ≤ 100 |