### PR TITLE
fix(content): add GET /api/content/lessons/{topicCode} endpoint

### DIFF
--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -279,6 +279,30 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponse_RoadSignList'
 
+  /api/content/lessons/{topicCode}:
+    get:
+      operationId: listLessonsByTopic
+      tags: [Content]
+      summary: Theory lessons for a topic (by topic code only)
+      description: Returns all active lessons for the given topic code. Simpler alternative to the hierarchical endpoint — no country/product context required.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: topicCode
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/TenantHeader'
+        - $ref: '#/components/parameters/LocaleQuery'
+      responses:
+        '200':
+          description: Lessons
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_LessonList'
+
   /api/content/{countryCode}/{productTypeCode}/{productCode}/lessons/{topicCode}:
     get:
       operationId: listLessons

--- a/src/main/java/com/passtheo/content/controller/ContentController.java
+++ b/src/main/java/com/passtheo/content/controller/ContentController.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -297,7 +298,7 @@ public class ContentController {
                 .map(l -> new LessonDto(
                         l.title(), l.slug(),
                         l.sections() != null ? l.sections().stream()
-                                .filter(s -> s != null)
+                                .filter(Objects::nonNull)
                                 .map(s -> new LessonSectionDto(
                                         s.heading(), s.body(), s.tip(),
                                         s.keyRule(), s.relatedRoadSignCode(), s.sortOrder()))

--- a/src/main/java/com/passtheo/content/controller/ContentController.java
+++ b/src/main/java/com/passtheo/content/controller/ContentController.java
@@ -262,6 +262,20 @@ public class ContentController {
     }
 
     /**
+     * Lists lessons for a topic (flat endpoint — no country/product hierarchy required).
+     *
+     * @param topicCode the topic code
+     * @param locale    content locale
+     * @return list of lessons
+     */
+    @GetMapping("/lessons/{topicCode}")
+    public ResponseEntity<ApiResponse<List<LessonDto>>> listLessonsByTopic(
+            @PathVariable @Nonnull String topicCode,
+            @RequestParam(defaultValue = "nl") String locale) {
+        return ResponseEntity.ok(ApiResponse.success(buildLessonDtos(topicCode, locale), MDC.get("traceId")));
+    }
+
+    /**
      * Lists lessons for a topic.
      *
      * @param topicCode the topic code
@@ -275,16 +289,20 @@ public class ContentController {
             @PathVariable String productCode,
             @PathVariable @Nonnull String topicCode,
             @RequestParam(defaultValue = "nl") String locale) {
-        var lessons = strapiContentCache.getLessons(topicCode, locale).stream()
+        return ResponseEntity.ok(ApiResponse.success(buildLessonDtos(topicCode, locale), MDC.get("traceId")));
+    }
+
+    private List<LessonDto> buildLessonDtos(@Nonnull String topicCode, @Nonnull String locale) {
+        return strapiContentCache.getLessons(topicCode, locale).stream()
                 .map(l -> new LessonDto(
                         l.title(), l.slug(),
                         l.sections() != null ? l.sections().stream()
+                                .filter(s -> s != null)
                                 .map(s -> new LessonSectionDto(
                                         s.heading(), s.body(), s.tip(),
                                         s.keyRule(), s.relatedRoadSignCode(), s.sortOrder()))
                                 .toList() : List.of(),
                         l.summary(), l.coverImage(), l.videoUrl(), l.readTimeMinutes()))
                 .toList();
-        return ResponseEntity.ok(ApiResponse.success(lessons, MDC.get("traceId")));
     }
 }

--- a/src/main/java/com/passtheo/content/dto/response/LessonDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/LessonDto.java
@@ -24,6 +24,6 @@ public record LessonDto(
         String tip,
         String keyRule,
         String relatedRoadSignCode,
-        int sortOrder
+        Integer sortOrder
     ) {}
 }

--- a/src/main/java/com/passtheo/content/integration/strapi/dto/StrapiLessonDto.java
+++ b/src/main/java/com/passtheo/content/integration/strapi/dto/StrapiLessonDto.java
@@ -20,7 +20,7 @@ public record StrapiLessonDto(
     Integer readTimeMinutes,
     boolean isActive,
     boolean isPremium,
-    int sortOrder
+    Integer sortOrder
 ) {
 
     /**
@@ -33,6 +33,6 @@ public record StrapiLessonDto(
         String tip,
         String keyRule,
         String relatedRoadSignCode,
-        int sortOrder
+        Integer sortOrder
     ) {}
 }

--- a/src/test/resources/karate/content-hierarchy.feature
+++ b/src/test/resources/karate/content-hierarchy.feature
@@ -79,12 +79,34 @@ Feature: Content Hierarchy Browsing
     Then status 200
     And match response.data == '#array'
 
-  Scenario: List lessons for a topic
+  Scenario: List lessons for a topic (hierarchical endpoint)
     Given path '/api/content/NL/cbr/auto-b/lessons/voorrangsborden'
     And headers paidHeaders
     When method GET
     Then status 200
     And match response.data == '#array'
+
+  Scenario: List lessons by topic code (flat endpoint)
+    Given path '/api/content/lessons/voorrangsborden'
+    And headers paidHeaders
+    When method GET
+    Then status 200
+    And match response.data == '#array'
+
+  Scenario: List lessons by topic code with locale
+    Given path '/api/content/lessons/voorrangsborden'
+    And headers paidHeaders
+    And param locale = 'en'
+    When method GET
+    Then status 200
+    And match response.data == '#array'
+
+  Scenario: List lessons for unknown topic code returns empty list
+    Given path '/api/content/lessons/nonexistent-topic-xyz'
+    And headers paidHeaders
+    When method GET
+    Then status 200
+    And match response.data == '#[]'
 
   Scenario: Content supports locale parameter
     Given path '/api/content/NL/cbr/auto-b/domains'


### PR DESCRIPTION
Closes #44

## Changes
- Added `GET /api/content/lessons/{topicCode}` flat endpoint to `ContentController` — Flutter can now call it without providing the country/productType/product path hierarchy
- Extracted shared `buildLessonDtos()` private helper so both the flat and hierarchical endpoints share the same mapping logic (no duplication)
- Added null-element filter in `buildLessonDtos()` sections stream to guard against NPE if Strapi returns a list with null entries
- Changed `int sortOrder` → `Integer sortOrder` in `StrapiLessonDto` and `SectionDto` to prevent Jackson deserialization failures when Strapi returns null for that field
- Updated OpenAPI spec with the new `listLessonsByTopic` operation
- Added 3 new Karate acceptance scenarios for the flat endpoint (200 success, locale param, unknown topic returns empty array)

## Root cause
`/api/content/lessons/kruisingen` matched no Spring handler → `NoResourceFoundException` → caught by shared `GlobalExceptionHandler`'s catch-all `@ExceptionHandler(Exception.class)` → returned as HTTP 500 instead of 404.

## Test plan
- [ ] `GET /api/content/lessons/kruisingen?locale=en` returns 200 with lesson list
- [ ] `GET /api/content/lessons/nonexistent-xyz` returns 200 with `data: []`
- [ ] `GET /api/content/NL/cbr/auto-b/lessons/voorrangsborden` still works (existing hierarchical endpoint untouched)