### PR TITLE
fix(content): filter question selection by topic when topicCode is provided

### DIFF
--- a/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
+++ b/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
@@ -180,12 +180,14 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
     @Query("SELECT qp FROM QuestionProgress qp WHERE qp.keycloakUserId = :userId " +
            "AND qp.productCode = :productCode " +
            "AND (:domainCode IS NULL OR qp.domainCode = :domainCode) " +
+           "AND (:topicCode IS NULL OR qp.topicCode = :topicCode) " +
            "AND qp.nextReviewAt IS NOT NULL AND qp.nextReviewAt < :now " +
            "ORDER BY qp.nextReviewAt ASC")
     List<QuestionProgress> findDueReviews(
             @Param("userId") UUID keycloakUserId,
             @Param("productCode") String productCode,
             @Param("domainCode") String domainCode,
+            @Param("topicCode") String topicCode,
             @Param("now") Instant now,
             Pageable pageable);
 
@@ -201,12 +203,14 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
     @Query("SELECT qp FROM QuestionProgress qp WHERE qp.keycloakUserId = :userId " +
            "AND qp.productCode = :productCode " +
            "AND (:domainCode IS NULL OR qp.domainCode = :domainCode) " +
+           "AND (:topicCode IS NULL OR qp.topicCode = :topicCode) " +
            "AND qp.masteryLevel = 'LEARNING' AND qp.consecutiveCorrect < :maxConsecutive " +
            "ORDER BY qp.consecutiveCorrect ASC, qp.lastAnsweredAt ASC")
     List<QuestionProgress> findWeak(
             @Param("userId") UUID keycloakUserId,
             @Param("productCode") String productCode,
             @Param("domainCode") String domainCode,
+            @Param("topicCode") String topicCode,
             @Param("maxConsecutive") int maxConsecutive,
             Pageable pageable);
 
