### PR TITLE
fix(content): align drag_numbers grading with frontend imageRegion priority

### DIFF
--- a/src/main/java/com/passtheo/content/service/AnswerProcessingService.java
+++ b/src/main/java/com/passtheo/content/service/AnswerProcessingService.java
@@ -132,15 +132,16 @@ public class AnswerProcessingService {
                 yield Map.of("selectedTargetIds", correctIds);
             }
             case "drag_numbers" -> {
+                // Image regions take priority (matches frontend DragNumbersRenderer._items).
                 Map<String, String> placements = new java.util.LinkedHashMap<>();
-                if (question.dragTargets() != null && !question.dragTargets().isEmpty()) {
-                    question.dragTargets().stream()
-                            .filter(dt -> dt.correctValue() != null)
-                            .forEach(dt -> placements.put(String.valueOf(dt.id()), dt.correctValue()));
-                } else if (question.imageRegions() != null) {
+                if (question.imageRegions() != null && !question.imageRegions().isEmpty()) {
                     question.imageRegions().stream()
                             .filter(r -> r.correctValue() != null)
                             .forEach(r -> placements.put(String.valueOf(r.id()), r.correctValue()));
+                } else if (question.dragTargets() != null) {
+                    question.dragTargets().stream()
+                            .filter(dt -> dt.correctValue() != null)
+                            .forEach(dt -> placements.put(String.valueOf(dt.id()), dt.correctValue()));
                 }
                 yield Map.of("placements", (Object) placements);
             }
@@ -227,9 +228,9 @@ public class AnswerProcessingService {
         }
         Map<?, ?> placements = (Map<?, ?>) placementsObj;
 
-        // Image-based ordering: use imageRegions when dragTargets is absent
-        if ((question.dragTargets() == null || question.dragTargets().isEmpty())
-                && question.imageRegions() != null && !question.imageRegions().isEmpty()) {
+        // Image-based ordering: use imageRegions when present (matches frontend
+        // DragNumbersRenderer._items which also prefers imageRegions over dragTargets).
+        if (question.imageRegions() != null && !question.imageRegions().isEmpty()) {
             for (StrapiQuestionDto.ImageRegionDto region : question.imageRegions()) {
                 if (region.correctValue() == null) {
                     continue;
@@ -242,7 +243,7 @@ public class AnswerProcessingService {
             return true;
         }
 
-        // Text-based ordering: use dragTargets
+        // Text-based ordering: use dragTargets (no image regions)
         if (question.dragTargets() == null) {
             return false;
         }

--- a/src/test/java/com/passtheo/content/unit/AnswerProcessingServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/AnswerProcessingServiceTest.java
@@ -243,12 +243,18 @@ class AnswerProcessingServiceTest {
     }
 
     @Test
-    void gradeAnswer_dragNumbers_prefersDragTargetsOverImageRegions() {
-        // When both dragTargets and imageRegions exist, use dragTargets
+    void gradeAnswer_dragNumbers_prefersImageRegionsOverDragTargets() {
+        // When both exist, imageRegions take priority (matches frontend DragNumbersRenderer).
+        // Frontend sends imageRegion IDs, so grading must use those too.
         StrapiQuestionDto question = buildQuestion("drag_numbers", null,
-                List.of(new StrapiQuestionDto.ImageRegionDto(10, "Region", 20, 70, 14, 16, false, "9")),
-                List.of(new StrapiQuestionDto.DragTargetDto(1, "Pos", "1", false, 0, null)));
-        assertThat(service.gradeAnswer(question, Map.of("placements", Map.of("1", "1")))).isTrue();
+                List.of(new StrapiQuestionDto.ImageRegionDto(808, "Car A", 20, 70, 14, 16, false, "1"),
+                        new StrapiQuestionDto.ImageRegionDto(809, "Car B", 60, 40, 16, 14, false, "2")),
+                List.of(new StrapiQuestionDto.DragTargetDto(681, "Car A", "1", false, 0, null),
+                        new StrapiQuestionDto.DragTargetDto(682, "Car B", "2", false, 1, null)));
+        // User sends imageRegion IDs (808, 809) — must be graded correctly
+        assertThat(service.gradeAnswer(question, Map.of("placements", Map.of("808", "1", "809", "2")))).isTrue();
+        // User sends dragTarget IDs (681, 682) — would fail because grading uses imageRegion IDs
+        assertThat(service.gradeAnswer(question, Map.of("placements", Map.of("681", "1", "682", "2")))).isFalse();
     }
 
     // ─── BUILD CORRECT ANSWER ───
@@ -287,6 +293,20 @@ class AnswerProcessingServiceTest {
         @SuppressWarnings("unchecked")
         Map<String, String> placements = (Map<String, String>) correct.get("placements");
         assertThat(placements).containsEntry("1", "2").containsEntry("2", "1");
+    }
+
+    @Test
+    void buildCorrectAnswer_dragNumbers_bothFieldsPresent_usesImageRegionIds() {
+        StrapiQuestionDto question = buildQuestion("drag_numbers", null,
+                List.of(new StrapiQuestionDto.ImageRegionDto(808, "Car A", 20, 70, 14, 16, false, "1"),
+                        new StrapiQuestionDto.ImageRegionDto(809, "Car B", 60, 40, 16, 14, false, "2")),
+                List.of(new StrapiQuestionDto.DragTargetDto(681, "Car A", "1", false, 0, null),
+                        new StrapiQuestionDto.DragTargetDto(682, "Car B", "2", false, 1, null)));
+        @SuppressWarnings("unchecked")
+        Map<String, String> placements = (Map<String, String>) service.buildCorrectAnswer(question).get("placements");
+        // Must use imageRegion IDs (808, 809), not dragTarget IDs (681, 682)
+        assertThat(placements).containsEntry("808", "1").containsEntry("809", "2");
+        assertThat(placements).doesNotContainKey("681");
     }
 
     // ─── MASTERY TRANSITIONS ───


### PR DESCRIPTION
Closes #50

## Changes
- **`gradeDragNumbers()`**: Now checks `imageRegions` first (when non-empty), falls back to `dragTargets` — matches Flutter `DragNumbersRenderer._items` priority
- **`buildCorrectAnswer()`**: Same priority flip for the `drag_numbers` case — returns imageRegion IDs in the correct answer
- Updated `gradeAnswer_dragNumbers_prefersDragTargetsOverImageRegions` test → now `prefersImageRegionsOverDragTargets`
- Added `buildCorrectAnswer_dragNumbers_bothFieldsPresent_usesImageRegionIds` test

## Root Cause
Frontend sends imageRegion IDs (e.g. 808-811) for image-based drag_numbers. Backend graded against dragTarget IDs (681-684). Same ordering values (1,2,3,4) but different keys → false negative.

## Test plan
- [x] `gradeAnswer_dragNumbers_prefersImageRegionsOverDragTargets` — confirms imageRegion IDs are used when both fields exist
- [x] `buildCorrectAnswer_dragNumbers_bothFieldsPresent_usesImageRegionIds` — confirms correct answer uses imageRegion IDs
- [x] All existing drag_numbers tests still pass (text-only, image-only)
- [x] Full test suite passes (34 tests)
- [ ] Manual: answer an image-based drag_numbers question correctly → should return `isCorrect: true`