### PR TITLE
feat(content): add exam confidence calculation to readiness endpoint

### DIFF
--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -1739,6 +1739,34 @@ components:
               accuracyPercent: { type: number }
               coveragePercent: { type: number }
               strength: { type: string, enum: [UNKNOWN, WEAK, MODERATE, STRONG, MASTERED] }
+        examConfidence:
+          type: integer
+          description: Composite exam confidence score (0-95)
+          minimum: 0
+          maximum: 95
+        examConfidenceLabel:
+          type: string
+          description: Human-readable confidence label
+          enum: [NOT_STARTED, NOT_READY, GETTING_THERE, ALMOST_READY, READY]
+        recommendation:
+          type: string
+          description: Actionable recommendation based on confidence level
+        confidenceBreakdown:
+          $ref: '#/components/schemas/ConfidenceBreakdownDto'
+
+    ConfidenceBreakdownDto:
+      type: object
+      description: Per-criterion point breakdown for exam confidence
+      properties:
+        coveragePoints: { type: integer, description: "Points for coverage (max 20)" }
+        accuracyPoints: { type: integer, description: "Points for accuracy (max 25)" }
+        examConsistencyPoints: { type: integer, description: "Points for mock exam consistency (max 30)" }
+        avgScorePoints: { type: integer, description: "Points for average exam score (max 15)" }
+        noWeakDomainsPoints: { type: integer, description: "Points for no weak domains (max 10)" }
+        coverageMet: { type: boolean, description: "Whether coverage threshold is met" }
+        accuracyMet: { type: boolean, description: "Whether accuracy threshold is met" }
+        consecutivePasses: { type: integer, description: "Number of consecutive recent exam passes" }
+        weakDomains: { type: integer, description: "Number of domains classified as WEAK" }
 
     ReadinessSnapshotDto:
       type: object

--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -1406,6 +1406,7 @@ components:
         description: { type: string }
         icon: { type: string }
         regulatoryBody: { type: string }
+        websiteUrl: { type: string, nullable: true }
         products:
           type: array
           items: { $ref: '#/components/schemas/CatalogProductDto' }
@@ -1746,11 +1747,12 @@ components:
           maximum: 95
         examConfidenceLabel:
           type: string
-          description: Human-readable confidence label
-          enum: [NOT_STARTED, NOT_READY, GETTING_THERE, ALMOST_READY, READY]
+          description: Machine-readable confidence label
+          enum: [NOT_READY, GETTING_THERE, ALMOST_READY, READY]
         recommendation:
           type: string
-          description: Actionable recommendation based on confidence level
+          description: Machine-readable recommendation key (Flutter maps to localized string)
+          enum: [KEEP_PRACTICING, FOCUS_WEAK_DOMAINS, PASS_MORE_EXAMS, BOOK_YOUR_EXAM]
         confidenceBreakdown:
           $ref: '#/components/schemas/ConfidenceBreakdownDto'
 
@@ -1766,7 +1768,10 @@ components:
         coverageMet: { type: boolean, description: "Whether coverage threshold is met" }
         accuracyMet: { type: boolean, description: "Whether accuracy threshold is met" }
         consecutivePasses: { type: integer, description: "Number of consecutive recent exam passes" }
-        weakDomains: { type: integer, description: "Number of domains classified as WEAK" }
+        weakDomainCodes:
+          type: array
+          description: Domain codes classified as WEAK (e.g. "snelheid")
+          items: { type: string }
 
     ReadinessSnapshotDto:
       type: object

--- a/src/main/java/com/passtheo/content/controller/ProgressController.java
+++ b/src/main/java/com/passtheo/content/controller/ProgressController.java
@@ -73,7 +73,7 @@ public class ProgressController {
                                 ds.domainCode(), ds.domainName(),
                                 ds.accuracyPercent(), ds.coveragePercent(), ds.strength()))
                         .toList(),
-                confidence.score(), confidence.label(), confidence.recommendation(),
+                confidence.score(), confidence.label().name(), confidence.recommendation().name(),
                 new ReadinessDto.ConfidenceBreakdownDto(
                         cb.coveragePoints(), cb.accuracyPoints(), cb.examConsistencyPoints(),
                         cb.avgScorePoints(), cb.noWeakDomainsPoints(),

--- a/src/main/java/com/passtheo/content/controller/ProgressController.java
+++ b/src/main/java/com/passtheo/content/controller/ProgressController.java
@@ -1,5 +1,6 @@
 package com.passtheo.content.controller;
 
+import com.passtheo.content.domain.valueobject.ExamConfidence;
 import com.passtheo.content.domain.valueobject.ReadinessScore;
 import com.passtheo.content.dto.response.DomainProgressDto;
 import com.passtheo.content.dto.response.MasteryStatsDto;
@@ -60,6 +61,8 @@ public class ProgressController {
             @RequestParam(defaultValue = "nl") String locale) {
 
         ReadinessScore score = readinessService.calculate(userId, productCode, locale);
+        ExamConfidence confidence = score.examConfidence();
+        ExamConfidence.Breakdown cb = confidence.breakdown();
         ReadinessDto dto = new ReadinessDto(
                 score.readinessScore(), score.coverageScore(), score.accuracyScore(),
                 score.examScore(), score.readinessLabel().name(),
@@ -69,7 +72,12 @@ public class ProgressController {
                         .map(ds -> new ReadinessDto.DomainStrengthDto(
                                 ds.domainCode(), ds.domainName(),
                                 ds.accuracyPercent(), ds.coveragePercent(), ds.strength()))
-                        .toList()
+                        .toList(),
+                confidence.score(), confidence.label(), confidence.recommendation(),
+                new ReadinessDto.ConfidenceBreakdownDto(
+                        cb.coveragePoints(), cb.accuracyPoints(), cb.examConsistencyPoints(),
+                        cb.avgScorePoints(), cb.noWeakDomainsPoints(),
+                        cb.coverageMet(), cb.accuracyMet(), cb.consecutivePasses(), cb.weakDomains())
         );
         return ResponseEntity.ok(ApiResponse.success(dto, MDC.get("traceId")));
     }

--- a/src/main/java/com/passtheo/content/controller/ProgressController.java
+++ b/src/main/java/com/passtheo/content/controller/ProgressController.java
@@ -77,7 +77,7 @@ public class ProgressController {
                 new ReadinessDto.ConfidenceBreakdownDto(
                         cb.coveragePoints(), cb.accuracyPoints(), cb.examConsistencyPoints(),
                         cb.avgScorePoints(), cb.noWeakDomainsPoints(),
-                        cb.coverageMet(), cb.accuracyMet(), cb.consecutivePasses(), cb.weakDomains())
+                        cb.coverageMet(), cb.accuracyMet(), cb.consecutivePasses(), cb.weakDomainCodes())
         );
         return ResponseEntity.ok(ApiResponse.success(dto, MDC.get("traceId")));
     }

--- a/src/main/java/com/passtheo/content/domain/enums/ConfidenceLabel.java
+++ b/src/main/java/com/passtheo/content/domain/enums/ConfidenceLabel.java
@@ -1,0 +1,20 @@
+package com.passtheo.content.domain.enums;
+
+/**
+ * Confidence label derived from exam confidence score (0-95).
+ * Flutter maps {@code name()} to localized strings via ARB keys.
+ */
+public enum ConfidenceLabel {
+
+    /** Score below 30. */
+    NOT_READY,
+
+    /** Score 30-59. */
+    GETTING_THERE,
+
+    /** Score 60-79. */
+    ALMOST_READY,
+
+    /** Score 80+. */
+    READY
+}

--- a/src/main/java/com/passtheo/content/domain/enums/RecommendationKey.java
+++ b/src/main/java/com/passtheo/content/domain/enums/RecommendationKey.java
@@ -1,0 +1,20 @@
+package com.passtheo.content.domain.enums;
+
+/**
+ * Machine-readable recommendation key derived from exam confidence score.
+ * Flutter maps {@code name()} to localized recommendation strings via ARB keys.
+ */
+public enum RecommendationKey {
+
+    /** Score below 40 — user needs more practice. */
+    KEEP_PRACTICING,
+
+    /** Score 40-59 — user should focus on weak domains. */
+    FOCUS_WEAK_DOMAINS,
+
+    /** Score 60-79 — user should pass more mock exams. */
+    PASS_MORE_EXAMS,
+
+    /** Score 80+ — user is ready to book the real exam. */
+    BOOK_YOUR_EXAM
+}