@@ -220,11 +224,13 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
      */
     @Query("SELECT qp.strapiQuestionId FROM QuestionProgress qp WHERE qp.keycloakUserId = :userId " +
            "AND qp.productCode = :productCode " +
-           "AND (:domainCode IS NULL OR qp.domainCode = :domainCode)")
+           "AND (:domainCode IS NULL OR qp.domainCode = :domainCode) " +
+           "AND (:topicCode IS NULL OR qp.topicCode = :topicCode)")
     Set<String> findSeenQuestionIds(
             @Param("userId") UUID keycloakUserId,
             @Param("productCode") String productCode,
-            @Param("domainCode") String domainCode);
+            @Param("domainCode") String domainCode,
+            @Param("topicCode") String topicCode);
 
     /**
      * Finds FAMILIAR questions sorted by nearest review date.
@@ -237,12 +243,14 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
     @Query("SELECT qp FROM QuestionProgress qp WHERE qp.keycloakUserId = :userId " +
            "AND qp.productCode = :productCode " +
            "AND (:domainCode IS NULL OR qp.domainCode = :domainCode) " +
+           "AND (:topicCode IS NULL OR qp.topicCode = :topicCode) " +
            "AND qp.masteryLevel = 'FAMILIAR' " +
            "ORDER BY qp.nextReviewAt ASC NULLS LAST")
     List<QuestionProgress> findFamiliarSorted(
             @Param("userId") UUID keycloakUserId,
             @Param("productCode") String productCode,
             @Param("domainCode") String domainCode,
+            @Param("topicCode") String topicCode,
             Pageable pageable);
 
     /**

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -135,21 +135,26 @@ public class PracticeSessionService {
         SessionType sessionType = SessionType.valueOf(request.sessionType());
         String locale = request.locale() != null ? request.locale() : "nl";
 
-        // Check minimum question pool before selection — domains with < 5 questions
-        // produce broken navigator grids in Flutter.
-        // Note: checks domain-level count only. If topic-level filtering is added to
-        // QuestionSelectionService in the future, this check needs updating.
-        int availableCount = (request.domainCode() != null && !request.domainCode().isBlank())
-                ? strapiContentCache.getQuestionCountByDomain(request.domainCode(), locale)
-                : strapiContentCache.getQuestionCount(request.productCode(), locale);
+        // Check minimum question pool before selection.
+        String topicCode = request.topicCode();
+        boolean hasTopicCode = topicCode != null && !topicCode.isBlank();
+        int availableCount;
+        if (hasTopicCode) {
+            availableCount = strapiContentCache.getQuestionCountByTopic(topicCode, locale);
+        } else if (request.domainCode() != null && !request.domainCode().isBlank()) {
+            availableCount = strapiContentCache.getQuestionCountByDomain(request.domainCode(), locale);
+        } else {
+            availableCount = strapiContentCache.getQuestionCount(request.productCode(), locale);
+        }
         if (availableCount < 5) {
             throw new AppException(HttpStatus.BAD_REQUEST, ErrorCode.VALIDATION_ERROR,
-                    "Not enough questions available for this domain. At least 5 required.");
+                    "Not enough questions available. At least 5 required.");
         }
 
-        // Select questions using spaced repetition
+        // Select questions using spaced repetition — filter by topic when provided.
         List<String> questionIds = questionSelectionService.selectQuestions(
                 userId, request.productCode(), request.domainCode(),
+                hasTopicCode ? topicCode : null,
                 sessionType, request.questionCount(), locale);
 
         if (questionIds.isEmpty()) {
@@ -334,6 +339,7 @@ public class PracticeSessionService {
             if (allIds.isEmpty()) {
                 allIds = questionSelectionService.selectQuestions(
                         userId, session.getProductCode(), session.getDomainCode(),
+                        session.getTopicCode(),
                         SessionType.PRACTICE, session.getTotalQuestions(), locale);
             }
             if (questionOrder < allIds.size()) {
@@ -520,6 +526,7 @@ public class PracticeSessionService {
             if (questionIds.isEmpty()) {
                 questionIds = questionSelectionService.selectQuestions(
                         userId, session.getProductCode(), session.getDomainCode(),
+                        session.getTopicCode(),
                         SessionType.PRACTICE, session.getTotalQuestions(), locale);
             }
             if (session.getAnsweredCount() < questionIds.size()) {

--- a/src/main/java/com/passtheo/content/service/QuestionSelectionService.java
+++ b/src/main/java/com/passtheo/content/service/QuestionSelectionService.java
@@ -63,13 +63,15 @@ public class QuestionSelectionService {
      * @param userId      the user's Keycloak ID
      * @param productCode the product code
      * @param domainCode  the domain code (nullable for mixed/all domains)
+     * @param topicCode   the topic code (nullable — when non-null, narrows to topic)
      * @param sessionType the session type (nullable defaults to PRACTICE behaviour)
      * @param count       number of questions to select
      * @param locale      content locale for Strapi lookups
      * @return ordered list of Strapi question IDs
      */
     public List<String> selectQuestions(@Nonnull UUID userId, @Nonnull String productCode,
-                                        String domainCode, @Nullable SessionType sessionType,
+                                        String domainCode, @Nullable String topicCode,
+                                        @Nullable SessionType sessionType,
                                         int count, @Nonnull String locale) {
         List<String> selected = new ArrayList<>();
         int dueAdded = 0;
@@ -77,9 +79,12 @@ public class QuestionSelectionService {
         int newAdded = 0;
         int fillAdded = 0;
 
+        // Normalise blank topicCode to null for consistent IS NULL handling in queries.
+        String effectiveTopic = (topicCode != null && !topicCode.isBlank()) ? topicCode : null;
+
         // Priority 1: Due reviews (nextReviewAt < now) — most overdue first
         List<QuestionProgress> dueReviews = progressRepository
-                .findDueReviews(userId, productCode, domainCode, Instant.now(), Pageable.ofSize(count));
+                .findDueReviews(userId, productCode, domainCode, effectiveTopic, Instant.now(), Pageable.ofSize(count));
         dueReviews.sort(Comparator.comparing(QuestionProgress::getNextReviewAt));
         LOG.debug("Question selection P1 due-reviews: user={}, available={}", userId, dueReviews.size());
         for (QuestionProgress qp : dueReviews) {
@@ -93,7 +98,7 @@ public class QuestionSelectionService {
         // Priority 2: Weak questions (LEARNING with consecutiveCorrect < threshold)
         if (selected.size() < count) {
             List<QuestionProgress> weak = progressRepository
-                    .findWeak(userId, productCode, domainCode, WEAK_CONSECUTIVE_THRESHOLD, Pageable.ofSize(count));
+                    .findWeak(userId, productCode, domainCode, effectiveTopic, WEAK_CONSECUTIVE_THRESHOLD, Pageable.ofSize(count));
             LOG.debug("Question selection P2 weak: user={}, available={}", userId, weak.size());
             for (QuestionProgress qp : weak) {
                 if (selected.size() >= count) {
@@ -119,9 +124,9 @@ public class QuestionSelectionService {
 
         // Priority 3: New (unseen) questions — shuffled randomly for variety
         if (selected.size() < count) {
-            List<String> allQuestionIds = getAllQuestionIds(productCode, domainCode, locale);
+            List<String> allQuestionIds = getAllQuestionIds(productCode, domainCode, effectiveTopic, locale);
             Set<String> seenIds = progressRepository
-                    .findSeenQuestionIds(userId, productCode, domainCode);
+                    .findSeenQuestionIds(userId, productCode, domainCode, effectiveTopic);
 
             List<String> newIds = allQuestionIds.stream()
                     .filter(id -> !seenIds.contains(id) && !selected.contains(id))
@@ -142,7 +147,7 @@ public class QuestionSelectionService {
         // Priority 4: Fill with FAMILIAR questions closest to review date
         if (selected.size() < count) {
             List<QuestionProgress> familiar = progressRepository
-                    .findFamiliarSorted(userId, productCode, domainCode, Pageable.ofSize(count));
+                    .findFamiliarSorted(userId, productCode, domainCode, effectiveTopic, Pageable.ofSize(count));
             LOG.debug("Question selection P4 familiar-fill: user={}, available={}", userId, familiar.size());
             for (QuestionProgress qp : familiar) {
                 if (selected.size() >= count) {
@@ -176,7 +181,12 @@ public class QuestionSelectionService {
      * @return list of question IDs
      */
     private List<String> getAllQuestionIds(@Nonnull String productCode, String domainCode,
-                                           @Nonnull String locale) {
+                                           @Nullable String topicCode, @Nonnull String locale) {
+        if (topicCode != null) {
+            return strapiContentCache.getQuestionsByTopic(topicCode, locale).stream()
+                    .map(q -> q.documentId())
+                    .toList();
+        }
         if (domainCode != null && !domainCode.isBlank()) {
             return strapiContentCache.getQuestionsByDomain(domainCode, locale).stream()
                     .map(q -> q.documentId())

--- a/src/main/java/com/passtheo/content/service/QuestionSelectionService.java
+++ b/src/main/java/com/passtheo/content/service/QuestionSelectionService.java
@@ -117,8 +117,8 @@ public class QuestionSelectionService {
                 throw new AppException(HttpStatus.BAD_REQUEST, ErrorCode.VALIDATION_ERROR,
                         "No weak questions to review — keep practicing!");
             }
-            LOG.debug("WEAK_REVIEW selection COMPLETE: user={}, product={}, domain={}, total={} [due={}, weak={}]",
-                    userId, productCode, domainCode, selected.size(), dueAdded, weakAdded);
+            LOG.debug("WEAK_REVIEW selection COMPLETE: user={}, product={}, domain={}, topic={}, total={} [due={}, weak={}]",
+                    userId, productCode, domainCode, effectiveTopic, selected.size(), dueAdded, weakAdded);
             return List.copyOf(selected);
         }
 
@@ -160,13 +160,13 @@ public class QuestionSelectionService {
             }
         }
 
-        LOG.debug("Question selection COMPLETE: user={}, product={}, domain={}, total={} [due={}, weak={}, new={}, fill={}]",
-                userId, productCode, domainCode, selected.size(),
+        LOG.debug("Question selection COMPLETE: user={}, product={}, domain={}, topic={}, total={} [due={}, weak={}, new={}, fill={}]",
+                userId, productCode, domainCode, effectiveTopic, selected.size(),
                 dueAdded, weakAdded, newAdded, fillAdded);
 
         if (selected.isEmpty()) {
-            LOG.warn("No questions selected: user={}, product={}, domain={}, requestedCount={}",
-                    userId, productCode, domainCode, count);
+            LOG.warn("No questions selected: user={}, product={}, domain={}, topic={}, requestedCount={}",
+                    userId, productCode, domainCode, effectiveTopic, count);
         }
 
         return List.copyOf(selected);

--- a/src/test/java/com/passtheo/content/unit/QuestionSelectionServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/QuestionSelectionServiceTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,16 +53,16 @@ class QuestionSelectionServiceTest {
 
     @Test
     void new_user_gets_unseen_questions() {
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new java.util.ArrayList<>());
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
-        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN))
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
                 .thenReturn(Set.of());
         when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
                 .thenReturn(buildQuestions(DOMAIN, 10));
 
-        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, 5, LOCALE);
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, null, 5, LOCALE);
 
         assertEquals(5, selected.size());
     }
@@ -69,16 +70,16 @@ class QuestionSelectionServiceTest {
     @Test
     void due_reviews_are_prioritized_first() {
         QuestionProgress dueQ = buildProgress("q-due-1", Instant.now().minus(1, ChronoUnit.DAYS));
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new java.util.ArrayList<>(List.of(dueQ)));
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
-        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN))
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
                 .thenReturn(Set.of("q-due-1"));
         when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
                 .thenReturn(buildQuestions(DOMAIN, 10));
 
-        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, 5, LOCALE);
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, null, 5, LOCALE);
 
         assertTrue(selected.contains("q-due-1"), "Due review question should be first");
         assertEquals(5, selected.size());
@@ -88,16 +89,16 @@ class QuestionSelectionServiceTest {
     void weak_questions_fill_when_no_due_reviews() {
         QuestionProgress weak = buildProgress("q-weak-1", null);
         weak.setConsecutiveCorrect(1);
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new java.util.ArrayList<>());
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of(weak));
-        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN))
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
                 .thenReturn(Set.of("q-weak-1"));
         when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
                 .thenReturn(buildQuestions(DOMAIN, 10));
 
-        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, 5, LOCALE);
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, null, 5, LOCALE);
 
         assertTrue(selected.contains("q-weak-1"));
     }
@@ -106,16 +107,16 @@ class QuestionSelectionServiceTest {
     void no_duplicate_questions_in_selection() {
         QuestionProgress dueQ = buildProgress("q-1", Instant.now().minus(1, ChronoUnit.DAYS));
         QuestionProgress weakQ = buildProgress("q-1", null);
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new java.util.ArrayList<>(List.of(dueQ)));
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of(weakQ));
-        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN))
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
                 .thenReturn(Set.of("q-1"));
         when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
                 .thenReturn(buildQuestions(DOMAIN, 5));
 
-        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, 3, LOCALE);
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, null, 3, LOCALE);
 
         long distinctCount = selected.stream().distinct().count();
         assertEquals(selected.size(), distinctCount, "No duplicates allowed");
