### PR TITLE
fix(content): auto-skip unanswered questions when session ends early

### DIFF
--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -624,6 +624,9 @@ public class PracticeSessionService {
         StudySession session = sessionRepository.findByIdAndKeycloakUserId(sessionId, userId)
                 .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR, "Session not found: " + sessionId));
 
+        // Auto-skip unanswered questions so they appear in the breakdown
+        autoSkipUnansweredQuestions(userId, session);
+
         session.setStatus(SessionStatus.COMPLETED);
         session.setCompletedAt(Instant.now());
         if (session.getAnsweredCount() > 0) {
@@ -896,6 +899,73 @@ public class PracticeSessionService {
                 TenantContext.get(), userId, strapiQuestionId, request.reportType(), request.comment());
         questionReportRepository.save(report);
         LOG.info("Question reported: user={}, question={}, type={}", userId, strapiQuestionId, request.reportType());
+    }
+
+    /**
+     * Creates skip records for all unanswered questions in a session.
+     * Called during completeSession() so the breakdown shows every question.
+     * Does NOT affect mastery — skips are neutral for spaced repetition.
+     */
+    private void autoSkipUnansweredQuestions(UUID userId, StudySession session) {
+        List<String> allQuestionIds = session.getQuestionIdList();
+        if (allQuestionIds.isEmpty()) {
+            return; // Legacy session without stored question IDs
+        }
+
+        Set<String> answeredIds = answerRepository.findBySessionIdOrderByQuestionOrderAsc(session.getId())
+                .stream()
+                .map(SessionAnswer::getStrapiQuestionId)
+                .collect(Collectors.toSet());
+
+        String locale = session.getLocale();
+        int autoSkipped = 0;
+
+        for (int i = 0; i < allQuestionIds.size(); i++) {
+            String questionId = allQuestionIds.get(i);
+            if (answeredIds.contains(questionId)) {
+                continue;
+            }
+
+            StrapiQuestionDto question = strapiContentCache.getQuestion(questionId, locale);
+            if (question == null) {
+                continue; // Deleted/deactivated in Strapi
+            }
+
+            int questionOrder = i + 1; // 1-indexed position in the full list
+
+            // Look up current mastery level (unchanged since skip doesn't affect it)
+            QuestionProgress progress = progressRepository
+                    .findByKeycloakUserIdAndStrapiQuestionId(userId, questionId)
+                    .orElse(null);
+            String masteryLevel = progress != null ? progress.getMasteryLevel().name() : MasteryLevel.NEW.name();
+
+            SessionAnswer skipAnswer = new SessionAnswer(
+                    session.getId(), userId, questionId,
+                    question.version(), question.interactionType(), false,
+                    SKIP_ANSWER_JSON, serializeJson(answerProcessingService.buildCorrectAnswer(question)),
+                    0, questionOrder);
+            skipAnswer.setTenantId(TenantContext.get());
+            skipAnswer.setQuestionSnapshot(serializeJson(answerProcessingService.buildQuestionSnapshot(question)));
+            skipAnswer.setPreviousMasteryLevel(masteryLevel);
+            skipAnswer.setNewMasteryLevel(masteryLevel);
+
+            String domainCode = resolveDomainCode(question, session.getProductCode(), locale);
+            skipAnswer.setDomainCode(domainCode);
+            String domainName = question.domain() != null ? question.domain().name() : null;
+            if (domainName == null && domainCode != null) {
+                domainName = resolveDomainName(domainCode, session.getProductCode(), locale);
+            }
+            skipAnswer.setDomainName(domainName);
+
+            answerRepository.save(skipAnswer);
+            autoSkipped++;
+        }
+
+        if (autoSkipped > 0) {
+            session.setAnsweredCount(session.getAnsweredCount() + autoSkipped);
+            sessionRepository.save(session);
+            LOG.info("Auto-skipped {} unanswered questions for session={}", autoSkipped, session.getId());
+        }
     }
 
     /**

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -906,7 +906,7 @@ public class PracticeSessionService {
      * Called during completeSession() so the breakdown shows every question.
      * Does NOT affect mastery — skips are neutral for spaced repetition.
      */
-    private void autoSkipUnansweredQuestions(UUID userId, StudySession session) {
+    private void autoSkipUnansweredQuestions(@Nonnull UUID userId, @Nonnull StudySession session) {
         List<String> allQuestionIds = session.getQuestionIdList();
         if (allQuestionIds.isEmpty()) {
             return; // Legacy session without stored question IDs
@@ -918,7 +918,7 @@ public class PracticeSessionService {
                 .collect(Collectors.toSet());
 
         String locale = session.getLocale();
-        int autoSkipped = 0;
+        List<SessionAnswer> skipAnswers = new ArrayList<>();
 
         for (int i = 0; i < allQuestionIds.size(); i++) {
             String questionId = allQuestionIds.get(i);
@@ -957,14 +957,14 @@ public class PracticeSessionService {
             }
             skipAnswer.setDomainName(domainName);
 
-            answerRepository.save(skipAnswer);
-            autoSkipped++;
+            skipAnswers.add(skipAnswer);
         }
 
-        if (autoSkipped > 0) {
-            session.setAnsweredCount(session.getAnsweredCount() + autoSkipped);
+        if (!skipAnswers.isEmpty()) {
+            answerRepository.saveAll(skipAnswers);
+            session.setAnsweredCount(session.getAnsweredCount() + skipAnswers.size());
             sessionRepository.save(session);
-            LOG.info("Auto-skipped {} unanswered questions for session={}", autoSkipped, session.getId());
+            LOG.info("Auto-skipped {} unanswered questions for session={}", skipAnswers.size(), session.getId());
         }
     }
 


### PR DESCRIPTION
Closes #57

## Changes
- Added `autoSkipUnansweredQuestions()` in `PracticeSessionService`
- Called from `completeSession()` before marking session COMPLETED
- For each unanswered question: creates a SessionAnswer with `user_answer = null`, `is_correct = false`, full question snapshot, domain info, and current mastery level
- `answeredCount` updated to include auto-skipped questions
- Accuracy recalculated against total (not just answered)
- Mastery NOT affected by auto-skips (neutral for spaced repetition)

## Test plan
- [x] `./gradlew test` — all existing tests pass
- [ ] Start a session with 10+ questions, answer 3, end early
- [ ] Call `GET /api/practice/sessions/{id}/breakdown` — verify all questions appear
- [ ] Unanswered questions show as `isSkipped: true` with question snapshots
- [ ] Accuracy = `correctCount / totalQuestions * 100` (not correctCount / 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)