### PR TITLE
fix(content): topic practice includes all available questions

### DIFF
--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -151,11 +151,15 @@ public class PracticeSessionService {
                     "Not enough questions available. At least 5 required.");
         }
 
+        // When practising a specific topic, use ALL available questions — the user
+        // expects to go through every question in the topic, not a capped subset.
+        int effectiveCount = hasTopicCode ? availableCount : request.questionCount();
+
         // Select questions using spaced repetition — filter by topic when provided.
         List<String> questionIds = questionSelectionService.selectQuestions(
                 userId, request.productCode(), request.domainCode(),
                 hasTopicCode ? topicCode : null,
-                sessionType, request.questionCount(), locale);
+                sessionType, effectiveCount, locale);
 
         if (questionIds.isEmpty()) {
             throw new AppException(HttpStatus.BAD_REQUEST, ErrorCode.VALIDATION_ERROR, "No questions available for the selected criteria");

--- a/src/main/java/com/passtheo/content/service/QuestionSelectionService.java
+++ b/src/main/java/com/passtheo/content/service/QuestionSelectionService.java
@@ -122,9 +122,11 @@ public class QuestionSelectionService {
             return List.copyOf(selected);
         }
 
+        // Fetch full question pool once — reused in P3 and P5.
+        List<String> allQuestionIds = getAllQuestionIds(productCode, domainCode, effectiveTopic, locale);
+
         // Priority 3: New (unseen) questions — shuffled randomly for variety
         if (selected.size() < count) {
-            List<String> allQuestionIds = getAllQuestionIds(productCode, domainCode, effectiveTopic, locale);
             Set<String> seenIds = progressRepository
                     .findSeenQuestionIds(userId, productCode, domainCode, effectiveTopic);
 
@@ -160,9 +162,26 @@ public class QuestionSelectionService {
             }
         }
 
-        LOG.debug("Question selection COMPLETE: user={}, product={}, domain={}, topic={}, total={} [due={}, weak={}, new={}, fill={}]",
+        // Priority 5: Catch-all — include remaining pool questions not covered by P1–P4.
+        // P4 only selects FAMILIAR mastery; this catches MASTERED (not yet due) and LEARNING
+        // questions with consecutiveCorrect >= threshold that would otherwise be dropped.
+        int catchAllAdded = 0;
+        if (selected.size() < count) {
+            for (String id : allQuestionIds) {
+                if (selected.size() >= count) {
+                    break;
+                }
+                if (!selected.contains(id)) {
+                    selected.add(id);
+                    catchAllAdded++;
+                }
+            }
+            LOG.debug("Question selection P5 catch-all: user={}, added={}", userId, catchAllAdded);
+        }
+
+        LOG.debug("Question selection COMPLETE: user={}, product={}, domain={}, topic={}, total={} [due={}, weak={}, new={}, fill={}, catchAll={}]",
                 userId, productCode, domainCode, effectiveTopic, selected.size(),
-                dueAdded, weakAdded, newAdded, fillAdded);
+                dueAdded, weakAdded, newAdded, fillAdded, catchAllAdded);
 
         if (selected.isEmpty()) {
             LOG.warn("No questions selected: user={}, product={}, domain={}, topic={}, requestedCount={}",

--- a/src/test/java/com/passtheo/content/unit/QuestionSelectionServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/QuestionSelectionServiceTest.java
@@ -264,6 +264,59 @@ class QuestionSelectionServiceTest {
         assertEquals(5, selected.size());
     }
 
+    // ─── Catch-all (P5) ───
+
+    @Test
+    void catchAll_includesMasteredQuestionsNotCoveredByP1toP4() {
+        // Scenario: topic has 12 questions, user has seen all of them.
+        // P1 returns 2 due reviews, P2 returns 1 weak, P3 returns 0 new (all seen),
+        // P4 returns 2 familiar. Without P5, only 5 selected out of 12.
+        // With P5, the remaining 7 (MASTERED, not-yet-due) are added.
+        QuestionProgress due1 = buildProgress("doc-domain-1", Instant.now().minus(1, ChronoUnit.DAYS));
+        QuestionProgress due2 = buildProgress("doc-domain-2", Instant.now().minus(2, ChronoUnit.DAYS));
+        QuestionProgress weak = buildProgress("doc-domain-3", null);
+        weak.setConsecutiveCorrect(1);
+        QuestionProgress fam1 = buildProgress("doc-domain-4", Instant.now().plus(3, ChronoUnit.DAYS));
+        QuestionProgress fam2 = buildProgress("doc-domain-5", Instant.now().plus(5, ChronoUnit.DAYS));
+
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), eq(TOPIC), any(Instant.class), any(Pageable.class)))
+                .thenReturn(new ArrayList<>(List.of(due1, due2)));
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), eq(TOPIC), anyInt(), any(Pageable.class)))
+                .thenReturn(List.of(weak));
+        // All 12 questions have been seen
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, TOPIC))
+                .thenReturn(Set.of("doc-domain-1", "doc-domain-2", "doc-domain-3", "doc-domain-4",
+                        "doc-domain-5", "doc-domain-6", "doc-domain-7", "doc-domain-8",
+                        "doc-domain-9", "doc-domain-10", "doc-domain-11", "doc-domain-12"));
+        when(strapiContentCache.getQuestionsByTopic(eq(TOPIC), eq(LOCALE)))
+                .thenReturn(buildQuestions("domain", 12));
+        when(progressRepository.findFamiliarSorted(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), eq(TOPIC), any(Pageable.class)))
+                .thenReturn(List.of(fam1, fam2));
+
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, TOPIC, SessionType.PRACTICE, 12, LOCALE);
+
+        assertEquals(12, selected.size(), "All 12 topic questions should be selected");
+        long distinctCount = selected.stream().distinct().count();
+        assertEquals(12, distinctCount, "No duplicates");
+    }
+
+    @Test
+    void catchAll_doesNotExceedRequestedCount() {
+        // Domain-level practice requesting 5 out of 10 — P5 should NOT overshoot count.
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
+                .thenReturn(new ArrayList<>());
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
+                .thenReturn(List.of());
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
+                .thenReturn(Set.of());
+        when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
+                .thenReturn(buildQuestions(DOMAIN, 10));
+
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, SessionType.PRACTICE, 5, LOCALE);
+
+        assertEquals(5, selected.size(), "Should not exceed requested count");
+    }
+
     // ─── Helpers ───
 
     private QuestionProgress buildProgress(String questionId, Instant nextReviewAt) {


### PR DESCRIPTION
Closes #48

## Changes
- **PracticeSessionService**: When `topicCode` is provided, uses `availableCount` (all questions in topic) instead of `request.questionCount()` (Flutter's default 20)
- **QuestionSelectionService**: Added Priority 5 catch-all step that includes remaining pool questions not covered by P1–P4 (catches MASTERED and non-weak LEARNING questions that were silently dropped)
- Hoisted `getAllQuestionIds()` call above P3 to reuse in P5 without redundant cache lookup

## Root Cause
Two compounding issues caused topic practice to end after ~5 questions instead of all available:
1. Session size was set to whatever the selection algorithm found, not the actual topic size
2. P4 (`findFamiliarSorted`) only returns `FAMILIAR` mastery — missed MASTERED questions not yet due and LEARNING questions with `consecutiveCorrect >= 2`

## Test plan
- [x] `catchAll_includesMasteredQuestionsNotCoveredByP1toP4` — 12-question topic with mixed mastery levels → all 12 selected
- [x] `catchAll_doesNotExceedRequestedCount` — domain-level practice still respects requested count
- [x] All 14 existing + new unit tests pass
- [ ] Manual: select a topic with 12 questions → session serves all 12
- [ ] Manual: domain-level practice still caps at requested count
- [ ] Manual: WEAK_REVIEW sessions still only show weak questions