@@ -123,34 +124,34 @@ class QuestionSelectionServiceTest {
 
     @Test
     void mixed_session_null_domain_uses_product_questions() {
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(null), any(Instant.class), any(Pageable.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(null), isNull(), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new java.util.ArrayList<>());
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(null), anyInt(), any(Pageable.class)))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(null), isNull(), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
-        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, null))
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, null, null))
                 .thenReturn(Set.of());
         when(strapiContentCache.getQuestionIds(eq(PRODUCT), eq(LOCALE)))
                 .thenReturn(List.of("q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10"));
 
-        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, null, null, 5, LOCALE);
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, null, null, null, 5, LOCALE);
 
         assertEquals(5, selected.size());
     }
 
     @Test
     void returns_empty_when_no_questions_exist() {
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new java.util.ArrayList<>());
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
-        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN))
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
                 .thenReturn(Set.of());
         when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
                 .thenReturn(List.of());
-        when(progressRepository.findFamiliarSorted(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Pageable.class)))
+        when(progressRepository.findFamiliarSorted(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Pageable.class)))
                 .thenReturn(List.of());
 
-        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, 5, LOCALE);
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, null, 5, LOCALE);
 
         assertTrue(selected.isEmpty());
     }
@@ -158,18 +159,18 @@ class QuestionSelectionServiceTest {
     @Test
     void familiar_questions_used_as_last_resort_fill() {
         QuestionProgress familiar = buildProgress("q-familiar-1", Instant.now().plus(3, ChronoUnit.DAYS));
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new ArrayList<>());
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
-        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN))
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
                 .thenReturn(Set.of());
         when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
                 .thenReturn(List.of());
