### PR TITLE
fix(content): handle deleted/deactivated Strapi questions gracefully

### DIFF
--- a/src/main/java/com/passtheo/content/service/AchievementService.java
+++ b/src/main/java/com/passtheo/content/service/AchievementService.java
@@ -155,8 +155,11 @@ public class AchievementService {
                         int total = strapiContentCache.getQuestionCountByDomain(agg.getDomainCode(), DEFAULT_LOCALE);
                         double accuracy = agg.getTotalAttempts() > 0
                                 ? (double) agg.getCorrectCount() / agg.getTotalAttempts() * 100.0 : 0.0;
+                        // Clamp attempted count to active total — progress records may reference
+                        // deactivated questions no longer in the Strapi active pool.
+                        long clampedAttempted = Math.min(agg.getAttemptedCount(), total);
                         double coverage = total > 0
-                                ? (double) agg.getAttemptedCount() / total * 100.0 : 0.0;
+                                ? (double) clampedAttempted / total * 100.0 : 0.0;
                         return ReadinessService.classifyDomainStrength(accuracy, coverage) == DomainStrength.MASTERED;
                     })
                     .count();

--- a/src/main/java/com/passtheo/content/service/MockExamService.java
+++ b/src/main/java/com/passtheo/content/service/MockExamService.java
@@ -238,6 +238,11 @@ public class MockExamService {
 
                 domainStats.computeIfAbsent("unknown", k -> new int[]{0, 0});
                 domainStats.get("unknown")[1]++;
+
+                // Add to wrong answers so the user can see why they lost a point
+                wrongAnswers.add(new ExamResultDto.WrongAnswerDto(
+                        item.strapiQuestionId(), "This question is no longer available",
+                        item.answer(), Map.of(), null));
                 continue;
             }
 

