### PR TITLE
feat(content): session breakdown with question snapshots, flagging, and error reporting

### DIFF
--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -593,6 +593,87 @@ paths:
                       icon: "https://cdn.passtheo.nl/achievements/studious.png"
                 timestamp: "2026-03-19T10:04:05Z"
 
+  /api/practice/sessions/{sessionId}/breakdown:
+    get:
+      operationId: getSessionBreakdown
+      tags: [Practice]
+      summary: Get full session breakdown for question-by-question review
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: '#/components/parameters/UserHeader'
+      responses:
+        '200':
+          description: Full session breakdown
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_SessionBreakdown'
+
+  /api/progress/questions/{strapiQuestionId}/flag:
+    post:
+      operationId: flagQuestion
+      tags: [Progress]
+      summary: Flag a question for extra practice
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: strapiQuestionId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/UserHeader'
+      responses:
+        '204':
+          description: Question flagged
+    delete:
+      operationId: unflagQuestion
+      tags: [Progress]
+      summary: Unflag a question
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: strapiQuestionId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/UserHeader'
+      responses:
+        '204':
+          description: Question unflagged
+
+  /api/content/questions/{strapiQuestionId}/report:
+    post:
+      operationId: reportQuestion
+      tags: [Content]
+      summary: Report an error in a question
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: strapiQuestionId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/UserHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuestionReportRequest'
+      responses:
+        '201':
+          description: Report submitted
+
   # ─── MOCK EXAMS ───
   /api/exams/mock/start:
     post:
@@ -1911,3 +1992,65 @@ components:
         includeExam: { type: boolean }
         status: { type: string, enum: [PENDING, IN_PROGRESS, COMPLETED, SKIPPED] }
         message: { type: string, nullable: true }
+
+    # ─── BREAKDOWN ───
+
+    ApiResponse_SessionBreakdown:
+      type: object
+      properties:
+        success: { type: boolean }
+        data:
+          $ref: '#/components/schemas/SessionBreakdownDto'
+        timestamp: { type: string, format: date-time }
+
+    SessionBreakdownDto:
+      type: object
+      properties:
+        sessionId: { type: string, format: uuid }
+        status: { type: string }
+        totalQuestions: { type: integer }
+        correctCount: { type: integer }
+        skippedCount: { type: integer }
+        accuracyPercent: { type: number, format: double }
+        timeSpentSeconds: { type: integer }
+        masteryChanges:
+          $ref: '#/components/schemas/MasteryChangesDto'
+        questions:
+          type: array
+          items:
+            $ref: '#/components/schemas/BreakdownQuestionDto'
+
+    MasteryChangesDto:
+      type: object
+      properties:
+        upgraded: { type: integer }
+        downgraded: { type: integer }
+        unchanged: { type: integer }
+
+    BreakdownQuestionDto:
+      type: object
+      properties:
+        questionOrder: { type: integer }
+        strapiQuestionId: { type: string }
+        interactionType: { type: string }
+        isCorrect: { type: boolean }
+        isSkipped: { type: boolean }
+        userAnswer: { type: object }
+        correctAnswer: { type: object }
+        questionSnapshot: { type: object }
+        domainCode: { type: string }
+        domainName: { type: string }
+        previousMasteryLevel: { type: string, enum: [NEW, LEARNING, FAMILIAR, MASTERED] }
+        newMasteryLevel: { type: string, enum: [NEW, LEARNING, FAMILIAR, MASTERED] }
+        isFlagged: { type: boolean }
+
+    QuestionReportRequest:
+      type: object
+      required: [reportType]
+      properties:
+        reportType:
+          type: string
+          enum: [INCORRECT_ANSWER, UNCLEAR_QUESTION, WRONG_IMAGE, WRONG_EXPLANATION, OTHER]
+        comment:
+          type: string
+          nullable: true

--- a/src/main/java/com/passtheo/content/controller/ContentController.java
+++ b/src/main/java/com/passtheo/content/controller/ContentController.java
@@ -1,8 +1,6 @@
 package com.passtheo.content.controller;
 
-import com.passtheo.content.domain.entity.QuestionReport;
 import com.passtheo.content.domain.enums.DomainStrength;
-import com.passtheo.content.domain.enums.ReportType;
 import com.passtheo.content.domain.valueobject.AccessGrant;
 import com.passtheo.content.dto.request.QuestionReportRequest;
 import com.passtheo.content.dto.response.CountryDto;
@@ -17,11 +15,10 @@ import com.passtheo.content.dto.response.TopicWithProgressDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.content.repository.QuestionProgressRepository;
-import com.passtheo.content.repository.QuestionReportRepository;
 import com.passtheo.content.service.EntitlementChecker;
 import com.passtheo.content.service.OnboardingCatalogService;
+import com.passtheo.content.service.PracticeSessionService;
 import com.passtheo.content.service.ReadinessService;
-import com.passtheo.shared.core.context.TenantContext;
 import com.passtheo.shared.core.dto.ApiResponse;
 import jakarta.annotation.Nonnull;
 import jakarta.validation.Valid;