-        when(progressRepository.findFamiliarSorted(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Pageable.class)))
+        when(progressRepository.findFamiliarSorted(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Pageable.class)))
                 .thenReturn(List.of(familiar));
 
-        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, 1, LOCALE);
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, null, 1, LOCALE);
 
         assertFalse(selected.isEmpty());
         assertTrue(selected.contains("q-familiar-1"));
@@ -184,12 +185,12 @@ class QuestionSelectionServiceTest {
         QuestionProgress weak2 = buildProgress("q-weak-2", null);
         QuestionProgress weak3 = buildProgress("q-weak-3", null);
         QuestionProgress weak4 = buildProgress("q-weak-4", null);
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new ArrayList<>(List.of(due)));
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of(weak1, weak2, weak3, weak4));
 
-        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN,
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null,
                 SessionType.WEAK_REVIEW, 10, LOCALE);
 
         assertEquals(5, selected.size());
@@ -201,28 +202,28 @@ class QuestionSelectionServiceTest {
     @Test
     void weakReview_throwsWhenFewerThan5() {
         QuestionProgress due = buildProgress("q-due", Instant.now().minus(1, ChronoUnit.DAYS));
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new ArrayList<>(List.of(due)));
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
 
         org.junit.jupiter.api.Assertions.assertThrows(AppException.class, () ->
-                service.selectQuestions(USER_ID, PRODUCT, DOMAIN,
+                service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null,
                         SessionType.WEAK_REVIEW, 10, LOCALE));
     }
 
     @Test
     void practice_sessionType_usesAllFourPriorities() {
-        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), any(Instant.class), any(Pageable.class)))
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
                 .thenReturn(new ArrayList<>());