--- a/src/main/java/com/passtheo/content/domain/valueobject/ExamConfidence.java
+++ b/src/main/java/com/passtheo/content/domain/valueobject/ExamConfidence.java
@@ -1,17 +1,22 @@
 package com.passtheo.content.domain.valueobject;
 
+import com.passtheo.content.domain.enums.ConfidenceLabel;
+import com.passtheo.content.domain.enums.RecommendationKey;
+
+import java.util.List;
+
 /**
  * Composite exam confidence score (0-95) computed from 5 criteria.
  *
  * @param score              total confidence score (0-95, capped)
- * @param label              human-readable label (NOT_STARTED, NOT_READY, GETTING_THERE, ALMOST_READY, READY)
- * @param recommendation     actionable recommendation text
+ * @param label              machine-readable label (NOT_READY, GETTING_THERE, ALMOST_READY, READY)
+ * @param recommendation     machine-readable recommendation key
  * @param breakdown          per-criterion point breakdown
  */
 public record ExamConfidence(
     int score,
-    String label,
-    String recommendation,
+    ConfidenceLabel label,
+    RecommendationKey recommendation,
     Breakdown breakdown
 ) {
 
@@ -37,6 +42,6 @@ public record ExamConfidence(
         boolean coverageMet,
         boolean accuracyMet,
         int consecutivePasses,
-        java.util.List<String> weakDomainCodes
+        List<String> weakDomainCodes
     ) { }
 }

--- a/src/main/java/com/passtheo/content/domain/valueobject/ExamConfidence.java
+++ b/src/main/java/com/passtheo/content/domain/valueobject/ExamConfidence.java
@@ -1,0 +1,42 @@
+package com.passtheo.content.domain.valueobject;
+
+/**
+ * Composite exam confidence score (0-95) computed from 5 criteria.
+ *
+ * @param score              total confidence score (0-95, capped)
+ * @param label              human-readable label (NOT_STARTED, NOT_READY, GETTING_THERE, ALMOST_READY, READY)
+ * @param recommendation     actionable recommendation text
+ * @param breakdown          per-criterion point breakdown
+ */
+public record ExamConfidence(
+    int score,
+    String label,
+    String recommendation,
+    Breakdown breakdown
+) {
+
+    /**
+     * Per-criterion point breakdown.
+     *
+     * @param coveragePoints        coverage criterion points (max 20)
+     * @param accuracyPoints        accuracy criterion points (max 25)
+     * @param examConsistencyPoints mock exam consistency points (max 30)
+     * @param avgScorePoints        average exam score points (max 15)
+     * @param noWeakDomainsPoints   no-weak-domains bonus points (max 10)
+     * @param coverageMet           whether the coverage threshold is met
+     * @param accuracyMet           whether the accuracy threshold is met
+     * @param consecutivePasses     number of consecutive recent exam passes
+     * @param weakDomains           number of domains classified as WEAK
+     */
+    public record Breakdown(
+        int coveragePoints,
+        int accuracyPoints,
+        int examConsistencyPoints,
+        int avgScorePoints,
+        int noWeakDomainsPoints,
+        boolean coverageMet,
+        boolean accuracyMet,
+        int consecutivePasses,
+        int weakDomains
+    ) { }
+}