@@ -57,29 +54,29 @@ public class ContentController {
 
     private final StrapiContentCache strapiContentCache;
     private final QuestionProgressRepository questionProgressRepository;
-    private final QuestionReportRepository questionReportRepository;
     private final EntitlementChecker entitlementChecker;
     private final OnboardingCatalogService onboardingCatalogService;
+    private final PracticeSessionService practiceSessionService;
 
     /**
      * Constructs the content controller.
      *
      * @param strapiContentCache         Strapi content cache
      * @param questionProgressRepository question progress repository
-     * @param questionReportRepository   question report repository
      * @param entitlementChecker         entitlement checker
      * @param onboardingCatalogService   onboarding catalog service
+     * @param practiceSessionService     practice session service (for report)
      */
     public ContentController(StrapiContentCache strapiContentCache,
                              QuestionProgressRepository questionProgressRepository,
-                             QuestionReportRepository questionReportRepository,
                              EntitlementChecker entitlementChecker,
-                             OnboardingCatalogService onboardingCatalogService) {
+                             OnboardingCatalogService onboardingCatalogService,
+                             PracticeSessionService practiceSessionService) {
         this.strapiContentCache = strapiContentCache;
         this.questionProgressRepository = questionProgressRepository;
-        this.questionReportRepository = questionReportRepository;
         this.entitlementChecker = entitlementChecker;
         this.onboardingCatalogService = onboardingCatalogService;
+        this.practiceSessionService = practiceSessionService;
     }
 
     /**
@@ -320,11 +317,7 @@ public class ContentController {
             @PathVariable @Nonnull String strapiQuestionId,
             @RequestBody @Valid @Nonnull QuestionReportRequest request) {
 
-        ReportType reportType = ReportType.valueOf(request.reportType());
-        QuestionReport report = new QuestionReport(
-                TenantContext.get(), userId, strapiQuestionId, reportType, request.comment());
-        questionReportRepository.save(report);
-        LOG.info("Question reported: user={}, question={}, type={}", userId, strapiQuestionId, reportType);
+        practiceSessionService.reportQuestion(userId, strapiQuestionId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null, MDC.get("traceId")));
     }
 

--- a/src/main/java/com/passtheo/content/controller/ContentController.java
+++ b/src/main/java/com/passtheo/content/controller/ContentController.java
@@ -1,7 +1,10 @@
 package com.passtheo.content.controller;
 
+import com.passtheo.content.domain.entity.QuestionReport;
 import com.passtheo.content.domain.enums.DomainStrength;
+import com.passtheo.content.domain.enums.ReportType;
 import com.passtheo.content.domain.valueobject.AccessGrant;
+import com.passtheo.content.dto.request.QuestionReportRequest;
 import com.passtheo.content.dto.response.CountryDto;
 import com.passtheo.content.dto.response.DomainWithProgressDto;
 import com.passtheo.content.dto.response.LessonDto;
@@ -14,16 +17,22 @@ import com.passtheo.content.dto.response.TopicWithProgressDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.content.repository.QuestionProgressRepository;
+import com.passtheo.content.repository.QuestionReportRepository;
 import com.passtheo.content.service.EntitlementChecker;
 import com.passtheo.content.service.OnboardingCatalogService;
 import com.passtheo.content.service.ReadinessService;
+import com.passtheo.shared.core.context.TenantContext;
 import com.passtheo.shared.core.dto.ApiResponse;
 import jakarta.annotation.Nonnull;
+import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,6 +57,7 @@ public class ContentController {
 
     private final StrapiContentCache strapiContentCache;
     private final QuestionProgressRepository questionProgressRepository;
+    private final QuestionReportRepository questionReportRepository;
     private final EntitlementChecker entitlementChecker;
     private final OnboardingCatalogService onboardingCatalogService;
 
@@ -56,15 +66,18 @@ public class ContentController {
      *
      * @param strapiContentCache         Strapi content cache
      * @param questionProgressRepository question progress repository
+     * @param questionReportRepository   question report repository
      * @param entitlementChecker         entitlement checker
      * @param onboardingCatalogService   onboarding catalog service
      */
     public ContentController(StrapiContentCache strapiContentCache,
                              QuestionProgressRepository questionProgressRepository,
+                             QuestionReportRepository questionReportRepository,
                              EntitlementChecker entitlementChecker,
                              OnboardingCatalogService onboardingCatalogService) {
         this.strapiContentCache = strapiContentCache;
         this.questionProgressRepository = questionProgressRepository;
+        this.questionReportRepository = questionReportRepository;
         this.entitlementChecker = entitlementChecker;
         this.onboardingCatalogService = onboardingCatalogService;
     }
@@ -291,6 +304,28 @@ public class ContentController {
             @PathVariable @Nonnull String topicCode,
             @RequestParam(defaultValue = "nl") String locale) {
         return ResponseEntity.ok(ApiResponse.success(buildLessonDtos(topicCode, locale), MDC.get("traceId")));
+    }
+
+    /**
+     * Reports an error in a question.
+     *
+     * @param userId           user ID from header
+     * @param strapiQuestionId the Strapi question document ID
+     * @param request          the report details
+     * @return 201 Created
+     */
+    @PostMapping("/questions/{strapiQuestionId}/report")
+    public ResponseEntity<ApiResponse<Void>> reportQuestion(
+            @RequestHeader("X-Keycloak-User-ID") UUID userId,
+            @PathVariable @Nonnull String strapiQuestionId,
+            @RequestBody @Valid @Nonnull QuestionReportRequest request) {
+
+        ReportType reportType = ReportType.valueOf(request.reportType());
+        QuestionReport report = new QuestionReport(
+                TenantContext.get(), userId, strapiQuestionId, reportType, request.comment());
+        questionReportRepository.save(report);
+        LOG.info("Question reported: user={}, question={}, type={}", userId, strapiQuestionId, reportType);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null, MDC.get("traceId")));
     }
 
     private List<LessonDto> buildLessonDtos(@Nonnull String topicCode, @Nonnull String locale) {

--- a/src/main/java/com/passtheo/content/controller/PracticeController.java
+++ b/src/main/java/com/passtheo/content/controller/PracticeController.java
@@ -4,6 +4,7 @@ import com.passtheo.content.dto.request.StartSessionRequest;
 import com.passtheo.content.dto.request.SubmitAnswerRequest;
 import com.passtheo.content.dto.response.ActiveSessionDto;
 import com.passtheo.content.dto.response.AnswerResultDto;
+import com.passtheo.content.dto.response.SessionBreakdownDto;
 import com.passtheo.content.dto.response.SessionDto;
 import com.passtheo.content.dto.response.SessionSummaryDto;
 import com.passtheo.content.integration.subscription.SubscriptionClient;
@@ -164,5 +165,21 @@ public class PracticeController {
 
         SessionSummaryDto summary = practiceSessionService.completeSession(userId, sessionId);
         return ResponseEntity.ok(ApiResponse.success(summary, MDC.get("traceId")));
+    }
+
+    /**
+     * Returns full session breakdown with per-question detail for review.
+     *
+     * @param sessionId the session ID
+     * @param userId    user ID from header
+     * @return session breakdown with all questions, answers, and explanations
+     */
+    @GetMapping("/{sessionId}/breakdown")
+    public ResponseEntity<ApiResponse<SessionBreakdownDto>> getSessionBreakdown(
+            @PathVariable @Nonnull UUID sessionId,
+            @RequestHeader("X-Keycloak-User-ID") UUID userId) {
+
+        SessionBreakdownDto breakdown = practiceSessionService.getSessionBreakdown(userId, sessionId);
+        return ResponseEntity.ok(ApiResponse.success(breakdown, MDC.get("traceId")));
     }
 }

--- a/src/main/java/com/passtheo/content/controller/ProgressController.java
+++ b/src/main/java/com/passtheo/content/controller/ProgressController.java
@@ -6,6 +6,7 @@ import com.passtheo.content.dto.response.DomainProgressDto;
 import com.passtheo.content.dto.response.MasteryStatsDto;
 import com.passtheo.content.dto.response.ReadinessDto;
 import com.passtheo.content.dto.response.ReadinessSnapshotDto;
+import com.passtheo.content.service.PracticeSessionService;
 import com.passtheo.content.service.ProgressService;
 import com.passtheo.content.service.ReadinessService;
 import com.passtheo.shared.core.dto.ApiResponse;