-        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), anyInt(), any(Pageable.class)))
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
-        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN))
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
                 .thenReturn(Set.of());
         when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
                 .thenReturn(buildQuestions(DOMAIN, 10));
 
-        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN,
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null,
                 SessionType.PRACTICE, 5, LOCALE);
 
         assertEquals(5, selected.size());

--- a/src/test/java/com/passtheo/content/unit/QuestionSelectionServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/QuestionSelectionServiceTest.java
@@ -44,6 +44,7 @@ class QuestionSelectionServiceTest {
     private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
     private static final String PRODUCT = "auto-b";
     private static final String DOMAIN = "verkeersborden";
+    private static final String TOPIC = "voorrangsborden";
     private static final String LOCALE = "nl";
 
     @BeforeEach
@@ -225,6 +226,40 @@ class QuestionSelectionServiceTest {
 
         List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null,
                 SessionType.PRACTICE, 5, LOCALE);
+
+        assertEquals(5, selected.size());
+    }
+
+    // ─── Topic-level filtering ───
+
+    @Test
+    void topicCode_selectsQuestionsFromTopicOnly() {
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), eq(TOPIC), any(Instant.class), any(Pageable.class)))
+                .thenReturn(new ArrayList<>());
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), eq(TOPIC), anyInt(), any(Pageable.class)))
+                .thenReturn(List.of());
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, TOPIC))
+                .thenReturn(Set.of());
+        when(strapiContentCache.getQuestionsByTopic(eq(TOPIC), eq(LOCALE)))
+                .thenReturn(buildQuestions(DOMAIN, 8));
+
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, TOPIC, null, 5, LOCALE);
+
+        assertEquals(5, selected.size());
+    }
+
+    @Test
+    void blankTopicCode_normalizedToNull_selectsFromDomain() {
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
+                .thenReturn(new ArrayList<>());
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
+                .thenReturn(List.of());
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
+                .thenReturn(Set.of());
+        when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
+                .thenReturn(buildQuestions(DOMAIN, 10));
+
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, "  ", null, 5, LOCALE);
 
         assertEquals(5, selected.size());
     }


### PR DESCRIPTION
Closes #46

## Changes
- Added `topicCode` parameter to `QuestionSelectionService.selectQuestions()`
- Added `topicCode` filter to all 4 repository queries (`findDueReviews`, `findWeak`, `findSeenQuestionIds`, `findFamiliarSorted`)
- `getAllQuestionIds()` now uses `getQuestionsByTopic()` when topicCode is non-null
- `PracticeSessionService.startSession()` passes topicCode to selection and uses topic-level pool count check
- Updated all unit tests for the new parameter

## Test plan
- [ ] Start a topic-level practice session (kruisingen) — verify only kruisingen questions appear
- [ ] Start a domain-level practice session (voorrang, no topic) — verify questions from all topics in domain
- [ ] Start a mixed session (no domain) — verify questions from all domains
- [ ] `./gradlew test` passes