--- a/src/main/java/com/passtheo/content/service/MockExamService.java
+++ b/src/main/java/com/passtheo/content/service/MockExamService.java
@@ -215,7 +215,29 @@ public class MockExamService {
         for (int i = 0; i < request.answers().size(); i++) {
             SubmitExamRequest.ExamAnswerItem item = request.answers().get(i);
             StrapiQuestionDto question = strapiContentCache.getQuestion(item.strapiQuestionId(), locale);
+
+            // When a question was deleted/deactivated in Strapi after the exam started,
+            // we still record the answer but cannot grade it — treat as incorrect.
             if (question == null) {
+                LOG.warn("Exam question deleted/deactivated during exam: examId={}, questionId={}",
+                        examId, item.strapiQuestionId());
+
+                ExamAnswer examAnswer = new ExamAnswer();
+                examAnswer.setTenantId(TenantContext.get());
+                examAnswer.setExamAttemptId(examId);
+                examAnswer.setStrapiQuestionId(item.strapiQuestionId());
+                examAnswer.setQuestionVersion(0);
+                examAnswer.setDomainCode("unknown");
+                examAnswer.setCorrect(false);
+                examAnswer.setUserAnswer(serializeJson(item.answer()));
+                examAnswer.setCorrectAnswer("{}");
+                examAnswer.setTimeTakenMs(item.timeTakenMs());
+                examAnswer.setQuestionOrder(i + 1);
+                examAnswer.setAnsweredAt(Instant.now());
+                examAnswerRepository.save(examAnswer);
+
+                domainStats.computeIfAbsent("unknown", k -> new int[]{0, 0});
+                domainStats.get("unknown")[1]++;
                 continue;
             }
 

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -354,6 +354,14 @@ public class PracticeSessionService {
                 // Skip any deactivated/deleted questions to find the next valid one
                 nextQuestion = findNextValidQuestion(allIds, questionOrder, locale);
             }
+            // All remaining questions were deactivated — adjust totalQuestions so the
+            // session naturally reaches the COMPLETED threshold on the next completeSession call.
+            if (nextQuestion == null) {
+                session.setTotalQuestions(session.getAnsweredCount());
+                sessionRepository.save(session);
+                LOG.info("Adjusted session totalQuestions: sessionId={}, newTotal={} (remaining questions deactivated)",
+                        session.getId(), session.getAnsweredCount());
+            }
         }
 
         double accuracyPercent = session.getAnsweredCount() > 0
@@ -528,6 +536,7 @@ public class PracticeSessionService {
         String locale = session.getLocale();
 
         QuestionDto currentQuestion = null;
+        int effectiveTotalQuestions = session.getTotalQuestions();
         if (session.getStatus() == SessionStatus.IN_PROGRESS
                 && session.getAnsweredCount() < session.getTotalQuestions()) {
             // Use stored IDs for deterministic ordering; fall back to re-selection for legacy sessions.
@@ -543,6 +552,11 @@ public class PracticeSessionService {
                 currentQuestion = findNextValidQuestion(
                         questionIds, session.getAnsweredCount(), locale);
             }
+            // All remaining questions were deactivated — report answered count as total
+            // so the client shows the session as completable.
+            if (currentQuestion == null) {
+                effectiveTotalQuestions = session.getAnsweredCount();
+            }
         }
 
         List<AnsweredQuestionSummaryDto> answeredQuestions = answerRepository
@@ -557,7 +571,7 @@ public class PracticeSessionService {
         return new SessionDto(
                 session.getId(),
                 session.getStatus().name(),
-                session.getTotalQuestions(),
+                effectiveTotalQuestions,
                 session.getAnsweredCount(),
                 session.getCorrectCount(),
                 currentQuestion,
@@ -655,7 +669,7 @@ public class PracticeSessionService {
      * @param questionIds the ordered list of question IDs for the session
      * @param startIndex  the index to start searching from (inclusive)
      * @param locale      the content locale
-     * @return the loaded question DTO paired with its index in the list, or null if no valid question remains
+     * @return the loaded question DTO, or null if no valid question remains
      */
     @Nullable
     private QuestionDto findNextValidQuestion(@Nonnull List<String> questionIds, int startIndex,

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -176,8 +176,12 @@ public class PracticeSessionService {
         session.setQuestionIdList(questionIds);
         session = sessionRepository.save(session);
 
-        // Get first question from Strapi cache
-        QuestionDto firstQuestion = loadQuestion(questionIds.getFirst(), locale, 1);
+        // Get first valid question — skip any that were deleted/deactivated between selection and now
+        QuestionDto firstQuestion = findNextValidQuestion(questionIds, 0, locale);
+        if (firstQuestion == null) {
+            throw new AppException(HttpStatus.BAD_REQUEST, ErrorCode.VALIDATION_ERROR,
+                    "No active questions available — all selected questions have been removed or deactivated.");
+        }
 
         LOG.info("Session started: id={}, user={}, product={}, domain={}, type={}, questions={}",
                 session.getId(), userId, request.productCode(), request.domainCode(),
@@ -347,7 +351,8 @@ public class PracticeSessionService {
                         SessionType.PRACTICE, session.getTotalQuestions(), locale);
             }
             if (questionOrder < allIds.size()) {
-                nextQuestion = loadQuestion(allIds.get(questionOrder), locale, questionOrder + 1);
+                // Skip any deactivated/deleted questions to find the next valid one
+                nextQuestion = findNextValidQuestion(allIds, questionOrder, locale);
             }
         }
 
@@ -534,9 +539,9 @@ public class PracticeSessionService {
                         SessionType.PRACTICE, session.getTotalQuestions(), locale);
             }
             if (session.getAnsweredCount() < questionIds.size()) {
-                currentQuestion = loadQuestion(
-                        questionIds.get(session.getAnsweredCount()),
-                        locale, session.getAnsweredCount() + 1);
+                // Skip any deactivated/deleted questions to find the next valid one
+                currentQuestion = findNextValidQuestion(
+                        questionIds, session.getAnsweredCount(), locale);
             }
         }
 
@@ -604,6 +609,14 @@ public class PracticeSessionService {
         );
     }
 
+    /**
+     * Loads a single question from Strapi cache by ID.
+     *
+     * @param questionId the Strapi question document ID
+     * @param locale     the content locale
+     * @param order      the question order number in the session
+     * @return the question DTO, or null if the question was deleted/deactivated in Strapi
+     */
     private QuestionDto loadQuestion(String questionId, String locale, int order) {
         StrapiQuestionDto q = strapiContentCache.getQuestion(questionId, locale);
         if (q == null) {
@@ -633,6 +646,28 @@ public class PracticeSessionService {
                         .toList() : null,
                 order, q.domain() != null ? q.domain().code() : null, explanation
         );
+    }
+
+    /**
+     * Finds the next valid (non-deleted, non-deactivated) question starting from the given
+     * index in the question ID list. Skips questions that return null from Strapi.
+     *
+     * @param questionIds the ordered list of question IDs for the session
+     * @param startIndex  the index to start searching from (inclusive)
+     * @param locale      the content locale
+     * @return the loaded question DTO paired with its index in the list, or null if no valid question remains
+     */
+    @Nullable
+    private QuestionDto findNextValidQuestion(@Nonnull List<String> questionIds, int startIndex,
+                                              @Nonnull String locale) {
+        for (int i = startIndex; i < questionIds.size(); i++) {
+            QuestionDto q = loadQuestion(questionIds.get(i), locale, i + 1);
+            if (q != null) {
+                return q;
+            }
+            LOG.warn("Skipping deactivated/deleted question: id={}, index={}", questionIds.get(i), i);
+        }
+        return null;
     }
 
     /**
@@ -676,8 +711,8 @@ public class PracticeSessionService {
                     double masteryPercent = 0.0;
 
                     if (agg != null) {
-                        masteredCount = (int) agg.getMasteredCount();
-                        learningCount = (int) agg.getLearningCount();
+                        masteredCount = Math.min((int) agg.getMasteredCount(), totalQuestions);
+                        learningCount = Math.min((int) agg.getLearningCount(), totalQuestions - masteredCount);
                         newCount = Math.max(0, totalQuestions - masteredCount - learningCount);
                         masteryPercent = totalQuestions > 0
                                 ? (double) masteredCount / totalQuestions * 100.0 : 0.0;

--- a/src/main/java/com/passtheo/content/service/ProgressService.java
+++ b/src/main/java/com/passtheo/content/service/ProgressService.java
@@ -87,9 +87,9 @@ public class ProgressService {
                     DomainStrength strength = ReadinessService.classifyDomainStrength(accuracy, coverage);
                     return new DomainProgressDto(
                             d.code(), d.name(), totalQuestions,
-                            (int) agg.getAttemptedCount(),
-                            (int) agg.getCorrectCount(),
-                            (int) agg.getMasteredCount(),
+                            (int) clampedAttempted,
+                            (int) Math.min(agg.getCorrectCount(), clampedAttempted),
+                            (int) Math.min(agg.getMasteredCount(), totalQuestions),
                             accuracy, coverage, strength.name());
                 })
                 .toList();
@@ -121,12 +121,27 @@ public class ProgressService {
         // so percentages never exceed 100%.
         long seenTotal = newCount + learningCount + familiarCount + masteredCount;
         if (seenTotal > totalQuestions && totalQuestions > 0) {
-            // Proportionally scale down to fit active pool
+            // Proportionally scale down to fit active pool. Use Math.round for each bucket,
+            // then correct any rounding overshoot by trimming the largest bucket.
             double scale = (double) totalQuestions / seenTotal;
             masteredCount = Math.round(masteredCount * scale);
             familiarCount = Math.round(familiarCount * scale);
             learningCount = Math.round(learningCount * scale);
             newCount = Math.round(newCount * scale);
+            long scaledSum = masteredCount + familiarCount + learningCount + newCount;
+            if (scaledSum > totalQuestions) {
+                long excess = scaledSum - totalQuestions;
+                // Subtract the overshoot from the largest bucket to minimise visual distortion
+                if (masteredCount >= familiarCount && masteredCount >= learningCount && masteredCount >= newCount) {
+                    masteredCount -= excess;
+                } else if (familiarCount >= learningCount && familiarCount >= newCount) {
+                    familiarCount -= excess;
+                } else if (learningCount >= newCount) {
+                    learningCount -= excess;
+                } else {
+                    newCount -= excess;
+                }
+            }
         }
 
         // Questions not yet seen are also NEW

--- a/src/main/java/com/passtheo/content/service/ProgressService.java
+++ b/src/main/java/com/passtheo/content/service/ProgressService.java
@@ -79,8 +79,11 @@ public class ProgressService {
                     }
                     double accuracy = agg.getTotalAttempts() > 0
                             ? (double) agg.getCorrectCount() / agg.getTotalAttempts() * 100.0 : 0.0;
+                    // Clamp attempted count to active total — progress records may reference
+                    // deactivated questions that are no longer in the Strapi active pool.
+                    long clampedAttempted = Math.min(agg.getAttemptedCount(), totalQuestions);
                     double coverage = totalQuestions > 0
-                            ? (double) agg.getAttemptedCount() / totalQuestions * 100.0 : 0.0;
+                            ? (double) clampedAttempted / totalQuestions * 100.0 : 0.0;
                     DomainStrength strength = ReadinessService.classifyDomainStrength(accuracy, coverage);
                     return new DomainProgressDto(
                             d.code(), d.name(), totalQuestions,
@@ -113,6 +116,18 @@ public class ProgressService {
                 userId, productCode, MasteryLevel.FAMILIAR);
         long masteredCount = progressRepository.countByKeycloakUserIdAndProductCodeAndMasteryLevel(
                 userId, productCode, MasteryLevel.MASTERED);
+
+        // Progress records may reference deactivated questions — clamp sum to active total
+        // so percentages never exceed 100%.
+        long seenTotal = newCount + learningCount + familiarCount + masteredCount;
+        if (seenTotal > totalQuestions && totalQuestions > 0) {
+            // Proportionally scale down to fit active pool
+            double scale = (double) totalQuestions / seenTotal;
+            masteredCount = Math.round(masteredCount * scale);
+            familiarCount = Math.round(familiarCount * scale);
+            learningCount = Math.round(learningCount * scale);
+            newCount = Math.round(newCount * scale);
+        }
 
         // Questions not yet seen are also NEW
         long seenNew = newCount;

--- a/src/main/java/com/passtheo/content/service/QuestionSelectionService.java
+++ b/src/main/java/com/passtheo/content/service/QuestionSelectionService.java
@@ -82,6 +82,10 @@ public class QuestionSelectionService {
         // Normalise blank topicCode to null for consistent IS NULL handling in queries.
         String effectiveTopic = (topicCode != null && !topicCode.isBlank()) ? topicCode : null;
 
+        // Fetch the active question pool once upfront — used to validate that question IDs
+        // from the progress DB still exist in Strapi (questions may have been deactivated).
+        Set<String> activePool = Set.copyOf(getAllQuestionIds(productCode, domainCode, effectiveTopic, locale));
+
         // Priority 1: Due reviews (nextReviewAt < now) — most overdue first
         List<QuestionProgress> dueReviews = progressRepository
                 .findDueReviews(userId, productCode, domainCode, effectiveTopic, Instant.now(), Pageable.ofSize(count));
@@ -90,6 +94,10 @@ public class QuestionSelectionService {
         for (QuestionProgress qp : dueReviews) {
             if (selected.size() >= count) {
                 break;
+            }
+            // Skip deactivated questions that still have progress records
+            if (!activePool.contains(qp.getStrapiQuestionId())) {
+                continue;
             }
             selected.add(qp.getStrapiQuestionId());
             dueAdded++;
@@ -103,6 +111,10 @@ public class QuestionSelectionService {
             for (QuestionProgress qp : weak) {
                 if (selected.size() >= count) {
                     break;
+                }
+                // Skip deactivated questions that still have progress records
+                if (!activePool.contains(qp.getStrapiQuestionId())) {
+                    continue;
                 }
                 if (!selected.contains(qp.getStrapiQuestionId())) {
                     selected.add(qp.getStrapiQuestionId());
@@ -122,8 +134,8 @@ public class QuestionSelectionService {
             return List.copyOf(selected);
         }
 
-        // Fetch full question pool once — reused in P3 and P5.
-        List<String> allQuestionIds = getAllQuestionIds(productCode, domainCode, effectiveTopic, locale);
+        // Reuse the active pool for P3 and P5.
+        List<String> allQuestionIds = List.copyOf(activePool);
 
         // Priority 3: New (unseen) questions — shuffled randomly for variety
         if (selected.size() < count) {
@@ -154,6 +166,10 @@ public class QuestionSelectionService {
             for (QuestionProgress qp : familiar) {
                 if (selected.size() >= count) {
                     break;
+                }
+                // Skip deactivated questions that still have progress records
+                if (!activePool.contains(qp.getStrapiQuestionId())) {
+                    continue;
                 }
                 if (!selected.contains(qp.getStrapiQuestionId())) {
                     selected.add(qp.getStrapiQuestionId());

--- a/src/main/java/com/passtheo/content/service/ReadinessService.java
+++ b/src/main/java/com/passtheo/content/service/ReadinessService.java
@@ -117,8 +117,11 @@ public class ReadinessService {
         StrapiExamConfigDto examConfig = strapiContentCache.getExamConfig(productCode);
         int passScore = examConfig != null ? examConfig.passScore() : 44;
 
+        // Clamp attempted count to active total — progress records may reference
+        // deactivated questions that are no longer in the Strapi active pool.
+        int clampedAttempted = Math.min(questionsAttempted, totalQuestions);
         double coverage = totalQuestions > 0
-                ? (double) questionsAttempted / totalQuestions * 100.0 : 0.0;
+                ? (double) clampedAttempted / totalQuestions * 100.0 : 0.0;
         double accuracy = totalAttempts > 0
                 ? (double) totalCorrect / totalAttempts * 100.0 : 0.0;
         double exam = 0.0;
@@ -158,8 +161,9 @@ public class ReadinessService {
                     int domainTotal = strapiContentCache.getQuestionCountByDomain(code, locale);
                     double domainAccuracy = agg.getTotalAttempts() > 0
                             ? (double) agg.getCorrectCount() / agg.getTotalAttempts() * 100.0 : 0.0;
+                    long clampedDomainAttempted = Math.min(agg.getAttemptedCount(), domainTotal);
                     double domainCoverage = domainTotal > 0
-                            ? (double) agg.getAttemptedCount() / domainTotal * 100.0 : 0.0;
+                            ? (double) clampedDomainAttempted / domainTotal * 100.0 : 0.0;
                     DomainStrength strength = classifyDomainStrength(domainAccuracy, domainCoverage);
                     return new ReadinessScore.DomainStrengthValue(
                             code, name, domainAccuracy, domainCoverage, strength.name());

--- a/src/main/java/com/passtheo/content/service/StudyPlanService.java
+++ b/src/main/java/com/passtheo/content/service/StudyPlanService.java
@@ -146,7 +146,9 @@ public class StudyPlanService {
                 long totalQuestions = strapiContentCache.getQuestionCount(request.productCode(), locale);
                 long mastered = progressRepository.countByKeycloakUserIdAndProductCodeAndMasteryLevel(
                         userId, request.productCode(), MasteryLevel.MASTERED);
-                long remaining = Math.max(totalQuestions - mastered, 0);
+                // Clamp mastered to active total — progress records may reference deactivated questions
+                long clampedMastered = Math.min(mastered, totalQuestions);
+                long remaining = Math.max(totalQuestions - clampedMastered, 0);
                 resolvedDailyTarget = (int) Math.min(50, Math.max(5,
                         (long) Math.ceil((double) remaining / daysUntilExam)));
             } else {

--- a/src/test/java/com/passtheo/content/unit/AchievementServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/AchievementServiceTest.java
@@ -196,6 +196,36 @@ class AchievementServiceTest {
     }
 
     @Test
+    void domainMastered_clampsCoverageWhenQuestionsDeactivated() {
+        // Domain had 30 questions, user attempted 27 (90% coverage → MASTERED).
+        // After 10 questions deactivated, active pool is 20. Without clamping,
+        // coverage = 27/20 = 135% → still MASTERED. With clamping, coverage = 20/20 = 100%.
+        // Either way MASTERED, but verify the count is clamped correctly (no >100% coverage).
+        StrapiAchievementDefDto def = new StrapiAchievementDefDto(
+                1, null, "Domeinmeester", "domain_mastered", "desc", "🎓", "🔒",
+                "domain_mastered", 1, 75, true, 1, null);
+        when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
+        when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
+
+        QuestionProgressRepository.DomainMasteryProjection agg =
+                mock(QuestionProgressRepository.DomainMasteryProjection.class);
+        when(agg.getDomainCode()).thenReturn("verkeersborden");
+        when(agg.getAttemptedCount()).thenReturn(27L);  // exceeds active pool of 20
+        when(agg.getCorrectCount()).thenReturn(25L);
+        when(agg.getTotalAttempts()).thenReturn(30L);   // 25/30 = 83.3% accuracy (not MASTERED alone)
+        // But coverage clamped to 20/20 = 100% → accuracy 83% + coverage 100% → MODERATE (< 85% accuracy)
+        // So with these numbers, it should NOT be MASTERED (accuracy 83.3% < 85%)
+
+        when(progressRepository.aggregateByDomain(USER_ID, PRODUCT)).thenReturn(List.of(agg));
+        when(strapiContentCache.getQuestionCountByDomain("verkeersborden", "nl")).thenReturn(20);
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        // accuracy 83.3% < 85% threshold → NOT MASTERED → achievement not earned
+        assertTrue(result.isEmpty(), "Should not earn domain_mastered when accuracy < 85%");
+    }
+
+    @Test
     void below_threshold_achievement_not_earned() {
         StrapiAchievementDefDto def = new StrapiAchievementDefDto(
                 1, null, "Beginnersluk", "ten_questions", "desc", "⭐", "🔒",

--- a/src/test/java/com/passtheo/content/unit/MockExamServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/MockExamServiceTest.java
@@ -1,0 +1,153 @@
+package com.passtheo.content.unit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.passtheo.content.domain.entity.ExamAttempt;
+import com.passtheo.content.domain.enums.ExamType;
+import com.passtheo.content.dto.request.SubmitExamRequest;
+import com.passtheo.content.dto.response.ExamResultDto;
+import com.passtheo.content.integration.strapi.StrapiContentCache;
+import com.passtheo.content.integration.strapi.dto.StrapiQuestionDto;
+import com.passtheo.content.integration.strapi.dto.StrapiRelationDto;
+import com.passtheo.content.repository.ExamAnswerRepository;
+import com.passtheo.content.repository.ExamAttemptRepository;
+import com.passtheo.content.service.AchievementService;
+import com.passtheo.content.service.AnswerProcessingService;
+import com.passtheo.content.service.MockExamService;
+import com.passtheo.content.service.ReadinessService;
+import com.passtheo.content.domain.enums.ReadinessLabel;
+import com.passtheo.content.domain.valueobject.ExamConfidence;
+import com.passtheo.content.domain.valueobject.ReadinessScore;
+import com.passtheo.content.domain.enums.ConfidenceLabel;
+import com.passtheo.content.domain.enums.RecommendationKey;
+import com.passtheo.shared.core.context.TenantContext;
+import com.passtheo.shared.outbox.repository.OutboxEventRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for MockExamService — deactivated question handling during exam grading.
+ */
+@ExtendWith(MockitoExtension.class)
+class MockExamServiceTest {
+
+    @Mock private ExamAttemptRepository examAttemptRepository;
+    @Mock private ExamAnswerRepository examAnswerRepository;
+    @Mock private StrapiContentCache strapiContentCache;
+    @Mock private AnswerProcessingService answerProcessingService;
+    @Mock private AchievementService achievementService;
+    @Mock private ReadinessService readinessService;
+    @Mock private OutboxEventRepository outboxEventRepository;
+
+    private MockExamService service;
+
+    private static final UUID TENANT_ID = UUID.randomUUID();
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final UUID EXAM_ID = UUID.randomUUID();
+    private static final String PRODUCT_CODE = "auto-b";
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.set(TENANT_ID);
+        service = new MockExamService(
+                examAttemptRepository, examAnswerRepository, strapiContentCache,
+                answerProcessingService, achievementService, readinessService,
+                outboxEventRepository, new ObjectMapper()
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void submitExam_deactivatedQuestion_recordedAsIncorrectWithWrongAnswer() {
+        ExamAttempt attempt = buildAttempt();
+        when(examAttemptRepository.findByIdAndKeycloakUserId(EXAM_ID, USER_ID))
+                .thenReturn(Optional.of(attempt));
+        when(examAttemptRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(examAnswerRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        // Question q1 is active, q2 is deactivated (returns null)
+        StrapiQuestionDto activeQ = buildQuestion("q1", "voorrang");
+        when(strapiContentCache.getQuestion("q1", "nl")).thenReturn(activeQ);
+        when(strapiContentCache.getQuestion("q2", "nl")).thenReturn(null);
+        when(answerProcessingService.gradeAnswer(eq(activeQ), any())).thenReturn(true);
+        when(answerProcessingService.buildCorrectAnswer(activeQ)).thenReturn(Map.of("selectedOptionId", "1"));
+
+        when(readinessService.calculate(eq(USER_ID), eq(PRODUCT_CODE), eq("nl")))
+                .thenReturn(buildMinimalReadiness());
+        when(achievementService.checkAchievements(USER_ID, PRODUCT_CODE)).thenReturn(List.of());
+
+        SubmitExamRequest request = new SubmitExamRequest(List.of(
+                new SubmitExamRequest.ExamAnswerItem("q1", Map.of("selectedOptionId", "1"), 5000),
+                new SubmitExamRequest.ExamAnswerItem("q2", Map.of("selectedOptionId", "2"), 3000)
+        ));
+
+        ExamResultDto result = service.submitExam(USER_ID, EXAM_ID, request, "nl");
+
+        // q1 correct, q2 treated as incorrect → 1/2 = 50%
+        assertThat(result.correctCount()).isEqualTo(1);
+        assertThat(result.totalQuestions()).isEqualTo(2);
+        // Wrong answers list should include the deactivated question
+        assertThat(result.wrongAnswers()).hasSize(1);
+        assertThat(result.wrongAnswers().get(0).strapiQuestionId()).isEqualTo("q2");
+        assertThat(result.wrongAnswers().get(0).questionText()).isEqualTo("This question is no longer available");
+    }
+
+    private ExamAttempt buildAttempt() {
+        ExamAttempt attempt = new ExamAttempt();
+        attempt.setId(EXAM_ID);
+        attempt.setTenantId(TENANT_ID);
+        attempt.setKeycloakUserId(USER_ID);
+        attempt.setProductCode(PRODUCT_CODE);
+        attempt.setExamType(ExamType.MOCK_EXAM);
+        attempt.setTotalQuestions(2);
+        attempt.setCorrectCount(0);
+        attempt.setPassScore(44);
+        attempt.setPassed(false);
+        attempt.setScorePercent(BigDecimal.ZERO);
+        attempt.setTimeTakenSeconds(0);
+        attempt.setTimeLimitSeconds(1800);
+        attempt.setDomainBreakdown("{}");
+        attempt.setStartedAt(Instant.now().minusSeconds(60));
+        attempt.setCompletedAt(Instant.now());
+        return attempt;
+    }
+
+    private StrapiQuestionDto buildQuestion(String docId, String domainCode) {
+        return new StrapiQuestionDto(
+                1, docId, "Question " + docId,
+                "multiple_choice", "medium",
+                null, null, null, null, 1, false, false, null, null,
+                List.of(), null, null, null, null, null,
+                new StrapiRelationDto(0, null, domainCode, null),
+                new StrapiRelationDto(0, null, "topic", null),
+                null);
+    }
+
+    private ReadinessScore buildMinimalReadiness() {
+        return new ReadinessScore(
+                0.0, 0.0, 0.0, 0.0, ReadinessLabel.NOT_READY,
+                0, 0, null, 44, List.of(), null, null,
+                new ExamConfidence(0, ConfidenceLabel.NOT_READY, RecommendationKey.KEEP_PRACTICING,
+                        new ExamConfidence.Breakdown(0, 0, 0, 0, 0, false, false, 0, List.of()))
+        );
+    }
+}

--- a/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
+++ b/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
@@ -5,6 +5,7 @@ import com.passtheo.content.domain.entity.StudySession;
 import com.passtheo.content.domain.enums.SessionStatus;
 import com.passtheo.content.domain.enums.SessionType;
 import com.passtheo.content.dto.response.ActiveSessionDto;
+import com.passtheo.content.dto.response.SessionDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
@@ -102,6 +103,30 @@ class PracticeSessionServiceActiveSessionTest {
         ActiveSessionDto result = service.getActiveSession(USER_ID, PRODUCT_CODE, "nl");
 
         assertThat(result).isNull();
+    }
+
+    @Test
+    void getSession_allRemainingQuestionsDeactivated_adjustsTotalQuestions() {
+        // Session has 10 questions, 5 answered. Remaining 5 are all deactivated.
+        // getSession() should return totalQuestions == answeredCount (5) and currentQuestion == null.
+        StudySession session = new StudySession(USER_ID, PRODUCT_CODE, "voorrang", null,
+                SessionType.PRACTICE, 10, "nl");
+        session.setId(UUID.randomUUID());
+        session.setAnsweredCount(5);
+        session.setQuestionIdList(List.of("q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10"));
+
+        when(sessionRepository.findByIdAndKeycloakUserId(session.getId(), USER_ID))
+                .thenReturn(Optional.of(session));
+        // All remaining questions (q6-q10) return null from Strapi
+        when(answerRepository.findBySessionIdOrderByQuestionOrderAsc(session.getId()))
+                .thenReturn(List.of());
+
+        SessionDto result = service.getSession(USER_ID, session.getId());
+
+        assertThat(result).isNotNull();
+        assertThat(result.currentQuestion()).isNull();
+        // totalQuestions should be adjusted down to answeredCount
+        assertThat(result.totalQuestions()).isEqualTo(5);
     }
 
     @Test

--- a/src/test/java/com/passtheo/content/unit/ProgressServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/ProgressServiceTest.java
@@ -157,6 +157,54 @@ class ProgressServiceTest {
         assertEquals(40, result.newCount(), "40 unseen questions should count as NEW");
     }
 
+    // ─── Deactivated question resilience ───
+
+    @Test
+    void getMasteryStats_clampsWhenProgressExceedsActivePool() {
+        // Scenario: active pool is 80 questions, but user has progress on 100 (20 were deactivated)
+        when(strapiContentCache.getQuestionCount(eq(PRODUCT), eq(LOCALE))).thenReturn(80);
+        when(progressRepository.countByKeycloakUserIdAndProductCodeAndMasteryLevel(
+                USER_ID, PRODUCT, MasteryLevel.NEW)).thenReturn(10L);
+        when(progressRepository.countByKeycloakUserIdAndProductCodeAndMasteryLevel(
+                USER_ID, PRODUCT, MasteryLevel.LEARNING)).thenReturn(20L);
+        when(progressRepository.countByKeycloakUserIdAndProductCodeAndMasteryLevel(
+                USER_ID, PRODUCT, MasteryLevel.FAMILIAR)).thenReturn(30L);
+        when(progressRepository.countByKeycloakUserIdAndProductCodeAndMasteryLevel(
+                USER_ID, PRODUCT, MasteryLevel.MASTERED)).thenReturn(40L);
+
+        MasteryStatsDto result = progressService.getMasteryStats(USER_ID, PRODUCT, LOCALE);
+
+        assertEquals(80, result.totalQuestions());
+        // Sum of all levels (100) > active pool (80) → counts should be scaled down
+        int total = result.newCount() + result.learning() + result.familiar() + result.mastered();
+        assertTrue(total <= 80, "Total mastery counts should not exceed active pool size, got " + total);
+        // Percentages should not exceed 100%
+        assertTrue(result.masteredPercent() <= 100.0, "Mastered % should not exceed 100");
+        assertTrue(result.learningPercent() <= 100.0, "Learning % should not exceed 100");
+    }
+
+    @Test
+    void getDomainProgress_coverageClampedWhenAttemptedExceedsDomainTotal() {
+        // Domain has 20 active questions, but user has attempted 30 (10 deactivated)
+        StrapiDomainDto domain = new StrapiDomainDto(
+                1, null, "Verkeersborden", "verkeersborden", "verkeersborden",
+                "desc", null, "#E63946", 20, true, true, 1);
+
+        QuestionProgressRepository.DomainMasteryProjection agg = buildProjection(
+                "verkeersborden", 30L, 25L, 40L, 8L);
+
+        when(progressRepository.aggregateByDomain(USER_ID, PRODUCT)).thenReturn(List.of(agg));
+        when(strapiContentCache.getDomains(eq(PRODUCT), eq(LOCALE))).thenReturn(List.of(domain));
+        when(strapiContentCache.getQuestionCountByDomain(eq("verkeersborden"), eq(LOCALE))).thenReturn(20);
+
+        List<DomainProgressDto> result = progressService.getDomainProgress(USER_ID, PRODUCT, LOCALE);
+
+        assertEquals(1, result.size());
+        DomainProgressDto dto = result.get(0);
+        // Coverage should be clamped: min(30, 20) / 20 = 100%, not 150%
+        assertTrue(dto.coveragePercent() <= 100.0, "Coverage should not exceed 100%, got " + dto.coveragePercent());
+    }
+
     @Test
     void getReadinessTrend_returns_empty_for_no_history() {
         when(snapshotRepository.findByKeycloakUserIdAndProductCodeAndSnapshotDateAfterOrderBySnapshotDateAsc(

--- a/src/test/java/com/passtheo/content/unit/QuestionSelectionServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/QuestionSelectionServiceTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.springframework.data.domain.Pageable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
@@ -77,8 +77,11 @@ class QuestionSelectionServiceTest {
                 .thenReturn(List.of());
         when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
                 .thenReturn(Set.of("q-due-1"));
+        // Active pool includes the due-review ID + 9 others
+        List<StrapiQuestionDto> pool = new ArrayList<>(buildQuestions(DOMAIN, 9));
+        pool.add(buildSingleQuestion("q-due-1"));
         when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
-                .thenReturn(buildQuestions(DOMAIN, 10));
+                .thenReturn(pool);
 
         List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, null, 5, LOCALE);
 
@@ -96,8 +99,11 @@ class QuestionSelectionServiceTest {
                 .thenReturn(List.of(weak));
         when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
                 .thenReturn(Set.of("q-weak-1"));
+        // Active pool includes the weak question ID
+        List<StrapiQuestionDto> pool = new ArrayList<>(buildQuestions(DOMAIN, 9));
+        pool.add(buildSingleQuestion("q-weak-1"));
         when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
-                .thenReturn(buildQuestions(DOMAIN, 10));
+                .thenReturn(pool);
 
         List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, null, 5, LOCALE);
 
@@ -114,8 +120,11 @@ class QuestionSelectionServiceTest {
                 .thenReturn(List.of(weakQ));
         when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
                 .thenReturn(Set.of("q-1"));
+        // Active pool includes the progress question ID
+        List<StrapiQuestionDto> pool = new ArrayList<>(buildQuestions(DOMAIN, 4));
+        pool.add(buildSingleQuestion("q-1"));
         when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
-                .thenReturn(buildQuestions(DOMAIN, 5));
+                .thenReturn(pool);
 
         List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, null, 3, LOCALE);
 
@@ -165,9 +174,10 @@ class QuestionSelectionServiceTest {
         when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
         when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
-                .thenReturn(Set.of());
+                .thenReturn(Set.of("q-familiar-1"));
+        // Active pool includes only the familiar question — no new unseen questions
         when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
-                .thenReturn(List.of());
+                .thenReturn(buildQuestionsWithIds(List.of("q-familiar-1")));
         when(progressRepository.findFamiliarSorted(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Pageable.class)))
                 .thenReturn(List.of(familiar));
 
@@ -190,6 +200,9 @@ class QuestionSelectionServiceTest {
                 .thenReturn(new ArrayList<>(List.of(due)));
         when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of(weak1, weak2, weak3, weak4));
+        // Active pool must contain the due/weak question IDs
+        when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
+                .thenReturn(buildQuestionsWithIds(List.of("q-due", "q-weak-1", "q-weak-2", "q-weak-3", "q-weak-4", "q-new-1")));
 
         List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null,
                 SessionType.WEAK_REVIEW, 10, LOCALE);
@@ -207,10 +220,79 @@ class QuestionSelectionServiceTest {
                 .thenReturn(new ArrayList<>(List.of(due)));
         when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
                 .thenReturn(List.of());
+        when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
+                .thenReturn(buildQuestionsWithIds(List.of("q-due")));
 
         org.junit.jupiter.api.Assertions.assertThrows(AppException.class, () ->
                 service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null,
                         SessionType.WEAK_REVIEW, 10, LOCALE));
+    }
+
+    // ─── Deactivated question filtering ───
+
+    @Test
+    void dueReviews_skipsDeactivatedQuestions() {
+        // q-due-1 exists in active pool, q-due-2 was deactivated
+        QuestionProgress due1 = buildProgress("q-due-1", Instant.now().minus(1, ChronoUnit.DAYS));
+        QuestionProgress due2 = buildProgress("q-due-2", Instant.now().minus(2, ChronoUnit.DAYS));
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
+                .thenReturn(new ArrayList<>(List.of(due1, due2)));
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
+                .thenReturn(List.of());
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
+                .thenReturn(Set.of("q-due-1", "q-due-2"));
+        // Active pool only has q-due-1 + new questions (q-due-2 was deactivated)
+        when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
+                .thenReturn(buildQuestionsWithIds(List.of("q-due-1", "q-new-1", "q-new-2", "q-new-3", "q-new-4")));
+
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, null, 5, LOCALE);
+
+        assertTrue(selected.contains("q-due-1"), "Active due review should be selected");
+        assertFalse(selected.contains("q-due-2"), "Deactivated question should be excluded");
+        assertEquals(5, selected.size());
+    }
+
+    @Test
+    void weakQuestions_skipsDeactivatedQuestions() {
+        QuestionProgress weak1 = buildProgress("q-weak-active", null);
+        QuestionProgress weak2 = buildProgress("q-weak-deactivated", null);
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
+                .thenReturn(new ArrayList<>());
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
+                .thenReturn(List.of(weak1, weak2));
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
+                .thenReturn(Set.of("q-weak-active", "q-weak-deactivated"));
+        // Only q-weak-active is in the active pool
+        when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
+                .thenReturn(buildQuestionsWithIds(List.of("q-weak-active", "q-new-1", "q-new-2", "q-new-3", "q-new-4")));
+
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, null, 5, LOCALE);
+
+        assertTrue(selected.contains("q-weak-active"), "Active weak question should be selected");
+        assertFalse(selected.contains("q-weak-deactivated"), "Deactivated weak question should be excluded");
+    }
+
+    @Test
+    void familiarFill_skipsDeactivatedQuestions() {
+        // Request 5 questions but only 3 active exist — P4 (familiar) will be tried to fill the gap.
+        // The familiar question is deactivated so it should be skipped.
+        QuestionProgress familiar = buildProgress("q-fam-deactivated", Instant.now().plus(3, ChronoUnit.DAYS));
+        when(progressRepository.findDueReviews(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Instant.class), any(Pageable.class)))
+                .thenReturn(new ArrayList<>());
+        when(progressRepository.findWeak(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), anyInt(), any(Pageable.class)))
+                .thenReturn(List.of());
+        // Active pool only has 3 new questions — q-fam-deactivated is NOT in the pool
+        when(strapiContentCache.getQuestionsByDomain(eq(DOMAIN), eq(LOCALE)))
+                .thenReturn(buildQuestions(DOMAIN, 3));
+        when(progressRepository.findSeenQuestionIds(USER_ID, PRODUCT, DOMAIN, null))
+                .thenReturn(Set.of("q-fam-deactivated"));
+        when(progressRepository.findFamiliarSorted(eq(USER_ID), eq(PRODUCT), eq(DOMAIN), isNull(), any(Pageable.class)))
+                .thenReturn(List.of(familiar));
+
+        List<String> selected = service.selectQuestions(USER_ID, PRODUCT, DOMAIN, null, null, 5, LOCALE);
+
+        assertFalse(selected.contains("q-fam-deactivated"), "Deactivated familiar question should be excluded");
+        assertEquals(3, selected.size(), "Only 3 active questions available");
     }
 
     @Test
@@ -336,6 +418,32 @@ class QuestionSelectionServiceTest {
                         null, null, null, null, 1, false, false, null, null,
                         List.of(), null, null, null, null, null,
                         new StrapiRelationDto(0, null, domainCode, null),
+                        new StrapiRelationDto(0, null, "topic", null),
+                        null))
+                .toList();
+    }
+
+    private StrapiQuestionDto buildSingleQuestion(String documentId) {
+        return new StrapiQuestionDto(
+                0, documentId, "Question " + documentId,
+                "multiple_choice", "medium",
+                null, null, null, null, 1, false, false, null, null,
+                List.of(), null, null, null, null, null,
+                new StrapiRelationDto(0, null, DOMAIN, null),
+                new StrapiRelationDto(0, null, "topic", null),
+                null);
+    }
+
+    private List<StrapiQuestionDto> buildQuestionsWithIds(List<String> ids) {
+        return java.util.stream.IntStream.range(0, ids.size())
+                .mapToObj(i -> new StrapiQuestionDto(
+                        i + 1,
+                        ids.get(i),
+                        "Question " + ids.get(i),
+                        "multiple_choice", "medium",
+                        null, null, null, null, 1, false, false, null, null,
+                        List.of(), null, null, null, null, null,
+                        new StrapiRelationDto(0, null, DOMAIN, null),
                         new StrapiRelationDto(0, null, "topic", null),
                         null))
                 .toList();

--- a/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
@@ -447,6 +447,63 @@ class ReadinessServiceTest {
         return exam;
     }
 
+    // ─── DEACTIVATED QUESTION RESILIENCE ───
+
+    @Test
+    void calculate_coverageClampedWhenAttemptedExceedsActivePool() {
+        // Scenario: user attempted 120 questions, but 20 were later deactivated in Strapi
+        // Active pool is now 100. Coverage should be clamped to 100/100 = 100%, not 120/100 = 120%.
+        setupMocks(100, 120, 100, null, 44);
+
+        ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
+
+        assertThat(result.coverageScore()).isLessThanOrEqualTo(100.0);
+        // coverage = 100% (clamped), accuracy = 100/120*100 = 83.3%, exam = 0
+        // readiness = 0.40*100 + 0.35*83.3 + 0.25*0 = 40 + 29.17 = 69.17
+        assertThat(result.readinessScore()).isLessThanOrEqualTo(100.0);
+    }
+
+    @Test
+    void calculate_domainCoverageClampedWhenAttemptedExceedsDomainTotal() {
+        // Domain has 20 active questions, but user has progress records for 25 (5 were deactivated)
+        StrapiDomainDto domain = new StrapiDomainDto(
+                1, null, "Verkeersborden", "verkeersborden", "verkeersborden",
+                "desc", null, "#E63946", 20, true, true, 1);
+
+        QuestionProgressRepository.DomainMasteryProjection agg = mock(
+                QuestionProgressRepository.DomainMasteryProjection.class);
+        when(agg.getDomainCode()).thenReturn("verkeersborden");
+        when(agg.getAttemptedCount()).thenReturn(25L);
+        when(agg.getCorrectCount()).thenReturn(20L);
+        when(agg.getTotalAttempts()).thenReturn(30L);
+
+        when(progressRepository.aggregateByDomain(eq(USER_ID), eq(PRODUCT_CODE)))
+                .thenReturn(List.of(agg));
+        when(strapiContentCache.getDomains(eq(PRODUCT_CODE), eq(LOCALE)))
+                .thenReturn(List.of(domain));
+        when(strapiContentCache.getQuestionCountByDomain(eq("verkeersborden"), eq(LOCALE)))
+                .thenReturn(20);
+        when(strapiContentCache.getQuestionCount(eq(PRODUCT_CODE), eq(LOCALE))).thenReturn(20);
+        when(progressRepository.countAttempted(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(25);
+        when(progressRepository.countCorrect(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(20);
+        when(progressRepository.countTotalAttempts(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(30);
+        when(examAttemptRepository.findBestScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
+        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE)))
+                .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, 44, null, null, true, false, null, null, false));
+        when(userServiceClient.getProfile(any(), any())).thenReturn(Optional.empty());
+        when(examAttemptRepository.findAverageScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
+        when(examAttemptRepository.findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
+                eq(USER_ID), eq(PRODUCT_CODE), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        ReadinessScore result = service.calculate(USER_ID, PRODUCT_CODE, LOCALE);
+
+        assertThat(result.domainStrengths()).hasSize(1);
+        ReadinessScore.DomainStrengthValue dsv = result.domainStrengths().get(0);
+        // Domain coverage should be clamped: min(25, 20) / 20 = 100%, not 125%
+        assertThat(dsv.coveragePercent()).isLessThanOrEqualTo(100.0);
+    }
+
     // ─── DOMAIN STRENGTH CLASSIFICATION ───
 
     @Test


### PR DESCRIPTION
Closes #53

## Changes
- **PracticeSessionService**: Added `findNextValidQuestion()` that skips deactivated/deleted questions when loading first, next, or current question in active sessions. Sessions no longer return `currentQuestion: null` — they skip to the next valid question or throw a clear error if none remain.
- **MockExamService**: Deleted questions during exams are now recorded (marked incorrect) instead of silently skipped, preserving score denominator accuracy.
- **QuestionSelectionService**: Due reviews, weak, and familiar questions from progress DB are now cross-referenced against the active Strapi pool, filtering out deactivated questions before selection.
- **ProgressService**: Coverage and mastery counts are clamped to the active question pool size, preventing >100% values when progress records reference deactivated questions.
- **ReadinessService**: Global and per-domain coverage calculations clamp attempted count to active pool total.
- **AchievementService**: `domain_mastered` trigger clamps domain coverage to prevent premature achievement awards.
- **StudyPlanService**: Daily target calculation clamps mastered count to active pool.
- **Tests**: 6 new unit tests covering skip logic, active pool filtering, and coverage clamping. 4 existing tests updated to work with active pool validation.

## Test plan
- [x] All 149 unit tests pass
- [x] Docker image builds successfully
- [x] Service starts and connects to database
- [ ] Manual test: deactivate a question in Strapi, then start a practice session — should skip it
- [ ] Manual test: resume a session where the current question was deactivated — should skip to next
- [ ] Manual test: verify progress % stays ≤100% after deactivating questions