@@ -14,7 +15,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,16 +38,20 @@ public class ProgressController {
 
     private final ReadinessService readinessService;
     private final ProgressService progressService;
+    private final PracticeSessionService practiceSessionService;
 
     /**
      * Constructs the progress controller.
      *
-     * @param readinessService readiness score service
-     * @param progressService  progress aggregation service
+     * @param readinessService       readiness score service
+     * @param progressService        progress aggregation service
+     * @param practiceSessionService practice session service (for flag/unflag)
      */
-    public ProgressController(ReadinessService readinessService, ProgressService progressService) {
+    public ProgressController(ReadinessService readinessService, ProgressService progressService,
+                              PracticeSessionService practiceSessionService) {
         this.readinessService = readinessService;
         this.progressService = progressService;
+        this.practiceSessionService = practiceSessionService;
     }
 
     /**
@@ -134,5 +142,37 @@ public class ProgressController {
 
         MasteryStatsDto stats = progressService.getMasteryStats(userId, productCode, locale);
         return ResponseEntity.ok(ApiResponse.success(stats, MDC.get("traceId")));
+    }
+
+    /**
+     * Flags a question for extra practice.
+     *
+     * @param userId           user ID from header
+     * @param strapiQuestionId the Strapi question document ID
+     * @return 204 No Content
+     */
+    @PostMapping("/questions/{strapiQuestionId}/flag")
+    public ResponseEntity<Void> flagQuestion(
+            @RequestHeader("X-Keycloak-User-ID") UUID userId,
+            @PathVariable @Nonnull String strapiQuestionId) {
+
+        practiceSessionService.flagQuestion(userId, strapiQuestionId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Unflags a question.
+     *
+     * @param userId           user ID from header
+     * @param strapiQuestionId the Strapi question document ID
+     * @return 204 No Content
+     */
+    @DeleteMapping("/questions/{strapiQuestionId}/flag")
+    public ResponseEntity<Void> unflagQuestion(
+            @RequestHeader("X-Keycloak-User-ID") UUID userId,
+            @PathVariable @Nonnull String strapiQuestionId) {
+
+        practiceSessionService.unflagQuestion(userId, strapiQuestionId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/passtheo/content/domain/entity/QuestionProgress.java
+++ b/src/main/java/com/passtheo/content/domain/entity/QuestionProgress.java
@@ -59,6 +59,9 @@ public class QuestionProgress extends BaseEntity {
     @Column(name = "interval_days", nullable = false)
     private int intervalDays;
 
+    @Column(name = "is_flagged", nullable = false)
+    private boolean flagged;
+
     protected QuestionProgress() {}
 
     /**
@@ -83,6 +86,7 @@ public class QuestionProgress extends BaseEntity {
         this.totalAttempts = 0;
         this.totalCorrect = 0;
         this.intervalDays = 0;
+        this.flagged = false;
     }
 
     public UUID getKeycloakUserId() { return keycloakUserId; }
@@ -111,4 +115,6 @@ public class QuestionProgress extends BaseEntity {
     public void setNextReviewAt(Instant nextReviewAt) { this.nextReviewAt = nextReviewAt; }
     public int getIntervalDays() { return intervalDays; }
     public void setIntervalDays(int intervalDays) { this.intervalDays = intervalDays; }
+    public boolean isFlagged() { return flagged; }
+    public void setFlagged(boolean flagged) { this.flagged = flagged; }
 }

--- a/src/main/java/com/passtheo/content/domain/entity/QuestionReport.java
+++ b/src/main/java/com/passtheo/content/domain/entity/QuestionReport.java
@@ -1,0 +1,79 @@
+package com.passtheo.content.domain.entity;
+
+import com.passtheo.content.domain.enums.ReportType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Records a user-reported error on a question.
+ */
+@Entity
+@Table(name = "question_reports")
+public class QuestionReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @Column(name = "keycloak_user_id", nullable = false)
+    private UUID keycloakUserId;
+
+    @Column(name = "strapi_question_id", nullable = false, length = 100)
+    private String strapiQuestionId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "report_type", nullable = false, length = 50)
+    private ReportType reportType;
+
+    @Column(name = "comment")
+    private String comment;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    protected QuestionReport() {}
+
+    /**
+     * Creates a new question report.
+     *
+     * @param tenantId         the tenant ID
+     * @param keycloakUserId   the user's Keycloak ID
+     * @param strapiQuestionId the Strapi question ID
+     * @param reportType       the type of report
+     * @param comment          optional user comment
+     */
+    public QuestionReport(UUID tenantId, UUID keycloakUserId, String strapiQuestionId,
+                          ReportType reportType, String comment) {
+        this.tenantId = tenantId;
+        this.keycloakUserId = keycloakUserId;
+        this.strapiQuestionId = strapiQuestionId;
+        this.reportType = reportType;
+        this.comment = comment;
+        this.createdAt = Instant.now();
+    }
+
+    public UUID getId() { return id; }
+    public UUID getTenantId() { return tenantId; }
+    public void setTenantId(UUID tenantId) { this.tenantId = tenantId; }
+    public UUID getKeycloakUserId() { return keycloakUserId; }
+    public void setKeycloakUserId(UUID keycloakUserId) { this.keycloakUserId = keycloakUserId; }
+    public String getStrapiQuestionId() { return strapiQuestionId; }
+    public void setStrapiQuestionId(String strapiQuestionId) { this.strapiQuestionId = strapiQuestionId; }
+    public ReportType getReportType() { return reportType; }
+    public void setReportType(ReportType reportType) { this.reportType = reportType; }
+    public String getComment() { return comment; }
+    public void setComment(String comment) { this.comment = comment; }
+    public Instant getCreatedAt() { return createdAt; }
+}

--- a/src/main/java/com/passtheo/content/domain/entity/SessionAnswer.java
+++ b/src/main/java/com/passtheo/content/domain/entity/SessionAnswer.java
@@ -52,6 +52,22 @@ public class SessionAnswer extends BaseEntity {
     @Column(name = "answered_at", nullable = false)
     private Instant answeredAt;
 
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "question_snapshot", columnDefinition = "jsonb")
+    private String questionSnapshot;
+
+    @Column(name = "previous_mastery_level", length = 20)
+    private String previousMasteryLevel;
+
+    @Column(name = "new_mastery_level", length = 20)
+    private String newMasteryLevel;
+
+    @Column(name = "domain_code", length = 100)
+    private String domainCode;
+
+    @Column(name = "domain_name")
+    private String domainName;
+
     protected SessionAnswer() {}
 
     /**
@@ -106,4 +122,14 @@ public class SessionAnswer extends BaseEntity {
     public void setQuestionOrder(int questionOrder) { this.questionOrder = questionOrder; }
     public Instant getAnsweredAt() { return answeredAt; }
     public void setAnsweredAt(Instant answeredAt) { this.answeredAt = answeredAt; }
+    public String getQuestionSnapshot() { return questionSnapshot; }
+    public void setQuestionSnapshot(String questionSnapshot) { this.questionSnapshot = questionSnapshot; }
+    public String getPreviousMasteryLevel() { return previousMasteryLevel; }
+    public void setPreviousMasteryLevel(String previousMasteryLevel) { this.previousMasteryLevel = previousMasteryLevel; }
+    public String getNewMasteryLevel() { return newMasteryLevel; }
+    public void setNewMasteryLevel(String newMasteryLevel) { this.newMasteryLevel = newMasteryLevel; }
+    public String getDomainCode() { return domainCode; }
+    public void setDomainCode(String domainCode) { this.domainCode = domainCode; }
+    public String getDomainName() { return domainName; }
+    public void setDomainName(String domainName) { this.domainName = domainName; }
 }

--- a/src/main/java/com/passtheo/content/domain/enums/ReportType.java
+++ b/src/main/java/com/passtheo/content/domain/enums/ReportType.java
@@ -1,0 +1,12 @@
+package com.passtheo.content.domain.enums;
+
+/**
+ * Types of errors users can report on questions.
+ */
+public enum ReportType {
+    INCORRECT_ANSWER,
+    UNCLEAR_QUESTION,
+    WRONG_IMAGE,
+    WRONG_EXPLANATION,
+    OTHER
+}

--- a/src/main/java/com/passtheo/content/dto/request/QuestionReportRequest.java
+++ b/src/main/java/com/passtheo/content/dto/request/QuestionReportRequest.java
@@ -1,0 +1,11 @@
+package com.passtheo.content.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request to report an error in a question.
+ */
+public record QuestionReportRequest(
+    @NotBlank String reportType,
+    String comment
+) {}

--- a/src/main/java/com/passtheo/content/dto/request/QuestionReportRequest.java
+++ b/src/main/java/com/passtheo/content/dto/request/QuestionReportRequest.java
@@ -1,11 +1,12 @@
 package com.passtheo.content.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import com.passtheo.content.domain.enums.ReportType;
+import jakarta.annotation.Nonnull;
 
 /**
  * Request to report an error in a question.
  */
 public record QuestionReportRequest(
-    @NotBlank String reportType,
+    @Nonnull ReportType reportType,
     String comment
 ) {}

--- a/src/main/java/com/passtheo/content/dto/response/BreakdownQuestionDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/BreakdownQuestionDto.java
@@ -1,0 +1,22 @@
+package com.passtheo.content.dto.response;
+
+import java.util.Map;
+
+/**
+ * Per-question detail in the session breakdown.
+ */
+public record BreakdownQuestionDto(
+    int questionOrder,
+    String strapiQuestionId,
+    String interactionType,
+    boolean isCorrect,
+    boolean isSkipped,
+    Map<String, Object> userAnswer,
+    Map<String, Object> correctAnswer,
+    Map<String, Object> questionSnapshot,
+    String domainCode,
+    String domainName,
+    String previousMasteryLevel,
+    String newMasteryLevel,
+    boolean isFlagged
+) {}

--- a/src/main/java/com/passtheo/content/dto/response/SessionBreakdownDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/SessionBreakdownDto.java
@@ -1,0 +1,19 @@
+package com.passtheo.content.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Full session breakdown response for question-by-question review.
+ */
+public record SessionBreakdownDto(
+    UUID sessionId,
+    String status,
+    int totalQuestions,
+    int correctCount,
+    int skippedCount,
+    double accuracyPercent,
+    int timeSpentSeconds,
+    SessionSummaryDto.MasteryChangesDto masteryChanges,
+    List<BreakdownQuestionDto> questions
+) {}

--- a/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
+++ b/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
@@ -320,6 +320,42 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
     int maxConsecutiveCorrect(@Param("userId") UUID keycloakUserId, @Param("productCode") String productCode);
 
     /**
+     * Finds user-flagged questions for a given product/domain scope.
+     * Used as Priority 0 in question selection.
+     *
+     * @param keycloakUserId the user's Keycloak ID
+     * @param productCode    the product code
+     * @param domainCode     the domain code (nullable for all domains)
+     * @param topicCode      the topic code (nullable)
+     * @return list of flagged question progress records
+     */
+    @Query("SELECT qp FROM QuestionProgress qp WHERE qp.keycloakUserId = :userId " +
+           "AND qp.productCode = :productCode " +
+           "AND (:domainCode IS NULL OR qp.domainCode = :domainCode) " +
+           "AND (:topicCode IS NULL OR qp.topicCode = :topicCode) " +
+           "AND qp.flagged = true " +
+           "ORDER BY qp.lastAnsweredAt ASC NULLS LAST")
+    List<QuestionProgress> findFlagged(
+            @Param("userId") UUID keycloakUserId,
+            @Param("productCode") String productCode,
+            @Param("domainCode") String domainCode,
+            @Param("topicCode") String topicCode,
+            Pageable pageable);
+
+    /**
+     * Finds flag status for multiple questions (for breakdown view).
+     *
+     * @param keycloakUserId    the user's Keycloak ID
+     * @param strapiQuestionIds the Strapi question IDs
+     * @return list of progress records that are flagged
+     */
+    @Query("SELECT qp FROM QuestionProgress qp WHERE qp.keycloakUserId = :userId " +
+           "AND qp.strapiQuestionId IN :questionIds AND qp.flagged = true")
+    List<QuestionProgress> findFlaggedByQuestionIds(
+            @Param("userId") UUID keycloakUserId,
+            @Param("questionIds") List<String> strapiQuestionIds);
+
+    /**
      * Deletes all progress for a user (GDPR).
      *
      * @param keycloakUserId the user's Keycloak ID

--- a/src/main/java/com/passtheo/content/repository/QuestionReportRepository.java
+++ b/src/main/java/com/passtheo/content/repository/QuestionReportRepository.java
@@ -1,0 +1,14 @@
+package com.passtheo.content.repository;
+
+import com.passtheo.content.domain.entity.QuestionReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+/**
+ * Repository for QuestionReport entities.
+ */
+@Repository
+public interface QuestionReportRepository extends JpaRepository<QuestionReport, UUID> {
+}

--- a/src/main/java/com/passtheo/content/service/AnswerProcessingService.java
+++ b/src/main/java/com/passtheo/content/service/AnswerProcessingService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -296,6 +297,82 @@ public class AnswerProcessingService {
                 .toList();
         return selectedIds.size() == correctIds.size()
                 && selectedIds.containsAll(correctIds);
+    }
+
+    /**
+     * Builds a question snapshot map for storage in session_answers.
+     * Contains all data needed to render the question in review mode without re-fetching from Strapi.
+     *
+     * @param question the Strapi question data
+     * @return snapshot map suitable for JSON serialization
+     */
+    public Map<String, Object> buildQuestionSnapshot(@Nonnull StrapiQuestionDto question) {
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        snapshot.put("questionText", question.questionText());
+        snapshot.put("interactionType", question.interactionType());
+        snapshot.put("imageUrl", question.image() != null ? question.image().url() : null);
+        snapshot.put("videoUrl", question.videoUrl());
+
+        if (question.answerOptions() != null) {
+            snapshot.put("answerOptions", question.answerOptions().stream()
+                    .map(o -> Map.of(
+                            "id", String.valueOf(o.id()),
+                            "text", Objects.requireNonNullElse(o.text(), ""),
+                            "imageUrl", Objects.requireNonNullElse(o.image(), ""),
+                            "isCorrect", o.isCorrect(),
+                            "sortOrder", o.sortOrder()))
+                    .toList());
+        }
+
+        if (question.imageRegions() != null && !question.imageRegions().isEmpty()) {
+            snapshot.put("imageRegions", question.imageRegions().stream()
+                    .map(r -> Map.of(
+                            "id", String.valueOf(r.id()),
+                            "label", Objects.requireNonNullElse(r.label(), ""),
+                            "xPercent", r.xPercent(),
+                            "yPercent", r.yPercent(),
+                            "widthPercent", r.widthPercent(),
+                            "heightPercent", r.heightPercent(),
+                            "isCorrect", r.isCorrect(),
+                            "correctValue", Objects.requireNonNullElse(r.correctValue(), "")))
+                    .toList());
+        }
+
+        if (question.dragTargets() != null && !question.dragTargets().isEmpty()) {
+            snapshot.put("dragTargets", question.dragTargets().stream()
+                    .map(dt -> Map.of(
+                            "id", String.valueOf(dt.id()),
+                            "label", Objects.requireNonNullElse(dt.label(), ""),
+                            "correctValue", Objects.requireNonNullElse(dt.correctValue(), ""),
+                            "isCorrect", dt.isCorrect(),
+                            "sortOrder", dt.sortOrder(),
+                            "imageUrl", Objects.requireNonNullElse(dt.image(), "")))
+                    .toList());
+        }
+
+        if (question.explanation() != null) {
+            Map<String, Object> explanation = new LinkedHashMap<>();
+            explanation.put("text", question.explanation().text());
+            explanation.put("tip", question.explanation().tip());
+            explanation.put("legalReference", question.explanation().legalReference());
+            explanation.put("imageUrl", question.explanation().image());
+            snapshot.put("explanation", explanation);
+        }
+
+        if (question.correctBoolean() != null) {
+            snapshot.put("correctBoolean", question.correctBoolean());
+        }
+        if (question.correctNumber() != null) {
+            snapshot.put("correctNumber", question.correctNumber());
+            snapshot.put("correctNumberTolerance", question.correctNumberTolerance());
+        }
+
+        if (question.topic() != null) {
+            snapshot.put("topicCode", question.topic().code());
+            snapshot.put("topicName", question.topic().name());
+        }
+
+        return snapshot;
     }
 
     private void adjustEaseFactor(QuestionProgress progress, boolean isCorrect) {

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -20,8 +20,10 @@ import com.passtheo.content.dto.response.AnswerResultDto;
 import com.passtheo.content.domain.valueobject.AccessGrant;
 import com.passtheo.content.dto.response.AnsweredQuestionSummaryDto;
 import com.passtheo.content.dto.response.DomainSummaryDto;
+import com.passtheo.content.dto.response.BreakdownQuestionDto;
 import com.passtheo.content.dto.response.EarnedAchievementDto;
 import com.passtheo.content.dto.response.QuestionDto;
+import com.passtheo.content.dto.response.SessionBreakdownDto;
 import com.passtheo.content.dto.response.SessionDto;
 import com.passtheo.content.dto.response.SessionSummaryDto;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
@@ -291,6 +293,31 @@ public class PracticeSessionService {
                 userAnswerJson, serializeJson(correctAnswer),
                 request.timeTakenMs(), questionOrder);
         answer.setTenantId(TenantContext.get());
+
+        // Store question snapshot for breakdown review (avoids re-fetching from Strapi)
+        answer.setQuestionSnapshot(serializeJson(answerProcessingService.buildQuestionSnapshot(question)));
+        answer.setPreviousMasteryLevel(previousLevel.name());
+        answer.setNewMasteryLevel(progress.getMasteryLevel().name());
+        String resolvedDomainCode = question.domain() != null ? question.domain().code() : null;
+        if ((resolvedDomainCode == null || resolvedDomainCode.isBlank())
+                && question.topic() != null && question.topic().code() != null) {
+            resolvedDomainCode = strapiContentCache.getDomainCodeForTopic(
+                    question.topic().code(), session.getProductCode(), session.getLocale());
+        }
+        answer.setDomainCode(resolvedDomainCode);
+        String resolvedDomainName = question.domain() != null ? question.domain().name() : null;
+        if (resolvedDomainName == null && resolvedDomainCode != null) {
+            resolvedDomainName = resolveDomainName(resolvedDomainCode, session.getProductCode(), session.getLocale());
+        }
+        answer.setDomainName(resolvedDomainName);
+
+        // Auto-unflag: when a flagged question is answered correctly, remove the flag
+        if (isCorrect && progress.isFlagged()) {
+            progress.setFlagged(false);
+            progressRepository.save(progress);
+            LOG.debug("Auto-unflagged question: user={}, question={}", userId, request.strapiQuestionId());
+        }
+
         answerRepository.save(answer);
 
         // Publish question.answered outbox event
@@ -603,6 +630,9 @@ public class PracticeSessionService {
         List<EarnedAchievementDto> achievements = achievementService
                 .checkAchievements(userId, session.getProductCode());
 
+        // Compute actual mastery changes from session answers
+        SessionSummaryDto.MasteryChangesDto masteryChanges = computeMasteryChanges(sessionId);
+
         LOG.info("Session completed: id={}, user={}, correct={}/{}, accuracy={}%, timeSpentSec={}",
                 sessionId, userId, session.getCorrectCount(), session.getTotalQuestions(),
                 session.getAccuracyPercent(), session.getTimeSpentSeconds());
@@ -617,7 +647,7 @@ public class PracticeSessionService {
                 session.getCorrectCount(),
                 session.getAccuracyPercent() != null ? session.getAccuracyPercent().doubleValue() : 0.0,
                 session.getTimeSpentSeconds(),
-                new SessionSummaryDto.MasteryChangesDto(0, 0, 0),
+                masteryChanges,
                 new SessionSummaryDto.StreakUpdateDto(streak.currentStreak(), streak.isNewDay()),
                 achievements
         );
@@ -738,6 +768,163 @@ public class PracticeSessionService {
                             masteryPercent, isLocked);
                 })
                 .toList();
+    }
+
+    /**
+     * Returns a full session breakdown with per-question detail for review.
+     *
+     * @param userId    the user's Keycloak ID
+     * @param sessionId the session ID
+     * @return the breakdown with all questions, answers, snapshots, and flag status
+     */
+    @Transactional(readOnly = true)
+    @SuppressWarnings("unchecked")
+    public SessionBreakdownDto getSessionBreakdown(@Nonnull UUID userId, @Nonnull UUID sessionId) {
+        StudySession session = sessionRepository.findByIdAndKeycloakUserId(sessionId, userId)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR,
+                        "Session not found: " + sessionId));
+
+        List<SessionAnswer> answers = answerRepository.findBySessionIdOrderByQuestionOrderAsc(sessionId);
+
+        // Batch-load flag status for all questions in this session
+        List<String> questionIds = answers.stream()
+                .map(SessionAnswer::getStrapiQuestionId)
+                .toList();
+        java.util.Set<String> flaggedIds = progressRepository.findFlaggedByQuestionIds(userId, questionIds)
+                .stream()
+                .map(QuestionProgress::getStrapiQuestionId)
+                .collect(java.util.stream.Collectors.toSet());
+
+        int skippedCount = 0;
+        List<BreakdownQuestionDto> breakdownQuestions = new java.util.ArrayList<>();
+
+        for (SessionAnswer sa : answers) {
+            boolean isSkipped = SKIP_ANSWER_JSON.equals(sa.getUserAnswer());
+            if (isSkipped) {
+                skippedCount++;
+            }
+
+            Map<String, Object> userAnswer = isSkipped ? null : deserializeJson(sa.getUserAnswer());
+            Map<String, Object> correctAnswer = deserializeJson(sa.getCorrectAnswer());
+            Map<String, Object> snapshot = sa.getQuestionSnapshot() != null
+                    ? deserializeJson(sa.getQuestionSnapshot()) : Map.of();
+
+            breakdownQuestions.add(new BreakdownQuestionDto(
+                    sa.getQuestionOrder(),
+                    sa.getStrapiQuestionId(),
+                    sa.getInteractionType(),
+                    sa.isCorrect(),
+                    isSkipped,
+                    userAnswer,
+                    correctAnswer,
+                    snapshot,
+                    sa.getDomainCode(),
+                    sa.getDomainName(),
+                    sa.getPreviousMasteryLevel(),
+                    sa.getNewMasteryLevel(),
+                    flaggedIds.contains(sa.getStrapiQuestionId())
+            ));
+        }
+
+        SessionSummaryDto.MasteryChangesDto masteryChanges = computeMasteryChanges(sessionId);
+
+        return new SessionBreakdownDto(
+                session.getId(),
+                session.getStatus().name(),
+                session.getTotalQuestions(),
+                session.getCorrectCount(),
+                skippedCount,
+                session.getAccuracyPercent() != null ? session.getAccuracyPercent().doubleValue() : 0.0,
+                session.getTimeSpentSeconds(),
+                masteryChanges,
+                List.copyOf(breakdownQuestions)
+        );
+    }
+
+    /**
+     * Flags a question for extra practice.
+     *
+     * @param userId           the user's Keycloak ID
+     * @param strapiQuestionId the Strapi question ID
+     */
+    @Transactional
+    public void flagQuestion(@Nonnull UUID userId, @Nonnull String strapiQuestionId) {
+        QuestionProgress progress = progressRepository
+                .findByKeycloakUserIdAndStrapiQuestionId(userId, strapiQuestionId)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR,
+                        "No progress found for question: " + strapiQuestionId));
+        progress.setFlagged(true);
+        progressRepository.save(progress);
+        LOG.debug("Question flagged: user={}, question={}", userId, strapiQuestionId);
+    }
+
+    /**
+     * Unflags a question.
+     *
+     * @param userId           the user's Keycloak ID
+     * @param strapiQuestionId the Strapi question ID
+     */
+    @Transactional
+    public void unflagQuestion(@Nonnull UUID userId, @Nonnull String strapiQuestionId) {
+        QuestionProgress progress = progressRepository
+                .findByKeycloakUserIdAndStrapiQuestionId(userId, strapiQuestionId)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR,
+                        "No progress found for question: " + strapiQuestionId));
+        progress.setFlagged(false);
+        progressRepository.save(progress);
+        LOG.debug("Question unflagged: user={}, question={}", userId, strapiQuestionId);
+    }
+
+    /**
+     * Computes mastery level changes from session answer records.
+     */
+    private SessionSummaryDto.MasteryChangesDto computeMasteryChanges(UUID sessionId) {
+        List<SessionAnswer> answers = answerRepository.findBySessionIdOrderByQuestionOrderAsc(sessionId);
+        int upgraded = 0;
+        int downgraded = 0;
+        int unchanged = 0;
+
+        for (SessionAnswer sa : answers) {
+            String prev = sa.getPreviousMasteryLevel();
+            String next = sa.getNewMasteryLevel();
+            if (prev == null || next == null || prev.equals(next)) {
+                unchanged++;
+            } else {
+                int prevOrd = masteryOrdinal(prev);
+                int nextOrd = masteryOrdinal(next);
+                if (nextOrd > prevOrd) {
+                    upgraded++;
+                } else if (nextOrd < prevOrd) {
+                    downgraded++;
+                } else {
+                    unchanged++;
+                }
+            }
+        }
+        return new SessionSummaryDto.MasteryChangesDto(upgraded, downgraded, unchanged);
+    }
+
+    private int masteryOrdinal(String level) {
+        return switch (level) {
+            case "NEW" -> 0;
+            case "LEARNING" -> 1;
+            case "FAMILIAR" -> 2;
+            case "MASTERED" -> 3;
+            default -> -1;
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> deserializeJson(String json) {
+        if (json == null || json.isBlank() || "null".equals(json)) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(json, Map.class);
+        } catch (JsonProcessingException e) {
+            LOG.warn("Failed to deserialize JSON for breakdown: {}", e.getMessage());
+            return Map.of();
+        }
     }
 
     private String serializeJson(Object obj) {

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -20,6 +20,8 @@ import com.passtheo.content.dto.response.AnswerResultDto;
 import com.passtheo.content.domain.valueobject.AccessGrant;
 import com.passtheo.content.dto.response.AnsweredQuestionSummaryDto;
 import com.passtheo.content.dto.response.DomainSummaryDto;
+import com.passtheo.content.domain.entity.QuestionReport;
+import com.passtheo.content.dto.request.QuestionReportRequest;
 import com.passtheo.content.dto.response.BreakdownQuestionDto;
 import com.passtheo.content.dto.response.EarnedAchievementDto;
 import com.passtheo.content.dto.response.QuestionDto;
@@ -31,6 +33,7 @@ import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiQuestionDto;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
+import com.passtheo.content.repository.QuestionReportRepository;
 import com.passtheo.content.repository.SessionAnswerRepository;
 import com.passtheo.content.repository.StudyPlanDayRepository;
 import com.passtheo.content.repository.StudyPlanRepository;
@@ -53,10 +56,13 @@ import java.math.RoundingMode;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Manages practice session lifecycle: create, answer, resume, complete.
@@ -80,6 +86,7 @@ public class PracticeSessionService {
     private final StrapiContentCache strapiContentCache;
     private final StudyPlanRepository planRepository;
     private final StudyPlanDayRepository planDayRepository;
+    private final QuestionReportRepository questionReportRepository;
     private final OutboxEventRepository outboxEventRepository;
     private final ObjectMapper objectMapper;
 
@@ -96,6 +103,7 @@ public class PracticeSessionService {
      * @param strapiContentCache       Strapi content cache
      * @param planRepository           study plan repository for progress sync
      * @param planDayRepository        study plan day repository for progress sync
+     * @param questionReportRepository question report repository
      * @param outboxEventRepository    outbox event repository
      * @param objectMapper             JSON serializer
      */
@@ -109,6 +117,7 @@ public class PracticeSessionService {
                                   StrapiContentCache strapiContentCache,
                                   StudyPlanRepository planRepository,
                                   StudyPlanDayRepository planDayRepository,
+                                  QuestionReportRepository questionReportRepository,
                                   OutboxEventRepository outboxEventRepository,
                                   ObjectMapper objectMapper) {
         this.sessionRepository = sessionRepository;
@@ -121,6 +130,7 @@ public class PracticeSessionService {
         this.strapiContentCache = strapiContentCache;
         this.planRepository = planRepository;
         this.planDayRepository = planDayRepository;
+        this.questionReportRepository = questionReportRepository;
         this.outboxEventRepository = outboxEventRepository;
         this.objectMapper = objectMapper;
     }
@@ -298,23 +308,19 @@ public class PracticeSessionService {
         answer.setQuestionSnapshot(serializeJson(answerProcessingService.buildQuestionSnapshot(question)));
         answer.setPreviousMasteryLevel(previousLevel.name());
         answer.setNewMasteryLevel(progress.getMasteryLevel().name());
-        String resolvedDomainCode = question.domain() != null ? question.domain().code() : null;
-        if ((resolvedDomainCode == null || resolvedDomainCode.isBlank())
-                && question.topic() != null && question.topic().code() != null) {
-            resolvedDomainCode = strapiContentCache.getDomainCodeForTopic(
-                    question.topic().code(), session.getProductCode(), session.getLocale());
+        String domainCode = resolveDomainCode(question, session.getProductCode(), session.getLocale());
+        answer.setDomainCode(domainCode);
+        String domainNameVal = question.domain() != null ? question.domain().name() : null;
+        if (domainNameVal == null && domainCode != null) {
+            domainNameVal = resolveDomainName(domainCode, session.getProductCode(), session.getLocale());
         }
-        answer.setDomainCode(resolvedDomainCode);
-        String resolvedDomainName = question.domain() != null ? question.domain().name() : null;
-        if (resolvedDomainName == null && resolvedDomainCode != null) {
-            resolvedDomainName = resolveDomainName(resolvedDomainCode, session.getProductCode(), session.getLocale());
-        }
-        answer.setDomainName(resolvedDomainName);
+        answer.setDomainName(domainNameVal);
 
-        // Auto-unflag: when a flagged question is answered correctly, remove the flag
+        // Auto-unflag: when a flagged question is answered correctly, remove the flag.
+        // The progress entity is already managed within this transaction — dirty checking
+        // will flush the change at commit, no explicit save needed.
         if (isCorrect && progress.isFlagged()) {
             progress.setFlagged(false);
-            progressRepository.save(progress);
             LOG.debug("Auto-unflagged question: user={}, question={}", userId, request.strapiQuestionId());
         }
 
@@ -631,7 +637,8 @@ public class PracticeSessionService {
                 .checkAchievements(userId, session.getProductCode());
 
         // Compute actual mastery changes from session answers
-        SessionSummaryDto.MasteryChangesDto masteryChanges = computeMasteryChanges(sessionId);
+        List<SessionAnswer> sessionAnswers = answerRepository.findBySessionIdOrderByQuestionOrderAsc(sessionId);
+        SessionSummaryDto.MasteryChangesDto masteryChanges = computeMasteryChanges(sessionAnswers);
 
         LOG.info("Session completed: id={}, user={}, correct={}/{}, accuracy={}%, timeSpentSec={}",
                 sessionId, userId, session.getCorrectCount(), session.getTotalQuestions(),
@@ -778,7 +785,6 @@ public class PracticeSessionService {
      * @return the breakdown with all questions, answers, snapshots, and flag status
      */
     @Transactional(readOnly = true)
-    @SuppressWarnings("unchecked")
     public SessionBreakdownDto getSessionBreakdown(@Nonnull UUID userId, @Nonnull UUID sessionId) {
         StudySession session = sessionRepository.findByIdAndKeycloakUserId(sessionId, userId)
                 .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR,
@@ -790,13 +796,14 @@ public class PracticeSessionService {
         List<String> questionIds = answers.stream()
                 .map(SessionAnswer::getStrapiQuestionId)
                 .toList();
-        java.util.Set<String> flaggedIds = progressRepository.findFlaggedByQuestionIds(userId, questionIds)
-                .stream()
-                .map(QuestionProgress::getStrapiQuestionId)
-                .collect(java.util.stream.Collectors.toSet());
+        Set<String> flaggedIds = questionIds.isEmpty() ? Set.of()
+                : progressRepository.findFlaggedByQuestionIds(userId, questionIds)
+                        .stream()
+                        .map(QuestionProgress::getStrapiQuestionId)
+                        .collect(Collectors.toSet());
 
         int skippedCount = 0;
-        List<BreakdownQuestionDto> breakdownQuestions = new java.util.ArrayList<>();
+        List<BreakdownQuestionDto> breakdownQuestions = new ArrayList<>();
 
         for (SessionAnswer sa : answers) {
             boolean isSkipped = SKIP_ANSWER_JSON.equals(sa.getUserAnswer());
@@ -826,7 +833,7 @@ public class PracticeSessionService {
             ));
         }
 
-        SessionSummaryDto.MasteryChangesDto masteryChanges = computeMasteryChanges(sessionId);
+        SessionSummaryDto.MasteryChangesDto masteryChanges = computeMasteryChanges(answers);
 
         return new SessionBreakdownDto(
                 session.getId(),
@@ -876,10 +883,41 @@ public class PracticeSessionService {
     }
 
     /**
-     * Computes mastery level changes from session answer records.
+     * Reports an error in a question.
+     *
+     * @param userId           the user's Keycloak ID
+     * @param strapiQuestionId the Strapi question document ID
+     * @param request          the report request
      */
-    private SessionSummaryDto.MasteryChangesDto computeMasteryChanges(UUID sessionId) {
-        List<SessionAnswer> answers = answerRepository.findBySessionIdOrderByQuestionOrderAsc(sessionId);
+    @Transactional
+    public void reportQuestion(@Nonnull UUID userId, @Nonnull String strapiQuestionId,
+                               @Nonnull QuestionReportRequest request) {
+        QuestionReport report = new QuestionReport(
+                TenantContext.get(), userId, strapiQuestionId, request.reportType(), request.comment());
+        questionReportRepository.save(report);
+        LOG.info("Question reported: user={}, question={}, type={}", userId, strapiQuestionId, request.reportType());
+    }
+
+    /**
+     * Resolves the domain code for a question, falling back to the topic-to-domain mapping cache.
+     */
+    private String resolveDomainCode(StrapiQuestionDto question, String productCode, String locale) {
+        String domainCode = question.domain() != null ? question.domain().code() : null;
+        if ((domainCode == null || domainCode.isBlank())
+                && question.topic() != null && question.topic().code() != null) {
+            domainCode = strapiContentCache.getDomainCodeForTopic(
+                    question.topic().code(), productCode, locale);
+        }
+        return domainCode;
+    }
+
+    /**
+     * Computes mastery level changes from session answer records.
+     *
+     * @param answers the session answers (already loaded)
+     * @return aggregated mastery changes
+     */
+    private SessionSummaryDto.MasteryChangesDto computeMasteryChanges(List<SessionAnswer> answers) {
         int upgraded = 0;
         int downgraded = 0;
         int unchanged = 0;
@@ -890,28 +928,22 @@ public class PracticeSessionService {
             if (prev == null || next == null || prev.equals(next)) {
                 unchanged++;
             } else {
-                int prevOrd = masteryOrdinal(prev);
-                int nextOrd = masteryOrdinal(next);
-                if (nextOrd > prevOrd) {
-                    upgraded++;
-                } else if (nextOrd < prevOrd) {
-                    downgraded++;
-                } else {
+                try {
+                    MasteryLevel prevLevel = MasteryLevel.valueOf(prev);
+                    MasteryLevel nextLevel = MasteryLevel.valueOf(next);
+                    if (nextLevel.ordinal() > prevLevel.ordinal()) {
+                        upgraded++;
+                    } else if (nextLevel.ordinal() < prevLevel.ordinal()) {
+                        downgraded++;
+                    } else {
+                        unchanged++;
+                    }
+                } catch (IllegalArgumentException e) {
                     unchanged++;
                 }
             }
         }
         return new SessionSummaryDto.MasteryChangesDto(upgraded, downgraded, unchanged);
-    }
-
-    private int masteryOrdinal(String level) {
-        return switch (level) {
-            case "NEW" -> 0;
-            case "LEARNING" -> 1;
-            case "FAMILIAR" -> 2;
-            case "MASTERED" -> 3;
-            default -> -1;
-        };
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/passtheo/content/service/QuestionSelectionService.java
+++ b/src/main/java/com/passtheo/content/service/QuestionSelectionService.java
@@ -86,6 +86,22 @@ public class QuestionSelectionService {
         // from the progress DB still exist in Strapi (questions may have been deactivated).
         Set<String> activePool = Set.copyOf(getAllQuestionIds(productCode, domainCode, effectiveTopic, locale));
 
+        // Priority 0: User-flagged questions (highest priority — user explicitly wants to practice these)
+        int flaggedAdded = 0;
+        List<QuestionProgress> flagged = progressRepository
+                .findFlagged(userId, productCode, domainCode, effectiveTopic, Pageable.ofSize(count));
+        LOG.debug("Question selection P0 flagged: user={}, available={}", userId, flagged.size());
+        for (QuestionProgress qp : flagged) {
+            if (selected.size() >= count) {
+                break;
+            }
+            if (!activePool.contains(qp.getStrapiQuestionId())) {
+                continue;
+            }
+            selected.add(qp.getStrapiQuestionId());
+            flaggedAdded++;
+        }
+
         // Priority 1: Due reviews (nextReviewAt < now) — most overdue first
         List<QuestionProgress> dueReviews = progressRepository
                 .findDueReviews(userId, productCode, domainCode, effectiveTopic, Instant.now(), Pageable.ofSize(count));
@@ -195,9 +211,9 @@ public class QuestionSelectionService {
             LOG.debug("Question selection P5 catch-all: user={}, added={}", userId, catchAllAdded);
         }
 
-        LOG.debug("Question selection COMPLETE: user={}, product={}, domain={}, topic={}, total={} [due={}, weak={}, new={}, fill={}, catchAll={}]",
+        LOG.debug("Question selection COMPLETE: user={}, product={}, domain={}, topic={}, total={} [flagged={}, due={}, weak={}, new={}, fill={}, catchAll={}]",
                 userId, productCode, domainCode, effectiveTopic, selected.size(),
-                dueAdded, weakAdded, newAdded, fillAdded, catchAllAdded);
+                flaggedAdded, dueAdded, weakAdded, newAdded, fillAdded, catchAllAdded);
 
         if (selected.isEmpty()) {
             LOG.warn("No questions selected: user={}, product={}, domain={}, topic={}, requestedCount={}",

--- a/src/main/resources/db/migration/U12__add_question_snapshot_and_mastery_to_session_answers.sql
+++ b/src/main/resources/db/migration/U12__add_question_snapshot_and_mastery_to_session_answers.sql
@@ -1,0 +1,10 @@
+-- U12: Undo V12 - remove question snapshot and mastery columns from session_answers
+
+DROP INDEX IF EXISTS idx_session_answers_breakdown;
+
+ALTER TABLE session_answers
+    DROP COLUMN IF EXISTS question_snapshot,
+    DROP COLUMN IF EXISTS previous_mastery_level,
+    DROP COLUMN IF EXISTS new_mastery_level,
+    DROP COLUMN IF EXISTS domain_code,
+    DROP COLUMN IF EXISTS domain_name;

--- a/src/main/resources/db/migration/U13__add_is_flagged_to_question_progress.sql
+++ b/src/main/resources/db/migration/U13__add_is_flagged_to_question_progress.sql
@@ -1,0 +1,6 @@
+-- U13: Undo V13 - remove is_flagged from question_progress
+
+DROP INDEX IF EXISTS idx_question_progress_flagged;
+
+ALTER TABLE question_progress
+    DROP COLUMN IF EXISTS is_flagged;

--- a/src/main/resources/db/migration/U14__create_question_reports.sql
+++ b/src/main/resources/db/migration/U14__create_question_reports.sql
@@ -1,0 +1,3 @@
+-- U14: Undo V14 - drop question_reports table
+
+DROP TABLE IF EXISTS question_reports;

--- a/src/main/resources/db/migration/V12__add_question_snapshot_and_mastery_to_session_answers.sql
+++ b/src/main/resources/db/migration/V12__add_question_snapshot_and_mastery_to_session_answers.sql
@@ -1,0 +1,13 @@
+-- V12: Add question snapshot (JSONB) and mastery tracking to session_answers
+-- for the practice session breakdown screen.
+
+ALTER TABLE session_answers
+    ADD COLUMN question_snapshot JSONB,
+    ADD COLUMN previous_mastery_level VARCHAR(20),
+    ADD COLUMN new_mastery_level VARCHAR(20),
+    ADD COLUMN domain_code VARCHAR(100),
+    ADD COLUMN domain_name VARCHAR(255);
+
+-- Index for efficient breakdown queries by session
+CREATE INDEX idx_session_answers_breakdown
+    ON session_answers (session_id, question_order);

--- a/src/main/resources/db/migration/V13__add_is_flagged_to_question_progress.sql
+++ b/src/main/resources/db/migration/V13__add_is_flagged_to_question_progress.sql
@@ -1,0 +1,9 @@
+-- V13: Add is_flagged to question_progress for user-flagged questions
+
+ALTER TABLE question_progress
+    ADD COLUMN is_flagged BOOLEAN NOT NULL DEFAULT false;
+
+-- Partial index for efficient flagged question queries
+CREATE INDEX idx_question_progress_flagged
+    ON question_progress (keycloak_user_id, product_code, is_flagged)
+    WHERE is_flagged = true;

--- a/src/main/resources/db/migration/V14__create_question_reports.sql
+++ b/src/main/resources/db/migration/V14__create_question_reports.sql
@@ -1,0 +1,26 @@
+-- V14: Create question_reports table for user error reports on questions
+
+CREATE TABLE question_reports (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id           UUID         NOT NULL,
+    keycloak_user_id    UUID         NOT NULL,
+    strapi_question_id  VARCHAR(100) NOT NULL,
+    report_type         VARCHAR(50)  NOT NULL
+        CHECK (report_type IN ('INCORRECT_ANSWER', 'UNCLEAR_QUESTION', 'WRONG_IMAGE', 'WRONG_EXPLANATION', 'OTHER')),
+    comment             TEXT,
+    created_at          TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+-- RLS
+ALTER TABLE question_reports ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation_question_reports ON question_reports
+    USING (tenant_id = current_setting('app.tenant_id')::UUID)
+    WITH CHECK (tenant_id = current_setting('app.tenant_id')::UUID);
+
+-- Indexes
+CREATE INDEX idx_question_reports_question
+    ON question_reports (strapi_question_id);
+
+CREATE INDEX idx_question_reports_user
+    ON question_reports (keycloak_user_id, created_at DESC);

--- a/src/main/resources/db/migration/V14__create_question_reports.sql
+++ b/src/main/resources/db/migration/V14__create_question_reports.sql
@@ -8,7 +8,9 @@ CREATE TABLE question_reports (
     report_type         VARCHAR(50)  NOT NULL
         CHECK (report_type IN ('INCORRECT_ANSWER', 'UNCLEAR_QUESTION', 'WRONG_IMAGE', 'WRONG_EXPLANATION', 'OTHER')),
     comment             TEXT,
-    created_at          TIMESTAMPTZ  NOT NULL DEFAULT now()
+    created_at          TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    deleted_at          TIMESTAMPTZ
 );
 
 -- RLS

--- a/src/test/java/com/passtheo/content/unit/ContentControllerListTopicsTest.java
+++ b/src/test/java/com/passtheo/content/unit/ContentControllerListTopicsTest.java
@@ -5,9 +5,9 @@ import com.passtheo.content.dto.response.TopicWithProgressDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiTopicDto;
 import com.passtheo.content.repository.QuestionProgressRepository;
-import com.passtheo.content.repository.QuestionReportRepository;
 import com.passtheo.content.service.EntitlementChecker;
 import com.passtheo.content.service.OnboardingCatalogService;
+import com.passtheo.content.service.PracticeSessionService;
 import com.passtheo.shared.core.dto.ApiResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,9 +31,9 @@ class ContentControllerListTopicsTest {
 
     @Mock private StrapiContentCache strapiContentCache;
     @Mock private QuestionProgressRepository questionProgressRepository;
-    @Mock private QuestionReportRepository questionReportRepository;
     @Mock private EntitlementChecker entitlementChecker;
     @Mock private OnboardingCatalogService onboardingCatalogService;
+    @Mock private PracticeSessionService practiceSessionService;
 
     private ContentController controller;
 
@@ -46,8 +46,8 @@ class ContentControllerListTopicsTest {
     @BeforeEach
     void setUp() {
         controller = new ContentController(
-                strapiContentCache, questionProgressRepository, questionReportRepository,
-                entitlementChecker, onboardingCatalogService);
+                strapiContentCache, questionProgressRepository,
+                entitlementChecker, onboardingCatalogService, practiceSessionService);
     }
 
     @Test

--- a/src/test/java/com/passtheo/content/unit/ContentControllerListTopicsTest.java
+++ b/src/test/java/com/passtheo/content/unit/ContentControllerListTopicsTest.java
@@ -5,6 +5,7 @@ import com.passtheo.content.dto.response.TopicWithProgressDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiTopicDto;
 import com.passtheo.content.repository.QuestionProgressRepository;
+import com.passtheo.content.repository.QuestionReportRepository;
 import com.passtheo.content.service.EntitlementChecker;
 import com.passtheo.content.service.OnboardingCatalogService;
 import com.passtheo.shared.core.dto.ApiResponse;
@@ -30,6 +31,7 @@ class ContentControllerListTopicsTest {
 
     @Mock private StrapiContentCache strapiContentCache;
     @Mock private QuestionProgressRepository questionProgressRepository;
+    @Mock private QuestionReportRepository questionReportRepository;
     @Mock private EntitlementChecker entitlementChecker;
     @Mock private OnboardingCatalogService onboardingCatalogService;
 
@@ -44,7 +46,7 @@ class ContentControllerListTopicsTest {
     @BeforeEach
     void setUp() {
         controller = new ContentController(
-                strapiContentCache, questionProgressRepository,
+                strapiContentCache, questionProgressRepository, questionReportRepository,
                 entitlementChecker, onboardingCatalogService);
     }
 

--- a/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
+++ b/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
@@ -10,6 +10,7 @@ import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
+import com.passtheo.content.repository.QuestionReportRepository;
 import com.passtheo.content.repository.SessionAnswerRepository;
 import com.passtheo.content.repository.StudyPlanDayRepository;
 import com.passtheo.content.repository.StudyPlanRepository;
@@ -48,6 +49,7 @@ class PracticeSessionServiceActiveSessionTest {
     @Mock private StrapiContentCache strapiContentCache;
     @Mock private StudyPlanRepository planRepository;
     @Mock private StudyPlanDayRepository planDayRepository;
+    @Mock private QuestionReportRepository questionReportRepository;
     @Mock private OutboxEventRepository outboxEventRepository;
 
     private PracticeSessionService service;
@@ -61,7 +63,7 @@ class PracticeSessionServiceActiveSessionTest {
                 sessionRepository, answerRepository, progressRepository,
                 questionSelectionService, answerProcessingService, streakService,
                 achievementService, strapiContentCache, planRepository, planDayRepository,
-                outboxEventRepository, new ObjectMapper()
+                questionReportRepository, outboxEventRepository, new ObjectMapper()
         );
     }
 


### PR DESCRIPTION
Closes #55

## Changes
- **V12 migration**: Add `question_snapshot` JSONB, `previous_mastery_level`, `new_mastery_level`, `domain_code`, `domain_name` to `session_answers`
- **V13 migration**: Add `is_flagged` boolean to `question_progress` with partial index
- **V14 migration**: Create `question_reports` table with RLS policies
- **AnswerProcessingService**: New `buildQuestionSnapshot()` method serializes full question data (text, options, explanation, regions, targets) at answer time
- **PracticeSessionService**: Store snapshot + mastery levels per answer; fix `MasteryChangesDto` (was hardcoded 0,0,0); add `getSessionBreakdown()` and `flagQuestion()`/`unflagQuestion()` methods; auto-unflag on correct answer
- **QuestionSelectionService**: Add Priority 0 for flagged questions (before due reviews)
- **PracticeController**: `GET /sessions/{id}/breakdown` endpoint
- **ProgressController**: `POST/DELETE /progress/questions/{id}/flag` endpoints
- **ContentController**: `POST /content/questions/{id}/report` endpoint
- **OpenAPI spec** updated with all new endpoints and schemas

## Test plan
- [x] `./gradlew test` — all existing tests pass
- [ ] Start service with Docker Compose, complete a practice session, call `GET /api/practice/sessions/{id}/breakdown` — verify question snapshots, mastery changes, domain info
- [ ] Flag a question via `POST /api/progress/questions/{id}/flag`, then start a new session — verify flagged question appears first
- [ ] Answer flagged question correctly — verify auto-unflag
- [ ] Report a question error via `POST /api/content/questions/{id}/report` — verify stored in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)