--- a/src/main/java/com/passtheo/content/domain/valueobject/ExamConfidence.java
+++ b/src/main/java/com/passtheo/content/domain/valueobject/ExamConfidence.java
@@ -26,7 +26,7 @@ public record ExamConfidence(
      * @param coverageMet           whether the coverage threshold is met
      * @param accuracyMet           whether the accuracy threshold is met
      * @param consecutivePasses     number of consecutive recent exam passes
-     * @param weakDomains           number of domains classified as WEAK
+     * @param weakDomainCodes       domain codes classified as WEAK (e.g. "snelheid")
      */
     public record Breakdown(
         int coveragePoints,
@@ -37,6 +37,6 @@ public record ExamConfidence(
         boolean coverageMet,
         boolean accuracyMet,
         int consecutivePasses,
-        int weakDomains
+        java.util.List<String> weakDomainCodes
     ) { }
 }

--- a/src/main/java/com/passtheo/content/domain/valueobject/ReadinessScore.java
+++ b/src/main/java/com/passtheo/content/domain/valueobject/ReadinessScore.java
@@ -19,6 +19,7 @@ import java.util.List;
  * @param domainStrengths    per-domain strength breakdown
  * @param examCountdownDays  days until scheduled exam (nullable if no exam date)
  * @param predictedReadyDate predicted date at which readiness reaches 80% (nullable)
+ * @param examConfidence     exam confidence assessment (nullable if not enough data)
  */
 public record ReadinessScore(
     double readinessScore,
@@ -32,7 +33,8 @@ public record ReadinessScore(
     int examPassScore,
     List<DomainStrengthValue> domainStrengths,
     Integer examCountdownDays,
-    java.time.LocalDate predictedReadyDate
+    java.time.LocalDate predictedReadyDate,
+    ExamConfidence examConfidence
 ) {
 
     /**

--- a/src/main/java/com/passtheo/content/domain/valueobject/ReadinessScore.java
+++ b/src/main/java/com/passtheo/content/domain/valueobject/ReadinessScore.java
@@ -1,6 +1,7 @@
 package com.passtheo.content.domain.valueobject;
 
 import com.passtheo.content.domain.enums.ReadinessLabel;
+import jakarta.annotation.Nonnull;
 
 import java.util.List;
 
@@ -19,7 +20,7 @@ import java.util.List;
  * @param domainStrengths    per-domain strength breakdown
  * @param examCountdownDays  days until scheduled exam (nullable if no exam date)
  * @param predictedReadyDate predicted date at which readiness reaches 80% (nullable)
- * @param examConfidence     exam confidence assessment (nullable if not enough data)
+ * @param examConfidence     exam confidence assessment (always computed, never null)
  */
 public record ReadinessScore(
     double readinessScore,
@@ -34,7 +35,7 @@ public record ReadinessScore(
     List<DomainStrengthValue> domainStrengths,
     Integer examCountdownDays,
     java.time.LocalDate predictedReadyDate,
-    ExamConfidence examConfidence
+    @Nonnull ExamConfidence examConfidence
 ) {
 
     /**

--- a/src/main/java/com/passtheo/content/dto/response/OnboardingCatalogDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/OnboardingCatalogDto.java
@@ -32,6 +32,7 @@ public record OnboardingCatalogDto(
         String description,
         String icon,
         String regulatoryBody,
+        String websiteUrl,
         List<CatalogProductDto> products
     ) {}
 

--- a/src/main/java/com/passtheo/content/dto/response/ReadinessDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/ReadinessDto.java
@@ -44,6 +44,6 @@ public record ReadinessDto(
         boolean coverageMet,
         boolean accuracyMet,
         int consecutivePasses,
-        int weakDomains
+        List<String> weakDomainCodes
     ) {}
 }

--- a/src/main/java/com/passtheo/content/dto/response/ReadinessDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/ReadinessDto.java
@@ -15,7 +15,11 @@ public record ReadinessDto(
     int totalQuestions,
     Integer bestExamScore,
     int examPassScore,
-    List<DomainStrengthDto> domainStrengths
+    List<DomainStrengthDto> domainStrengths,
+    int examConfidence,
+    String examConfidenceLabel,
+    String recommendation,
+    ConfidenceBreakdownDto confidenceBreakdown
 ) {
     /**
      * Per-domain strength breakdown.
@@ -26,5 +30,20 @@ public record ReadinessDto(
         double accuracyPercent,
         double coveragePercent,
         String strength
+    ) {}
+
+    /**
+     * Per-criterion point breakdown for exam confidence.
+     */
+    public record ConfidenceBreakdownDto(
+        int coveragePoints,
+        int accuracyPoints,
+        int examConsistencyPoints,
+        int avgScorePoints,
+        int noWeakDomainsPoints,
+        boolean coverageMet,
+        boolean accuracyMet,
+        int consecutivePasses,
+        int weakDomains
     ) {}
 }

--- a/src/main/java/com/passtheo/content/repository/ExamAttemptRepository.java
+++ b/src/main/java/com/passtheo/content/repository/ExamAttemptRepository.java
@@ -86,6 +86,17 @@ public interface ExamAttemptRepository extends JpaRepository<ExamAttempt, UUID> 
     Optional<ExamAttempt> findByIdAndKeycloakUserId(@Nonnull UUID id, @Nonnull UUID keycloakUserId);
 
     /**
+     * Computes the average correctCount across all exam attempts for a user/product.
+     *
+     * @param keycloakUserId the user's Keycloak ID
+     * @param productCode    the product code
+     * @return average correct count, or null if no exams taken
+     */
+    @Query("SELECT AVG(ea.correctCount) FROM ExamAttempt ea WHERE ea.keycloakUserId = :userId " +
+           "AND ea.productCode = :productCode")
+    Double findAverageScore(@Param("userId") UUID keycloakUserId, @Param("productCode") String productCode);
+
+    /**
      * Deletes all exams for a user (GDPR).
      *
      * @param keycloakUserId the user's Keycloak ID

--- a/src/main/java/com/passtheo/content/repository/ExamAttemptRepository.java
+++ b/src/main/java/com/passtheo/content/repository/ExamAttemptRepository.java
@@ -38,7 +38,7 @@ public interface ExamAttemptRepository extends JpaRepository<ExamAttempt, UUID> 
      * @return the best correct count, or null if no exams taken
      */
     @Query("SELECT MAX(ea.correctCount) FROM ExamAttempt ea WHERE ea.keycloakUserId = :userId " +
-           "AND ea.productCode = :productCode")
+           "AND ea.productCode = :productCode AND ea.deletedAt IS NULL")
     Integer findBestScore(@Param("userId") UUID keycloakUserId, @Param("productCode") String productCode);
 
     /**
@@ -59,7 +59,7 @@ public interface ExamAttemptRepository extends JpaRepository<ExamAttempt, UUID> 
      * @return count of perfect exams
      */
     @Query("SELECT COUNT(ea) FROM ExamAttempt ea WHERE ea.keycloakUserId = :userId " +
-           "AND ea.productCode = :productCode AND ea.correctCount = ea.totalQuestions")
+           "AND ea.productCode = :productCode AND ea.correctCount = ea.totalQuestions AND ea.deletedAt IS NULL")
     long countPerfect(@Param("userId") UUID keycloakUserId, @Param("productCode") String productCode);
 
     /**
@@ -71,7 +71,7 @@ public interface ExamAttemptRepository extends JpaRepository<ExamAttempt, UUID> 
      * @return count of recent exams
      */
     @Query("SELECT COUNT(ea) FROM ExamAttempt ea WHERE ea.keycloakUserId = :userId " +
-           "AND ea.productCode = :productCode AND ea.completedAt > :cutoff")
+           "AND ea.productCode = :productCode AND ea.completedAt > :cutoff AND ea.deletedAt IS NULL")
     long countRecentExams(@Param("userId") UUID keycloakUserId,
                           @Param("productCode") String productCode,
                           @Param("cutoff") Instant cutoff);
@@ -93,7 +93,7 @@ public interface ExamAttemptRepository extends JpaRepository<ExamAttempt, UUID> 
      * @return average correct count, or null if no exams taken
      */
     @Query("SELECT AVG(ea.correctCount) FROM ExamAttempt ea WHERE ea.keycloakUserId = :userId " +
-           "AND ea.productCode = :productCode")
+           "AND ea.productCode = :productCode AND ea.deletedAt IS NULL")
     Double findAverageScore(@Param("userId") UUID keycloakUserId, @Param("productCode") String productCode);
 
     /**

--- a/src/main/java/com/passtheo/content/service/OnboardingCatalogService.java
+++ b/src/main/java/com/passtheo/content/service/OnboardingCatalogService.java
@@ -99,6 +99,7 @@ public class OnboardingCatalogService {
                 productType.description(),
                 productType.icon(),
                 productType.regulatoryBody(),
+                productType.websiteUrl(),
                 catalogProducts);
     }
 

--- a/src/main/java/com/passtheo/content/service/ReadinessService.java
+++ b/src/main/java/com/passtheo/content/service/ReadinessService.java
@@ -262,23 +262,23 @@ public class ReadinessService {
         }
 
         // Criterion 5: No weak domains (max 10)
-        int weakDomains = (int) domainStrengths.stream()
+        List<String> weakDomainCodes = domainStrengths.stream()
                 .filter(ds -> DomainStrength.WEAK.name().equals(ds.strength()))
-                .count();
-        int noWeakDomainsPoints = weakDomains == 0 ? NO_WEAK_DOMAINS_MAX_POINTS : 0;
+                .map(ReadinessScore.DomainStrengthValue::domainCode)
+                .toList();
+        int noWeakDomainsPoints = weakDomainCodes.isEmpty() ? NO_WEAK_DOMAINS_MAX_POINTS : 0;
 
         int rawTotal = coveragePoints + accuracyPoints + examConsistencyPoints
                 + avgScorePoints + noWeakDomainsPoints;
         int score = Math.min(rawTotal, CONFIDENCE_CAP);
 
-        String label = classifyConfidenceLabel(score, coverage);
-        String recommendation = generateRecommendation(label, coverageMet, accuracyMet,
-                consecutivePasses, weakDomains);
+        String label = classifyConfidenceLabel(score);
+        String recommendation = generateRecommendationKey(score);
 
         ExamConfidence.Breakdown breakdown = new ExamConfidence.Breakdown(
                 coveragePoints, accuracyPoints, examConsistencyPoints,
                 avgScorePoints, noWeakDomainsPoints,
-                coverageMet, accuracyMet, consecutivePasses, weakDomains);
+                coverageMet, accuracyMet, consecutivePasses, weakDomainCodes);
 
         return new ExamConfidence(score, label, recommendation, breakdown);
     }
@@ -309,16 +309,12 @@ public class ReadinessService {
     }
 
     /**
-     * Classifies the confidence score into a label.
+     * Classifies the confidence score into a machine-readable label.
      *
-     * @param score    the confidence score (0-95)
-     * @param coverage coverage percentage
-     * @return the confidence label
+     * @param score the confidence score (0-95)
+     * @return the confidence label enum key
      */
