### PR TITLE
feat(content): add lastPracticed to topic progress response

### DIFF
--- a/src/main/java/com/passtheo/content/controller/ContentController.java
+++ b/src/main/java/com/passtheo/content/controller/ContentController.java
@@ -228,9 +228,10 @@ public class ContentController {
                     double accuracy = agg != null && agg.getTotalAttempts() > 0
                             ? (double) agg.getCorrectCount() / agg.getTotalAttempts() * 100.0 : 0.0;
                     int mastered = agg != null ? (int) agg.getMasteredCount() : 0;
+                    java.time.Instant lastPracticed = agg != null ? agg.getLastPracticed() : null;
 
                     var progress = new TopicWithProgressDto.TopicProgressOverlay(
-                            coverage, accuracy, mastered);
+                            coverage, accuracy, mastered, lastPracticed);
 
                     return new TopicWithProgressDto(t.code(), t.name(), t.difficulty(), questionCount, progress);
                 })

--- a/src/main/java/com/passtheo/content/dto/response/TopicWithProgressDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/TopicWithProgressDto.java
@@ -1,5 +1,7 @@
 package com.passtheo.content.dto.response;
 
+import java.time.Instant;
+
 /**
  * Topic with user progress overlay.
  */
@@ -12,10 +14,16 @@ public record TopicWithProgressDto(
 ) {
     /**
      * Progress overlay for a topic.
+     *
+     * @param coveragePercent  percentage of questions attempted (0-100)
+     * @param accuracyPercent  percentage of correct answers (0-100)
+     * @param masteredCount    number of questions at MASTERED level
+     * @param lastPracticed    most recent answer timestamp, or null if never practiced
      */
     public record TopicProgressOverlay(
         double coveragePercent,
         double accuracyPercent,
-        int masteredCount
+        int masteredCount,
+        Instant lastPracticed
     ) {}
 }

--- a/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
+++ b/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
@@ -127,6 +127,13 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
          * @return mastered question count
          */
         long getMasteredCount();
+
+        /**
+         * Returns the most recent updatedAt timestamp across all questions in this topic.
+         *
+         * @return last practiced timestamp, or null if no progress exists
+         */
+        java.time.Instant getLastPracticed();
     }
 
     /**
@@ -141,7 +148,8 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
            "COUNT(qp) AS attemptedCount, " +
            "SUM(qp.totalCorrect) AS correctCount, " +
            "SUM(qp.totalAttempts) AS totalAttempts, " +
-           "SUM(CASE WHEN qp.masteryLevel = 'MASTERED' THEN 1 ELSE 0 END) AS masteredCount " +
+           "SUM(CASE WHEN qp.masteryLevel = 'MASTERED' THEN 1 ELSE 0 END) AS masteredCount, " +
+           "MAX(qp.updatedAt) AS lastPracticed " +
            "FROM QuestionProgress qp WHERE qp.keycloakUserId = :userId " +
            "AND qp.productCode = :productCode AND qp.domainCode = :domainCode " +
            "AND qp.topicCode <> '' " +

--- a/src/test/java/com/passtheo/content/unit/ContentControllerListTopicsTest.java
+++ b/src/test/java/com/passtheo/content/unit/ContentControllerListTopicsTest.java
@@ -15,11 +15,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,6 +65,7 @@ class ContentControllerListTopicsTest {
         assertEquals(0.0, progress.coveragePercent());
         assertEquals(0.0, progress.accuracyPercent());
         assertEquals(0, progress.masteredCount());
+        assertNull(progress.lastPracticed());
     }
 
     @Test
@@ -77,6 +80,8 @@ class ContentControllerListTopicsTest {
         when(projection.getCorrectCount()).thenReturn(7L);
         when(projection.getTotalAttempts()).thenReturn(14L);
         when(projection.getMasteredCount()).thenReturn(3L);
+        Instant lastPracticed = Instant.parse("2026-04-03T10:30:00Z");
+        when(projection.getLastPracticed()).thenReturn(lastPracticed);
         when(questionProgressRepository.aggregateByTopic(USER_ID, PRODUCT, DOMAIN)).thenReturn(List.of(projection));
 
         ResponseEntity<ApiResponse<List<TopicWithProgressDto>>> response =
@@ -86,6 +91,7 @@ class ContentControllerListTopicsTest {
         assertEquals(50.0, progress.coveragePercent(), 0.01);  // 10/20 * 100
         assertEquals(50.0, progress.accuracyPercent(), 0.01);  // 7/14 * 100
         assertEquals(3, progress.masteredCount());
+        assertEquals(lastPracticed, progress.lastPracticed());
     }
 
     @Test


### PR DESCRIPTION
Closes #37

## Changes
- Added `MAX(qp.updatedAt) AS lastPracticed` to `aggregateByTopic` JPQL query
- Added `getLastPracticed()` to `TopicMasteryProjection` interface
- Added `Instant lastPracticed` to `TopicProgressOverlay` DTO record
- Mapped lastPracticed in `ContentController.listTopics()`
- Updated unit tests with lastPracticed assertions

## Test plan
- [ ] `./gradlew test` passes
- [ ] API response now includes `lastPracticed` field in topic progress overlay
- [ ] `lastPracticed` is null when no progress exists, ISO-8601 timestamp otherwise

## Cross-service
- Related: passtheo/passtheo-ui#24 — Flutter model fix to consume this new field