### PR TITLE
fix(content): handle drag_numbers imageRegions without correctValue

### DIFF
--- a/src/main/java/com/passtheo/content/service/AnswerProcessingService.java
+++ b/src/main/java/com/passtheo/content/service/AnswerProcessingService.java
@@ -132,18 +132,11 @@ public class AnswerProcessingService {
                 yield Map.of("selectedTargetIds", correctIds);
             }
             case "drag_numbers" -> {
-                // Image regions take priority (matches frontend DragNumbersRenderer._items).
+                // Frontend uses imageRegion IDs when present (DragNumbersRenderer._items).
+                // correctValue may live on imageRegions or dragTargets depending on
+                // how the content was authored in Strapi.
                 Map<String, String> placements = new java.util.LinkedHashMap<>();
-                if (question.imageRegions() != null && !question.imageRegions().isEmpty()) {
-                    question.imageRegions().stream()
-                            .filter(r -> r.correctValue() != null)
-                            .forEach(r -> placements.put(String.valueOf(r.id()), r.correctValue()));
-                } else if (question.dragTargets() != null) {
-                    question.dragTargets().stream()
-                            .filter(dt -> dt.correctValue() != null)
-                            .forEach(dt -> placements.put(String.valueOf(dt.id()), dt.correctValue()));
-                }
-                yield Map.of("placements", (Object) placements);
+                yield Map.of("placements", (Object) buildDragNumbersPlacements(question, placements));
             }
             case "multiple_response" -> {
                 List<String> correctIds = question.answerOptions() != null
@@ -226,37 +219,66 @@ public class AnswerProcessingService {
         if (placementsObj == null) {
             return false;
         }
-        Map<?, ?> placements = (Map<?, ?>) placementsObj;
+        Map<?, ?> userPlacements = (Map<?, ?>) placementsObj;
 
-        // Image-based ordering: use imageRegions when present (matches frontend
-        // DragNumbersRenderer._items which also prefers imageRegions over dragTargets).
-        if (question.imageRegions() != null && !question.imageRegions().isEmpty()) {
-            for (StrapiQuestionDto.ImageRegionDto region : question.imageRegions()) {
-                if (region.correctValue() == null) {
-                    continue;
-                }
-                Object placed = placements.get(String.valueOf(region.id()));
-                if (placed == null || !region.correctValue().equals(placed.toString())) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        // Text-based ordering: use dragTargets (no image regions)
-        if (question.dragTargets() == null) {
+        // Build the expected placements using the same logic as buildCorrectAnswer.
+        Map<String, String> expected = buildDragNumbersPlacements(question, new java.util.LinkedHashMap<>());
+        if (expected.isEmpty()) {
+            LOG.warn("drag_numbers question {} has no resolvable correct placements", question.documentId());
             return false;
         }
-        for (StrapiQuestionDto.DragTargetDto target : question.dragTargets()) {
-            if (target.correctValue() == null) {
-                continue;
-            }
-            Object placed = placements.get(String.valueOf(target.id()));
-            if (placed == null || !target.correctValue().equals(placed.toString())) {
+
+        for (Map.Entry<String, String> entry : expected.entrySet()) {
+            Object placed = userPlacements.get(entry.getKey());
+            if (placed == null || !entry.getValue().equals(placed.toString())) {
                 return false;
             }
         }
         return true;
+    }
+
+    /**
+     * Resolves the correct placements map for a drag_numbers question.
+     * Frontend always uses imageRegion IDs when imageRegions exist, so the returned
+     * map keys must match what the frontend sends. correctValue may live on
+     * imageRegions directly or on dragTargets (positional mapping).
+     *
+     * @param question   the Strapi question
+     * @param placements map to populate (returned for convenience)
+     * @return the populated placements map
+     */
+    private Map<String, String> buildDragNumbersPlacements(StrapiQuestionDto question,
+                                                            Map<String, String> placements) {
+        boolean hasRegions = question.imageRegions() != null && !question.imageRegions().isEmpty();
+        boolean hasTargets = question.dragTargets() != null && !question.dragTargets().isEmpty();
+
+        if (hasRegions) {
+            boolean regionsHaveCorrectValue = question.imageRegions().stream()
+                    .anyMatch(r -> r.correctValue() != null);
+
+            if (regionsHaveCorrectValue) {
+                // Pattern A: imageRegions carry correctValue directly.
+                question.imageRegions().stream()
+                        .filter(r -> r.correctValue() != null)
+                        .forEach(r -> placements.put(String.valueOf(r.id()), r.correctValue()));
+            } else if (hasTargets) {
+                // Pattern B: imageRegions define tap areas, dragTargets hold correctValue.
+                // Map positionally — imageRegion[i] corresponds to dragTarget[i].
+                int count = Math.min(question.imageRegions().size(), question.dragTargets().size());
+                for (int i = 0; i < count; i++) {
+                    String correctValue = question.dragTargets().get(i).correctValue();
+                    if (correctValue != null) {
+                        placements.put(String.valueOf(question.imageRegions().get(i).id()), correctValue);
+                    }
+                }
+            }
+        } else if (hasTargets) {
+            // Text-only: no imageRegions, use dragTarget IDs directly.
+            question.dragTargets().stream()
+                    .filter(dt -> dt.correctValue() != null)
+                    .forEach(dt -> placements.put(String.valueOf(dt.id()), dt.correctValue()));
+        }
+        return placements;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/passtheo/content/unit/AnswerProcessingServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/AnswerProcessingServiceTest.java
@@ -309,6 +309,41 @@ class AnswerProcessingServiceTest {
         assertThat(placements).doesNotContainKey("681");
     }
 
+    // ─── Pattern B: imageRegions without correctValue, dragTargets carry it ───
+
+    @Test
+    void gradeAnswer_dragNumbers_imageRegionsWithoutCorrectValue_usesPositionalMapping() {
+        // imageRegions define tap areas (no correctValue), dragTargets hold the ordering.
+        // Frontend sends imageRegion IDs — grading maps positionally to dragTarget correctValues.
+        StrapiQuestionDto question = buildQuestion("drag_numbers", null,
+                List.of(new StrapiQuestionDto.ImageRegionDto(808, "Car A", 20, 70, 14, 16, false, null),
+                        new StrapiQuestionDto.ImageRegionDto(809, "Car B", 60, 40, 16, 14, false, null),
+                        new StrapiQuestionDto.ImageRegionDto(810, "Car C", 30, 80, 14, 16, false, null),
+                        new StrapiQuestionDto.ImageRegionDto(811, "Pedestrian", 50, 20, 14, 16, false, null)),
+                List.of(new StrapiQuestionDto.DragTargetDto(681, "Car A", "1", false, 0, null),
+                        new StrapiQuestionDto.DragTargetDto(682, "Car B", "2", false, 1, null),
+                        new StrapiQuestionDto.DragTargetDto(683, "Car C", "3", false, 2, null),
+                        new StrapiQuestionDto.DragTargetDto(684, "Pedestrian", "4", false, 3, null)));
+        // Correct: 808→1, 809→2, 810→3, 811→4
+        assertThat(service.gradeAnswer(question, Map.of("placements", Map.of("808", "1", "809", "2", "810", "3", "811", "4")))).isTrue();
+        // Wrong order
+        assertThat(service.gradeAnswer(question, Map.of("placements", Map.of("808", "4", "809", "3", "810", "2", "811", "1")))).isFalse();
+    }
+
+    @Test
+    void buildCorrectAnswer_dragNumbers_imageRegionsWithoutCorrectValue_mapsPositionally() {
+        StrapiQuestionDto question = buildQuestion("drag_numbers", null,
+                List.of(new StrapiQuestionDto.ImageRegionDto(808, "Car A", 20, 70, 14, 16, false, null),
+                        new StrapiQuestionDto.ImageRegionDto(809, "Car B", 60, 40, 16, 14, false, null)),
+                List.of(new StrapiQuestionDto.DragTargetDto(681, "Car A", "1", false, 0, null),
+                        new StrapiQuestionDto.DragTargetDto(682, "Car B", "2", false, 1, null)));
+        @SuppressWarnings("unchecked")
+        Map<String, String> placements = (Map<String, String>) service.buildCorrectAnswer(question).get("placements");
+        // Uses imageRegion IDs (808, 809) mapped to dragTarget correctValues (1, 2)
+        assertThat(placements).containsEntry("808", "1").containsEntry("809", "2");
+        assertThat(placements).doesNotContainKey("681");
+    }
+
     // ─── MASTERY TRANSITIONS ───
 
     @Test


### PR DESCRIPTION
Follow-up to #50 — the initial fix only handled Pattern A (imageRegions WITH correctValue). This handles Pattern B.

## Problem
Some drag_numbers questions have imageRegions for tap positions (no `correctValue`) with `correctValue` on dragTargets instead. The previous fix returned empty `correctAnswer.placements` causing the Flutter UI to show "wrong" even when `isCorrect: true`.

## Changes
- Extracted shared `buildDragNumbersPlacements()` helper used by both `gradeDragNumbers()` and `buildCorrectAnswer()`
- **Pattern A**: imageRegions have `correctValue` → use imageRegion IDs + their values (existing)
- **Pattern B**: imageRegions lack `correctValue` → map imageRegion IDs to dragTarget `correctValue` positionally
- **Text-only**: no imageRegions → use dragTarget IDs directly (unchanged)

## Test plan
- [x] `gradeAnswer_dragNumbers_imageRegionsWithoutCorrectValue_usesPositionalMapping` — Pattern B correct+wrong
- [x] `buildCorrectAnswer_dragNumbers_imageRegionsWithoutCorrectValue_mapsPositionally` — returns imageRegion IDs with dragTarget values
- [x] All existing tests pass (Pattern A, text-only, image-only)
- [ ] Manual: answer image-based drag_numbers correctly → green checkmarks + "Correct order" shows items