-    public static String classifyConfidenceLabel(int score, double coverage) {
-        if (coverage == 0.0) {
-            return "NOT_STARTED";
-        }
+    public static String classifyConfidenceLabel(int score) {
         if (score < 30) {
             return "NOT_READY";
         }
@@ -332,47 +328,23 @@ public class ReadinessService {
     }
 
     /**
-     * Generates an actionable recommendation based on the confidence label and breakdown.
+     * Returns a machine-readable recommendation key based on confidence score.
+     * Flutter maps these keys to localized strings via ARB files.
      *
-     * @param label             the confidence label
-     * @param coverageMet       whether coverage threshold is met
-     * @param accuracyMet       whether accuracy threshold is met
-     * @param consecutivePasses number of consecutive exam passes
-     * @param weakDomains       number of weak domains
-     * @return a recommendation string
+     * @param score the confidence score (0-95)
+     * @return the recommendation key
      */
-    static String generateRecommendation(String label, boolean coverageMet, boolean accuracyMet,
-                                          int consecutivePasses, int weakDomains) {
-        return switch (label) {
-            case "NOT_STARTED" -> "Start practicing to build your confidence. Try a few questions each day.";
-            case "NOT_READY" -> {
-                if (!coverageMet) {
-                    yield "Focus on covering more topics. You haven't seen enough questions yet.";
-                }
-                if (!accuracyMet) {
-                    yield "Review your incorrect answers and study the explanations carefully.";
-                }
-                yield "Keep practicing daily to build your exam readiness.";
-            }
-            case "GETTING_THERE" -> {
-                if (weakDomains > 0) {
-                    yield "You have " + weakDomains + " weak topic(s). Focus on those before taking more mock exams.";
-                }
-                if (consecutivePasses == 0) {
-                    yield "Try a mock exam to test your knowledge under exam conditions.";
-                }
-                yield "You're making progress! Keep studying and take another mock exam.";
-            }
-            case "ALMOST_READY" -> {
-                if (consecutivePasses < CONSISTENCY_HIGH_CONSECUTIVE) {
-                    yield "Pass " + (CONSISTENCY_HIGH_CONSECUTIVE - consecutivePasses)
-                            + " more mock exam(s) in a row to prove consistency.";
-                }
-                yield "You're close! One more strong mock exam should do it.";
-            }
-            case "READY" -> "You're well prepared. Book your exam when you're ready!";
-            default -> "Keep practicing to improve your confidence.";
-        };
+    public static String generateRecommendationKey(int score) {
+        if (score < 40) {
+            return "KEEP_PRACTICING";
+        }
+        if (score < 60) {
+            return "FOCUS_WEAK_DOMAINS";
+        }
+        if (score < 80) {
+            return "PASS_MORE_EXAMS";
+        }
+        return "BOOK_YOUR_EXAM";
     }
 
     /**

--- a/src/main/java/com/passtheo/content/service/ReadinessService.java
+++ b/src/main/java/com/passtheo/content/service/ReadinessService.java
@@ -1,6 +1,7 @@
 package com.passtheo.content.service;
 
 import com.passtheo.shared.core.client.UserServiceInternalClient;
+import com.passtheo.content.domain.entity.ExamAttempt;
 import com.passtheo.content.domain.enums.DomainStrength;
 import com.passtheo.content.domain.enums.ReadinessLabel;
 import com.passtheo.content.domain.valueobject.ReadinessScore;
@@ -15,6 +16,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.passtheo.content.domain.valueobject.ExamConfidence;
+import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -49,6 +53,21 @@ public class ReadinessService {
 
     private static final double READY_THRESHOLD = 80.0;
     private static final double DAILY_PROGRESS_ESTIMATE = 0.5;
+
+    // Exam confidence criteria thresholds
+    private static final int CONFIDENCE_CAP = 95;
+    private static final int COVERAGE_MAX_POINTS = 20;
+    private static final int ACCURACY_MAX_POINTS = 25;
+    private static final int EXAM_CONSISTENCY_MAX_POINTS = 30;
+    private static final int AVG_SCORE_MAX_POINTS = 15;
+    private static final int NO_WEAK_DOMAINS_MAX_POINTS = 10;
+    private static final double COVERAGE_HIGH_THRESHOLD = 90.0;
+    private static final double COVERAGE_MID_THRESHOLD = 70.0;
+    private static final double ACCURACY_HIGH_THRESHOLD = 88.0;
+    private static final double ACCURACY_MID_THRESHOLD = 80.0;
+    private static final int CONSISTENCY_HIGH_CONSECUTIVE = 3;
+    private static final double AVG_SCORE_HIGH_THRESHOLD = 46.0;
+    private static final double AVG_SCORE_MID_THRESHOLD = 44.0;
 
     private final QuestionProgressRepository progressRepository;
     private final ExamAttemptRepository examAttemptRepository;
@@ -160,11 +179,200 @@ public class ReadinessService {
             predictedReadyDate = today;
         }
 
+        ExamConfidence examConfidence = calculateExamConfidence(
+                userId, productCode, coverage, accuracy, passScore, domainStrengths);
+
         return new ReadinessScore(
                 readiness, coverage, accuracy, exam, label,
                 questionsAttempted, totalQuestions, bestExamScore, passScore,
-                domainStrengths, examCountdownDays, predictedReadyDate
+                domainStrengths, examCountdownDays, predictedReadyDate, examConfidence
         );
+    }
+
+    /**
+     * Calculates the composite exam confidence score (0-95) from 5 weighted criteria.
+     *
+     * <ul>
+     *   <li>Coverage (max 20): &ge;90% &rarr; 20, 70-89% &rarr; 10, &lt;70% &rarr; 0</li>
+     *   <li>Accuracy (max 25): &ge;88% &rarr; 25, 80-87% &rarr; 15, &lt;80% &rarr; 0</li>
+     *   <li>Mock consistency (max 30): 3+ consecutive passes &rarr; 30, 1-2 &rarr; 15, 0 &rarr; 0</li>
+     *   <li>Average score (max 15): avg &ge;46 &rarr; 15, avg &ge;44 &rarr; 10, &lt;44 &rarr; 0</li>
+     *   <li>No weak domains (max 10): 0 WEAK &rarr; 10, any WEAK &rarr; 0</li>
+     * </ul>
+     *
+     * @param userId          the user's Keycloak ID
+     * @param productCode     the product code
+     * @param coverage        coverage percentage (0-100)
+     * @param accuracy        accuracy percentage (0-100)
+     * @param passScore       the pass score threshold
+     * @param domainStrengths per-domain strength breakdown
+     * @return the exam confidence assessment
+     */
+    ExamConfidence calculateExamConfidence(UUID userId, String productCode,
+                                           double coverage, double accuracy, int passScore,
+                                           List<ReadinessScore.DomainStrengthValue> domainStrengths) {
+        // Criterion 1: Coverage (max 20)
+        int coveragePoints;
+        boolean coverageMet;
+        if (coverage >= COVERAGE_HIGH_THRESHOLD) {
+            coveragePoints = COVERAGE_MAX_POINTS;
+            coverageMet = true;
+        } else if (coverage >= COVERAGE_MID_THRESHOLD) {
+            coveragePoints = 10;
+            coverageMet = true;
+        } else {
+            coveragePoints = 0;
+            coverageMet = false;
+        }
+
+        // Criterion 2: Accuracy (max 25)
+        int accuracyPoints;
+        boolean accuracyMet;
+        if (accuracy >= ACCURACY_HIGH_THRESHOLD) {
+            accuracyPoints = ACCURACY_MAX_POINTS;
+            accuracyMet = true;
+        } else if (accuracy >= ACCURACY_MID_THRESHOLD) {
+            accuracyPoints = 15;
+            accuracyMet = true;
+        } else {
+            accuracyPoints = 0;
+            accuracyMet = false;
+        }
+
+        // Criterion 3: Mock exam consistency — consecutive passes (max 30)
+        int consecutivePasses = countConsecutivePasses(userId, productCode, passScore);
+        int examConsistencyPoints;
+        if (consecutivePasses >= CONSISTENCY_HIGH_CONSECUTIVE) {
+            examConsistencyPoints = EXAM_CONSISTENCY_MAX_POINTS;
+        } else if (consecutivePasses >= 1) {
+            examConsistencyPoints = 15;
+        } else {
+            examConsistencyPoints = 0;
+        }
+
+        // Criterion 4: Average exam score (max 15)
+        Double avgScore = examAttemptRepository.findAverageScore(userId, productCode);
+        int avgScorePoints;
+        if (avgScore != null && avgScore >= AVG_SCORE_HIGH_THRESHOLD) {
+            avgScorePoints = AVG_SCORE_MAX_POINTS;
+        } else if (avgScore != null && avgScore >= AVG_SCORE_MID_THRESHOLD) {
+            avgScorePoints = 10;
+        } else {
+            avgScorePoints = 0;
+        }
+
+        // Criterion 5: No weak domains (max 10)
+        int weakDomains = (int) domainStrengths.stream()
+                .filter(ds -> DomainStrength.WEAK.name().equals(ds.strength()))
+                .count();
+        int noWeakDomainsPoints = weakDomains == 0 ? NO_WEAK_DOMAINS_MAX_POINTS : 0;
+
+        int rawTotal = coveragePoints + accuracyPoints + examConsistencyPoints
+                + avgScorePoints + noWeakDomainsPoints;
+        int score = Math.min(rawTotal, CONFIDENCE_CAP);
+
+        String label = classifyConfidenceLabel(score, coverage);
+        String recommendation = generateRecommendation(label, coverageMet, accuracyMet,
+                consecutivePasses, weakDomains);
+
+        ExamConfidence.Breakdown breakdown = new ExamConfidence.Breakdown(
+                coveragePoints, accuracyPoints, examConsistencyPoints,
+                avgScorePoints, noWeakDomainsPoints,
+                coverageMet, accuracyMet, consecutivePasses, weakDomains);
+
+        return new ExamConfidence(score, label, recommendation, breakdown);
+    }
+
+    /**
+     * Counts consecutive recent exam passes (scored at or above passScore), from most recent backward.
+     *
+     * @param userId      the user's Keycloak ID
+     * @param productCode the product code
+     * @param passScore   the pass score threshold
+     * @return number of consecutive passes from the most recent attempt
+     */
+    private int countConsecutivePasses(UUID userId, String productCode, int passScore) {
+        List<ExamAttempt> recentExams = examAttemptRepository
+                .findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
+                        userId, productCode, PageRequest.of(0, 20))
+                .getContent();
+
+        int count = 0;
+        for (ExamAttempt exam : recentExams) {
+            if (exam.isPassed() && exam.getCorrectCount() >= passScore) {
+                count++;
+            } else {
+                break;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Classifies the confidence score into a label.
+     *
+     * @param score    the confidence score (0-95)
+     * @param coverage coverage percentage
+     * @return the confidence label
+     */
+    public static String classifyConfidenceLabel(int score, double coverage) {
+        if (coverage == 0.0) {
+            return "NOT_STARTED";
+        }
+        if (score < 30) {
+            return "NOT_READY";
+        }
+        if (score < 60) {
+            return "GETTING_THERE";
+        }
+        if (score < 80) {
+            return "ALMOST_READY";
+        }
+        return "READY";
+    }
+
+    /**
+     * Generates an actionable recommendation based on the confidence label and breakdown.
+     *
+     * @param label             the confidence label
+     * @param coverageMet       whether coverage threshold is met
+     * @param accuracyMet       whether accuracy threshold is met
+     * @param consecutivePasses number of consecutive exam passes
+     * @param weakDomains       number of weak domains
+     * @return a recommendation string
+     */
+    static String generateRecommendation(String label, boolean coverageMet, boolean accuracyMet,
+                                          int consecutivePasses, int weakDomains) {
+        return switch (label) {
+            case "NOT_STARTED" -> "Start practicing to build your confidence. Try a few questions each day.";
+            case "NOT_READY" -> {
+                if (!coverageMet) {
+                    yield "Focus on covering more topics. You haven't seen enough questions yet.";
+                }
+                if (!accuracyMet) {
+                    yield "Review your incorrect answers and study the explanations carefully.";
+                }
+                yield "Keep practicing daily to build your exam readiness.";
+            }
+            case "GETTING_THERE" -> {
+                if (weakDomains > 0) {
+                    yield "You have " + weakDomains + " weak topic(s). Focus on those before taking more mock exams.";
+                }
+                if (consecutivePasses == 0) {
+                    yield "Try a mock exam to test your knowledge under exam conditions.";
+                }
+                yield "You're making progress! Keep studying and take another mock exam.";
+            }
+            case "ALMOST_READY" -> {
+                if (consecutivePasses < CONSISTENCY_HIGH_CONSECUTIVE) {
+                    yield "Pass " + (CONSISTENCY_HIGH_CONSECUTIVE - consecutivePasses)
+                            + " more mock exam(s) in a row to prove consistency.";
+                }
+                yield "You're close! One more strong mock exam should do it.";
+            }
+            case "READY" -> "You're well prepared. Book your exam when you're ready!";
+            default -> "Keep practicing to improve your confidence.";
+        };
     }
 
     /**

--- a/src/main/java/com/passtheo/content/service/ReadinessService.java
+++ b/src/main/java/com/passtheo/content/service/ReadinessService.java
@@ -2,8 +2,11 @@ package com.passtheo.content.service;
 
 import com.passtheo.shared.core.client.UserServiceInternalClient;
 import com.passtheo.content.domain.entity.ExamAttempt;
+import com.passtheo.content.domain.enums.ConfidenceLabel;
 import com.passtheo.content.domain.enums.DomainStrength;
 import com.passtheo.content.domain.enums.ReadinessLabel;
+import com.passtheo.content.domain.enums.RecommendationKey;
+import com.passtheo.content.domain.valueobject.ExamConfidence;
 import com.passtheo.content.domain.valueobject.ReadinessScore;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
@@ -14,11 +17,9 @@ import com.passtheo.shared.core.context.TenantContext;
 import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.passtheo.content.domain.valueobject.ExamConfidence;
-import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -68,6 +69,10 @@ public class ReadinessService {
     private static final int CONSISTENCY_HIGH_CONSECUTIVE = 3;
     private static final double AVG_SCORE_HIGH_THRESHOLD = 46.0;
     private static final double AVG_SCORE_MID_THRESHOLD = 44.0;
+    private static final int COVERAGE_MID_POINTS = 10;
+    private static final int ACCURACY_MID_POINTS = 15;
+    private static final int EXAM_CONSISTENCY_MID_POINTS = 15;
+    private static final int AVG_SCORE_MID_POINTS = 10;
 
     private final QuestionProgressRepository progressRepository;
     private final ExamAttemptRepository examAttemptRepository;
@@ -208,9 +213,9 @@ public class ReadinessService {
      * @param domainStrengths per-domain strength breakdown
      * @return the exam confidence assessment
      */
-    ExamConfidence calculateExamConfidence(UUID userId, String productCode,
-                                           double coverage, double accuracy, int passScore,
-                                           List<ReadinessScore.DomainStrengthValue> domainStrengths) {
+    private ExamConfidence calculateExamConfidence(@Nonnull UUID userId, @Nonnull String productCode,
+                                                   double coverage, double accuracy, int passScore,
+                                                   @Nonnull List<ReadinessScore.DomainStrengthValue> domainStrengths) {
         // Criterion 1: Coverage (max 20)
         int coveragePoints;
         boolean coverageMet;
@@ -218,7 +223,7 @@ public class ReadinessService {
             coveragePoints = COVERAGE_MAX_POINTS;
             coverageMet = true;
         } else if (coverage >= COVERAGE_MID_THRESHOLD) {
-            coveragePoints = 10;
+            coveragePoints = COVERAGE_MID_POINTS;
             coverageMet = true;
         } else {
             coveragePoints = 0;
@@ -232,7 +237,7 @@ public class ReadinessService {
             accuracyPoints = ACCURACY_MAX_POINTS;
             accuracyMet = true;
         } else if (accuracy >= ACCURACY_MID_THRESHOLD) {
-            accuracyPoints = 15;
+            accuracyPoints = ACCURACY_MID_POINTS;
             accuracyMet = true;
         } else {
             accuracyPoints = 0;
@@ -245,7 +250,7 @@ public class ReadinessService {
         if (consecutivePasses >= CONSISTENCY_HIGH_CONSECUTIVE) {
             examConsistencyPoints = EXAM_CONSISTENCY_MAX_POINTS;
         } else if (consecutivePasses >= 1) {
-            examConsistencyPoints = 15;
+            examConsistencyPoints = EXAM_CONSISTENCY_MID_POINTS;
         } else {
             examConsistencyPoints = 0;
         }
@@ -256,7 +261,7 @@ public class ReadinessService {
         if (avgScore != null && avgScore >= AVG_SCORE_HIGH_THRESHOLD) {
             avgScorePoints = AVG_SCORE_MAX_POINTS;
         } else if (avgScore != null && avgScore >= AVG_SCORE_MID_THRESHOLD) {
-            avgScorePoints = 10;
+            avgScorePoints = AVG_SCORE_MID_POINTS;
         } else {
             avgScorePoints = 0;
         }
@@ -272,8 +277,8 @@ public class ReadinessService {
                 + avgScorePoints + noWeakDomainsPoints;
         int score = Math.min(rawTotal, CONFIDENCE_CAP);
 
-        String label = classifyConfidenceLabel(score);
-        String recommendation = generateRecommendationKey(score);
+        ConfidenceLabel label = classifyConfidenceLabel(score);
+        RecommendationKey recommendation = generateRecommendationKey(score);
 
         ExamConfidence.Breakdown breakdown = new ExamConfidence.Breakdown(
                 coveragePoints, accuracyPoints, examConsistencyPoints,
@@ -284,11 +289,14 @@ public class ReadinessService {
     }
 
     /**
-     * Counts consecutive recent exam passes (scored at or above passScore), from most recent backward.
+     * Counts consecutive recent exam passes from most recent backward.
+     * An exam counts as a pass when {@code isPassed()} is true AND the correctCount
+     * meets the passScore threshold. The double-check guards against exams marked passed
+     * with a stale or mismatched passScore (e.g. exam config changed after the attempt).
      *
      * @param userId      the user's Keycloak ID
      * @param productCode the product code
-     * @param passScore   the pass score threshold
+     * @param passScore   the current pass score threshold
      * @return number of consecutive passes from the most recent attempt
      */
     private int countConsecutivePasses(UUID userId, String productCode, int passScore) {
@@ -312,39 +320,39 @@ public class ReadinessService {
      * Classifies the confidence score into a machine-readable label.
      *
      * @param score the confidence score (0-95)
-     * @return the confidence label enum key
+     * @return the confidence label
      */
-    public static String classifyConfidenceLabel(int score) {
+    public static ConfidenceLabel classifyConfidenceLabel(int score) {
         if (score < 30) {
-            return "NOT_READY";
+            return ConfidenceLabel.NOT_READY;
         }
         if (score < 60) {
-            return "GETTING_THERE";
+            return ConfidenceLabel.GETTING_THERE;
         }
         if (score < 80) {
-            return "ALMOST_READY";
+            return ConfidenceLabel.ALMOST_READY;
         }
-        return "READY";
+        return ConfidenceLabel.READY;
     }
 
     /**
      * Returns a machine-readable recommendation key based on confidence score.
-     * Flutter maps these keys to localized strings via ARB files.
+     * Flutter maps {@code name()} to localized strings via ARB files.
      *
      * @param score the confidence score (0-95)
      * @return the recommendation key
      */
-    public static String generateRecommendationKey(int score) {
+    public static RecommendationKey generateRecommendationKey(int score) {
         if (score < 40) {
-            return "KEEP_PRACTICING";
+            return RecommendationKey.KEEP_PRACTICING;
         }
         if (score < 60) {
-            return "FOCUS_WEAK_DOMAINS";
+            return RecommendationKey.FOCUS_WEAK_DOMAINS;
         }
         if (score < 80) {
-            return "PASS_MORE_EXAMS";
+            return RecommendationKey.PASS_MORE_EXAMS;
         }
-        return "BOOK_YOUR_EXAM";
+        return RecommendationKey.BOOK_YOUR_EXAM;
     }
 
     /**

--- a/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
@@ -3,6 +3,7 @@ package com.passtheo.content.unit;
 import com.passtheo.shared.core.client.UserServiceInternalClient;
 import com.passtheo.content.domain.enums.DomainStrength;
 import com.passtheo.content.domain.enums.ReadinessLabel;
+import com.passtheo.content.domain.valueobject.ExamConfidence;
 import com.passtheo.content.domain.valueobject.ReadinessScore;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
@@ -17,6 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -193,6 +196,10 @@ class ReadinessServiceTest {
         when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE)))
                 .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, 44, null, null, true, false, null, null, false));
         when(userServiceClient.getProfile(any(), any())).thenReturn(Optional.empty());
+        when(examAttemptRepository.findAverageScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
+        when(examAttemptRepository.findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
+                eq(USER_ID), eq(PRODUCT_CODE), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
 
         ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
 
@@ -216,12 +223,179 @@ class ReadinessServiceTest {
                 .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, 44, null, null, true, false, null, null, false));
         when(progressRepository.aggregateByDomain(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(List.of());
         when(strapiContentCache.getDomains(eq(PRODUCT_CODE), eq(LOCALE))).thenReturn(List.of());
+        when(examAttemptRepository.findAverageScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
+        when(examAttemptRepository.findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
+                eq(USER_ID), eq(PRODUCT_CODE), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
 
         ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
 
         assertThat(result.accuracyScore()).isCloseTo(66.67, within(0.1));
         assertThat(result.accuracyScore()).isLessThanOrEqualTo(100.0);
         assertThat(result.readinessScore()).isLessThanOrEqualTo(100.0);
+    }
+
+    // ─── EXAM CONFIDENCE ───
+
+    @Test
+    void calculate_zeroProgress_examConfidenceNotStarted() {
+        setupMocks(500, 0, 0, null, 44);
+
+        ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
+
+        assertThat(result.examConfidence()).isNotNull();
+        // Only noWeakDomainsPoints=10 (vacuously no weak domains)
+        assertThat(result.examConfidence().score()).isEqualTo(10);
+        assertThat(result.examConfidence().label()).isEqualTo("NOT_STARTED");
+    }
+
+    @Test
+    void calculate_highCoverageAndAccuracy_noExams_earnsCoverageAndAccuracyPoints() {
+        // coverage = 450/500 = 90%, accuracy = 400/450 = 88.9%
+        setupMocks(500, 450, 400, null, 44);
+
+        ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
+
+        ExamConfidence.Breakdown b = result.examConfidence().breakdown();
+        assertThat(b.coveragePoints()).isEqualTo(20);  // ≥90%
+        assertThat(b.accuracyPoints()).isEqualTo(25);  // ≥88%
+        assertThat(b.examConsistencyPoints()).isEqualTo(0);  // no exams
+        assertThat(b.avgScorePoints()).isEqualTo(0);  // no exams
+        assertThat(b.noWeakDomainsPoints()).isEqualTo(10);  // no domains = no weak
+        assertThat(result.examConfidence().score()).isEqualTo(55);
+    }
+
+    @Test
+    void calculate_midCoverageAndAccuracy_earnsMidPoints() {
+        // coverage = 375/500 = 75%, accuracy = 320/375 = 85.3%
+        setupMocks(500, 375, 320, null, 44);
+
+        ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
+
+        ExamConfidence.Breakdown b = result.examConfidence().breakdown();
+        assertThat(b.coveragePoints()).isEqualTo(10);  // 70-89%
+        assertThat(b.accuracyPoints()).isEqualTo(15);  // 80-87%
+    }
+
+    @Test
+    void calculate_lowCoverageAndAccuracy_earnsZeroPoints() {
+        // coverage = 200/500 = 40%, accuracy = 120/200 = 60%
+        setupMocks(500, 200, 120, null, 44);
+
+        ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
+
+        ExamConfidence.Breakdown b = result.examConfidence().breakdown();
+        assertThat(b.coveragePoints()).isEqualTo(0);  // <70%
+        assertThat(b.accuracyPoints()).isEqualTo(0);  // <80%
+        assertThat(b.coverageMet()).isFalse();
+        assertThat(b.accuracyMet()).isFalse();
+    }
+
+    @Test
+    void calculateExamConfidence_threeConsecutivePasses_earnsFullConsistencyPoints() {
+        setupMocks(500, 450, 400, 46, 44);
+
+        // Mock 3 consecutive passing exams
+        var exam1 = mockExamAttempt(true, 46);
+        var exam2 = mockExamAttempt(true, 45);
+        var exam3 = mockExamAttempt(true, 44);
+        when(examAttemptRepository.findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
+                eq(USER_ID), eq(PRODUCT_CODE), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(exam1, exam2, exam3)));
+        when(examAttemptRepository.findAverageScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(45.0);
+
+        ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
+
+        ExamConfidence.Breakdown b = result.examConfidence().breakdown();
+        assertThat(b.examConsistencyPoints()).isEqualTo(30);
+        assertThat(b.consecutivePasses()).isEqualTo(3);
+        assertThat(b.avgScorePoints()).isEqualTo(10);  // avg=45, 44≤avg<46 → 10
+    }
+
+    @Test
+    void calculateExamConfidence_onePass_earnsPartialConsistencyPoints() {
+        setupMocks(500, 450, 400, 46, 44);
+
+        var exam1 = mockExamAttempt(true, 46);
+        var exam2 = mockExamAttempt(false, 40);
+        when(examAttemptRepository.findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
+                eq(USER_ID), eq(PRODUCT_CODE), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(exam1, exam2)));
+        when(examAttemptRepository.findAverageScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(43.0);
+
+        ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
+
+        ExamConfidence.Breakdown b = result.examConfidence().breakdown();
+        assertThat(b.examConsistencyPoints()).isEqualTo(15);  // 1-2 passes
+        assertThat(b.consecutivePasses()).isEqualTo(1);
+        assertThat(b.avgScorePoints()).isEqualTo(0);  // avg<44
+    }
+
+    @Test
+    void calculateExamConfidence_highAvgScore_earnsFullAvgPoints() {
+        setupMocks(500, 450, 400, 48, 44);
+
+        var exam1 = mockExamAttempt(true, 48);
+        when(examAttemptRepository.findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
+                eq(USER_ID), eq(PRODUCT_CODE), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(exam1)));
+        when(examAttemptRepository.findAverageScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(48.0);
+
+        ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
+
+        assertThat(result.examConfidence().breakdown().avgScorePoints()).isEqualTo(15);  // avg≥46
+    }
+
+    @Test
+    void calculateExamConfidence_maxScore_cappedAt95() {
+        // All criteria maxed: 20 + 25 + 30 + 15 + 10 = 100 → capped at 95
+        setupMocks(500, 450, 400, 48, 44);
+
+        var exam1 = mockExamAttempt(true, 48);
+        var exam2 = mockExamAttempt(true, 47);
+        var exam3 = mockExamAttempt(true, 46);
+        when(examAttemptRepository.findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
+                eq(USER_ID), eq(PRODUCT_CODE), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(exam1, exam2, exam3)));
+        when(examAttemptRepository.findAverageScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(47.0);
+
+        ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
+
+        assertThat(result.examConfidence().score()).isEqualTo(95);
+        assertThat(result.examConfidence().label()).isEqualTo("READY");
+    }
+
+    @Test
+    void classifyConfidenceLabel_zeroScoreZeroCoverage_notStarted() {
+        assertThat(ReadinessService.classifyConfidenceLabel(0, 0.0)).isEqualTo("NOT_STARTED");
+    }
+
+    @Test
+    void classifyConfidenceLabel_scoreBelowThirty_notReady() {
+        assertThat(ReadinessService.classifyConfidenceLabel(20, 50.0)).isEqualTo("NOT_READY");
+    }
+
+    @Test
+    void classifyConfidenceLabel_scoreThirtyToSixty_gettingThere() {
+        assertThat(ReadinessService.classifyConfidenceLabel(45, 70.0)).isEqualTo("GETTING_THERE");
+    }
+
+    @Test
+    void classifyConfidenceLabel_scoreSixtyToEighty_almostReady() {
+        assertThat(ReadinessService.classifyConfidenceLabel(70, 90.0)).isEqualTo("ALMOST_READY");
+    }
+
+    @Test
+    void classifyConfidenceLabel_scoreEightyPlus_ready() {
+        assertThat(ReadinessService.classifyConfidenceLabel(85, 90.0)).isEqualTo("READY");
+    }
+
+    private com.passtheo.content.domain.entity.ExamAttempt mockExamAttempt(boolean passed, int correctCount) {
+        var exam = mock(com.passtheo.content.domain.entity.ExamAttempt.class);
+        when(exam.isPassed()).thenReturn(passed);
+        // Lenient because short-circuit evaluation may skip getCorrectCount() when isPassed() is false
+        org.mockito.Mockito.lenient().when(exam.getCorrectCount()).thenReturn(correctCount);
+        return exam;
     }
 
     // ─── DOMAIN STRENGTH CLASSIFICATION ───
@@ -264,5 +438,10 @@ class ReadinessServiceTest {
                 .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, passScore, null, null, true, false, null, null, false));
         when(progressRepository.aggregateByDomain(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(List.of());
         when(strapiContentCache.getDomains(eq(PRODUCT_CODE), eq(LOCALE))).thenReturn(List.of());
+        // Exam confidence mocks (lenient because individual tests may override)
+        org.mockito.Mockito.lenient().when(examAttemptRepository.findAverageScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
+        org.mockito.Mockito.lenient().when(examAttemptRepository.findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
+                eq(USER_ID), eq(PRODUCT_CODE), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
     }
 }

--- a/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
@@ -238,7 +238,7 @@ class ReadinessServiceTest {
     // ─── EXAM CONFIDENCE ───
 
     @Test
-    void calculate_zeroProgress_examConfidenceNotStarted() {
+    void calculate_zeroProgress_examConfidenceNotReady() {
         setupMocks(500, 0, 0, null, 44);
 
         ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
@@ -246,7 +246,9 @@ class ReadinessServiceTest {
         assertThat(result.examConfidence()).isNotNull();
         // Only noWeakDomainsPoints=10 (vacuously no weak domains)
         assertThat(result.examConfidence().score()).isEqualTo(10);
-        assertThat(result.examConfidence().label()).isEqualTo("NOT_STARTED");
+        assertThat(result.examConfidence().label()).isEqualTo("NOT_READY");
+        assertThat(result.examConfidence().recommendation()).isEqualTo("KEEP_PRACTICING");
+        assertThat(result.examConfidence().breakdown().weakDomainCodes()).isEmpty();
     }
 
     @Test
@@ -363,31 +365,58 @@ class ReadinessServiceTest {
 
         assertThat(result.examConfidence().score()).isEqualTo(95);
         assertThat(result.examConfidence().label()).isEqualTo("READY");
+        assertThat(result.examConfidence().recommendation()).isEqualTo("BOOK_YOUR_EXAM");
     }
 
     @Test
-    void classifyConfidenceLabel_zeroScoreZeroCoverage_notStarted() {
-        assertThat(ReadinessService.classifyConfidenceLabel(0, 0.0)).isEqualTo("NOT_STARTED");
+    void classifyConfidenceLabel_zeroScore_notReady() {
+        assertThat(ReadinessService.classifyConfidenceLabel(0)).isEqualTo("NOT_READY");
     }
 
     @Test
     void classifyConfidenceLabel_scoreBelowThirty_notReady() {
-        assertThat(ReadinessService.classifyConfidenceLabel(20, 50.0)).isEqualTo("NOT_READY");
+        assertThat(ReadinessService.classifyConfidenceLabel(20)).isEqualTo("NOT_READY");
     }
 
     @Test
     void classifyConfidenceLabel_scoreThirtyToSixty_gettingThere() {
-        assertThat(ReadinessService.classifyConfidenceLabel(45, 70.0)).isEqualTo("GETTING_THERE");
+        assertThat(ReadinessService.classifyConfidenceLabel(45)).isEqualTo("GETTING_THERE");
     }
 
     @Test
     void classifyConfidenceLabel_scoreSixtyToEighty_almostReady() {
-        assertThat(ReadinessService.classifyConfidenceLabel(70, 90.0)).isEqualTo("ALMOST_READY");
+        assertThat(ReadinessService.classifyConfidenceLabel(70)).isEqualTo("ALMOST_READY");
     }
 
     @Test
     void classifyConfidenceLabel_scoreEightyPlus_ready() {
-        assertThat(ReadinessService.classifyConfidenceLabel(85, 90.0)).isEqualTo("READY");
+        assertThat(ReadinessService.classifyConfidenceLabel(85)).isEqualTo("READY");
+    }
+
+    // ─── RECOMMENDATION KEYS ───
+
+    @Test
+    void generateRecommendationKey_lowScore_keepPracticing() {
+        assertThat(ReadinessService.generateRecommendationKey(10)).isEqualTo("KEEP_PRACTICING");
+        assertThat(ReadinessService.generateRecommendationKey(39)).isEqualTo("KEEP_PRACTICING");
+    }
+
+    @Test
+    void generateRecommendationKey_midScore_focusWeakDomains() {
+        assertThat(ReadinessService.generateRecommendationKey(40)).isEqualTo("FOCUS_WEAK_DOMAINS");
+        assertThat(ReadinessService.generateRecommendationKey(59)).isEqualTo("FOCUS_WEAK_DOMAINS");
+    }
+
+    @Test
+    void generateRecommendationKey_highScore_passMoreExams() {
+        assertThat(ReadinessService.generateRecommendationKey(60)).isEqualTo("PASS_MORE_EXAMS");
+        assertThat(ReadinessService.generateRecommendationKey(79)).isEqualTo("PASS_MORE_EXAMS");
+    }
+
+    @Test
+    void generateRecommendationKey_maxScore_bookYourExam() {
+        assertThat(ReadinessService.generateRecommendationKey(80)).isEqualTo("BOOK_YOUR_EXAM");
+        assertThat(ReadinessService.generateRecommendationKey(95)).isEqualTo("BOOK_YOUR_EXAM");
     }
 
     private com.passtheo.content.domain.entity.ExamAttempt mockExamAttempt(boolean passed, int correctCount) {

--- a/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
@@ -1,8 +1,10 @@
 package com.passtheo.content.unit;
 
 import com.passtheo.shared.core.client.UserServiceInternalClient;
+import com.passtheo.content.domain.enums.ConfidenceLabel;
 import com.passtheo.content.domain.enums.DomainStrength;
 import com.passtheo.content.domain.enums.ReadinessLabel;
+import com.passtheo.content.domain.enums.RecommendationKey;
 import com.passtheo.content.domain.valueobject.ExamConfidence;
 import com.passtheo.content.domain.valueobject.ReadinessScore;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
@@ -246,8 +248,8 @@ class ReadinessServiceTest {
         assertThat(result.examConfidence()).isNotNull();
         // Only noWeakDomainsPoints=10 (vacuously no weak domains)
         assertThat(result.examConfidence().score()).isEqualTo(10);
-        assertThat(result.examConfidence().label()).isEqualTo("NOT_READY");
-        assertThat(result.examConfidence().recommendation()).isEqualTo("KEEP_PRACTICING");
+        assertThat(result.examConfidence().label()).isEqualTo(ConfidenceLabel.NOT_READY);
+        assertThat(result.examConfidence().recommendation()).isEqualTo(RecommendationKey.KEEP_PRACTICING);
         assertThat(result.examConfidence().breakdown().weakDomainCodes()).isEmpty();
     }
 
@@ -364,59 +366,77 @@ class ReadinessServiceTest {
         ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
 
         assertThat(result.examConfidence().score()).isEqualTo(95);
-        assertThat(result.examConfidence().label()).isEqualTo("READY");
-        assertThat(result.examConfidence().recommendation()).isEqualTo("BOOK_YOUR_EXAM");
+        assertThat(result.examConfidence().label()).isEqualTo(ConfidenceLabel.READY);
+        assertThat(result.examConfidence().recommendation()).isEqualTo(RecommendationKey.BOOK_YOUR_EXAM);
     }
 
     @Test
     void classifyConfidenceLabel_zeroScore_notReady() {
-        assertThat(ReadinessService.classifyConfidenceLabel(0)).isEqualTo("NOT_READY");
+        assertThat(ReadinessService.classifyConfidenceLabel(0)).isEqualTo(ConfidenceLabel.NOT_READY);
     }
 
     @Test
     void classifyConfidenceLabel_scoreBelowThirty_notReady() {
-        assertThat(ReadinessService.classifyConfidenceLabel(20)).isEqualTo("NOT_READY");
+        assertThat(ReadinessService.classifyConfidenceLabel(20)).isEqualTo(ConfidenceLabel.NOT_READY);
+    }
+
+    @Test
+    void classifyConfidenceLabel_boundary_29isNotReady_30isGettingThere() {
+        assertThat(ReadinessService.classifyConfidenceLabel(29)).isEqualTo(ConfidenceLabel.NOT_READY);
+        assertThat(ReadinessService.classifyConfidenceLabel(30)).isEqualTo(ConfidenceLabel.GETTING_THERE);
     }
 
     @Test
     void classifyConfidenceLabel_scoreThirtyToSixty_gettingThere() {
-        assertThat(ReadinessService.classifyConfidenceLabel(45)).isEqualTo("GETTING_THERE");
+        assertThat(ReadinessService.classifyConfidenceLabel(45)).isEqualTo(ConfidenceLabel.GETTING_THERE);
+    }
+
+    @Test
+    void classifyConfidenceLabel_boundary_59isGettingThere_60isAlmostReady() {
+        assertThat(ReadinessService.classifyConfidenceLabel(59)).isEqualTo(ConfidenceLabel.GETTING_THERE);
+        assertThat(ReadinessService.classifyConfidenceLabel(60)).isEqualTo(ConfidenceLabel.ALMOST_READY);
     }
 
     @Test
     void classifyConfidenceLabel_scoreSixtyToEighty_almostReady() {
-        assertThat(ReadinessService.classifyConfidenceLabel(70)).isEqualTo("ALMOST_READY");
+        assertThat(ReadinessService.classifyConfidenceLabel(70)).isEqualTo(ConfidenceLabel.ALMOST_READY);
+    }
+
+    @Test
+    void classifyConfidenceLabel_boundary_79isAlmostReady_80isReady() {
+        assertThat(ReadinessService.classifyConfidenceLabel(79)).isEqualTo(ConfidenceLabel.ALMOST_READY);
+        assertThat(ReadinessService.classifyConfidenceLabel(80)).isEqualTo(ConfidenceLabel.READY);
     }
 
     @Test
     void classifyConfidenceLabel_scoreEightyPlus_ready() {
-        assertThat(ReadinessService.classifyConfidenceLabel(85)).isEqualTo("READY");
+        assertThat(ReadinessService.classifyConfidenceLabel(85)).isEqualTo(ConfidenceLabel.READY);
     }
 
     // ─── RECOMMENDATION KEYS ───
 
     @Test
     void generateRecommendationKey_lowScore_keepPracticing() {
-        assertThat(ReadinessService.generateRecommendationKey(10)).isEqualTo("KEEP_PRACTICING");
-        assertThat(ReadinessService.generateRecommendationKey(39)).isEqualTo("KEEP_PRACTICING");
+        assertThat(ReadinessService.generateRecommendationKey(10)).isEqualTo(RecommendationKey.KEEP_PRACTICING);
+        assertThat(ReadinessService.generateRecommendationKey(39)).isEqualTo(RecommendationKey.KEEP_PRACTICING);
     }
 
     @Test
     void generateRecommendationKey_midScore_focusWeakDomains() {
-        assertThat(ReadinessService.generateRecommendationKey(40)).isEqualTo("FOCUS_WEAK_DOMAINS");
-        assertThat(ReadinessService.generateRecommendationKey(59)).isEqualTo("FOCUS_WEAK_DOMAINS");
+        assertThat(ReadinessService.generateRecommendationKey(40)).isEqualTo(RecommendationKey.FOCUS_WEAK_DOMAINS);
+        assertThat(ReadinessService.generateRecommendationKey(59)).isEqualTo(RecommendationKey.FOCUS_WEAK_DOMAINS);
     }
 
     @Test
     void generateRecommendationKey_highScore_passMoreExams() {
-        assertThat(ReadinessService.generateRecommendationKey(60)).isEqualTo("PASS_MORE_EXAMS");
-        assertThat(ReadinessService.generateRecommendationKey(79)).isEqualTo("PASS_MORE_EXAMS");
+        assertThat(ReadinessService.generateRecommendationKey(60)).isEqualTo(RecommendationKey.PASS_MORE_EXAMS);
+        assertThat(ReadinessService.generateRecommendationKey(79)).isEqualTo(RecommendationKey.PASS_MORE_EXAMS);
     }
 
     @Test
     void generateRecommendationKey_maxScore_bookYourExam() {
-        assertThat(ReadinessService.generateRecommendationKey(80)).isEqualTo("BOOK_YOUR_EXAM");
-        assertThat(ReadinessService.generateRecommendationKey(95)).isEqualTo("BOOK_YOUR_EXAM");
+        assertThat(ReadinessService.generateRecommendationKey(80)).isEqualTo(RecommendationKey.BOOK_YOUR_EXAM);
+        assertThat(ReadinessService.generateRecommendationKey(95)).isEqualTo(RecommendationKey.BOOK_YOUR_EXAM);
     }
 
     private com.passtheo.content.domain.entity.ExamAttempt mockExamAttempt(boolean passed, int correctCount) {


### PR DESCRIPTION
Closes #39

## Changes
- Add exam confidence calculation to readiness endpoint
- Product-agnostic confidence enum keys
- Review feedback: enums, @Nonnull, soft-delete, boundary tests

## Test plan
- [ ] Readiness endpoint returns confidence data
- [ ] Boundary tests pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>