### PR TITLE
feat(content): add XP system, streak on exam, and domain name translation

### DIFF
--- a/src/main/java/com/passtheo/content/controller/ExamController.java
+++ b/src/main/java/com/passtheo/content/controller/ExamController.java
@@ -115,7 +115,7 @@ public class ExamController {
     public ResponseEntity<ApiResponse<SessionBreakdownDto>> getExamBreakdown(
             @PathVariable @Nonnull UUID examId,
             @RequestHeader("X-Keycloak-User-ID") UUID userId,
-            @RequestParam(defaultValue = "nl") String locale) {
+            @RequestParam(defaultValue = "nl") @Nonnull String locale) {
 
         SessionBreakdownDto breakdown = mockExamService.getExamBreakdown(userId, examId, locale);
         return ResponseEntity.ok(ApiResponse.success(breakdown, MDC.get("traceId")));

--- a/src/main/java/com/passtheo/content/controller/ExamController.java
+++ b/src/main/java/com/passtheo/content/controller/ExamController.java
@@ -5,6 +5,7 @@ import com.passtheo.content.dto.request.SubmitExamRequest;
 import com.passtheo.content.dto.response.ExamDto;
 import com.passtheo.content.dto.response.ExamHistorySummaryDto;
 import com.passtheo.content.dto.response.ExamResultDto;
+import com.passtheo.content.dto.response.SessionBreakdownDto;
 import com.passtheo.content.service.EntitlementChecker;
 import com.passtheo.content.service.MockExamService;
 import com.passtheo.shared.core.dto.ApiResponse;
@@ -100,6 +101,24 @@ public class ExamController {
 
         ExamResultDto result = mockExamService.submitExam(userId, examId, request, locale);
         return ResponseEntity.ok(ApiResponse.success(result, MDC.get("traceId")));
+    }
+
+    /**
+     * Gets full exam breakdown for question-by-question review.
+     *
+     * @param examId  the exam attempt ID
+     * @param userId  user ID from header
+     * @param locale  content locale
+     * @return exam breakdown with all questions
+     */
+    @GetMapping("/mock/{examId}/breakdown")
+    public ResponseEntity<ApiResponse<SessionBreakdownDto>> getExamBreakdown(
+            @PathVariable @Nonnull UUID examId,
+            @RequestHeader("X-Keycloak-User-ID") UUID userId,
+            @RequestParam(defaultValue = "nl") String locale) {
+
+        SessionBreakdownDto breakdown = mockExamService.getExamBreakdown(userId, examId, locale);
+        return ResponseEntity.ok(ApiResponse.success(breakdown, MDC.get("traceId")));
     }
 
     /**

--- a/src/main/java/com/passtheo/content/domain/entity/UserXp.java
+++ b/src/main/java/com/passtheo/content/domain/entity/UserXp.java
@@ -50,16 +50,8 @@ public class UserXp extends BaseEntity {
         return keycloakUserId;
     }
 
-    public void setKeycloakUserId(UUID keycloakUserId) {
-        this.keycloakUserId = keycloakUserId;
-    }
-
     public String getProductCode() {
         return productCode;
-    }
-
-    public void setProductCode(String productCode) {
-        this.productCode = productCode;
     }
 
     public int getTotalXp() {

--- a/src/main/java/com/passtheo/content/domain/entity/UserXp.java
+++ b/src/main/java/com/passtheo/content/domain/entity/UserXp.java
@@ -1,0 +1,88 @@
+package com.passtheo.content.domain.entity;
+
+import com.passtheo.shared.core.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+import java.util.UUID;
+
+/**
+ * Tracks cumulative experience points and level for a user per product.
+ */
+@Entity
+@Table(name = "user_xp")
+public class UserXp extends BaseEntity {
+
+    @Column(name = "keycloak_user_id", nullable = false)
+    private UUID keycloakUserId;
+
+    @Column(name = "product_code", nullable = false, length = 50)
+    private String productCode;
+
+    @Column(name = "total_xp", nullable = false)
+    private int totalXp;
+
+    @Column(name = "current_level", nullable = false)
+    private int currentLevel;
+
+    @Version
+    @Column(name = "version", nullable = false)
+    private int version;
+
+    protected UserXp() { }
+
+    /**
+     * Creates a new XP record for a user/product.
+     *
+     * @param keycloakUserId the user's Keycloak ID
+     * @param productCode    the product code
+     */
+    public UserXp(UUID keycloakUserId, String productCode) {
+        this.keycloakUserId = keycloakUserId;
+        this.productCode = productCode;
+        this.totalXp = 0;
+        this.currentLevel = 1;
+    }
+
+    public UUID getKeycloakUserId() {
+        return keycloakUserId;
+    }
+
+    public void setKeycloakUserId(UUID keycloakUserId) {
+        this.keycloakUserId = keycloakUserId;
+    }
+
+    public String getProductCode() {
+        return productCode;
+    }
+
+    public void setProductCode(String productCode) {
+        this.productCode = productCode;
+    }
+
+    public int getTotalXp() {
+        return totalXp;
+    }
+
+    public void setTotalXp(int totalXp) {
+        this.totalXp = totalXp;
+    }
+
+    public int getCurrentLevel() {
+        return currentLevel;
+    }
+
+    public void setCurrentLevel(int currentLevel) {
+        this.currentLevel = currentLevel;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+}

--- a/src/main/java/com/passtheo/content/domain/valueobject/XpResult.java
+++ b/src/main/java/com/passtheo/content/domain/valueobject/XpResult.java
@@ -1,0 +1,20 @@
+package com.passtheo.content.domain.valueobject;
+
+/**
+ * Result of an XP grant operation.
+ *
+ * @param xpEarned       XP earned in this operation
+ * @param totalXp        total XP after grant
+ * @param currentLevel   current level after grant
+ * @param xpForNextLevel XP threshold for the next level
+ * @param leveledUp      whether a level-up occurred
+ * @param previousLevel  level before this grant
+ */
+public record XpResult(
+    int xpEarned,
+    int totalXp,
+    int currentLevel,
+    int xpForNextLevel,
+    boolean leveledUp,
+    int previousLevel
+) { }

--- a/src/main/java/com/passtheo/content/dto/response/EarnedAchievementDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/EarnedAchievementDto.java
@@ -2,9 +2,15 @@ package com.passtheo.content.dto.response;
 
 /**
  * Earned achievement notification DTO (compact, for inline display).
+ *
+ * @param code     achievement code
+ * @param name     achievement name
+ * @param icon     achievement icon identifier
+ * @param xpReward XP awarded for this achievement
  */
 public record EarnedAchievementDto(
     String code,
     String name,
-    String icon
+    String icon,
+    int xpReward
 ) {}

--- a/src/main/java/com/passtheo/content/dto/response/ExamResultDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/ExamResultDto.java
@@ -18,7 +18,9 @@ public record ExamResultDto(
     List<DomainBreakdownDto> domainBreakdown,
     List<WrongAnswerDto> wrongAnswers,
     ReadinessUpdateDto readinessUpdate,
-    List<EarnedAchievementDto> newAchievements
+    List<EarnedAchievementDto> newAchievements,
+    StreakUpdateDto streakUpdate,
+    XpUpdateDto xpUpdate
 ) {
     /**
      * Per-domain exam breakdown.
@@ -49,5 +51,24 @@ public record ExamResultDto(
         double previousScore,
         double newScore,
         String label
+    ) {}
+
+    /**
+     * Streak update from this exam submission.
+     */
+    public record StreakUpdateDto(
+        int currentStreak,
+        boolean isNewDay
+    ) {}
+
+    /**
+     * XP earned from this exam submission.
+     */
+    public record XpUpdateDto(
+        int xpEarned,
+        int totalXp,
+        int currentLevel,
+        int xpForNextLevel,
+        boolean leveledUp
     ) {}
 }

--- a/src/main/java/com/passtheo/content/dto/response/ExamResultDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/ExamResultDto.java
@@ -53,22 +53,4 @@ public record ExamResultDto(
         String label
     ) {}
 
-    /**
-     * Streak update from this exam submission.
-     */
-    public record StreakUpdateDto(
-        int currentStreak,
-        boolean isNewDay
-    ) {}
-
-    /**
-     * XP earned from this exam submission.
-     */
-    public record XpUpdateDto(
-        int xpEarned,
-        int totalXp,
-        int currentLevel,
-        int xpForNextLevel,
-        boolean leveledUp
-    ) {}
 }

--- a/src/main/java/com/passtheo/content/dto/response/SessionSummaryDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/SessionSummaryDto.java
@@ -27,22 +27,4 @@ public record SessionSummaryDto(
         int unchanged
     ) {}
 
-    /**
-     * Streak update from this session.
-     */
-    public record StreakUpdateDto(
-        int currentStreak,
-        boolean isNewDay
-    ) {}
-
-    /**
-     * XP earned from this session completion.
-     */
-    public record XpUpdateDto(
-        int xpEarned,
-        int totalXp,
-        int currentLevel,
-        int xpForNextLevel,
-        boolean leveledUp
-    ) {}
 }

--- a/src/main/java/com/passtheo/content/dto/response/SessionSummaryDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/SessionSummaryDto.java
@@ -15,7 +15,8 @@ public record SessionSummaryDto(
     int timeSpentSeconds,
     MasteryChangesDto masteryChanges,
     StreakUpdateDto streakUpdate,
-    List<EarnedAchievementDto> newAchievements
+    List<EarnedAchievementDto> newAchievements,
+    XpUpdateDto xpUpdate
 ) {
     /**
      * Summary of mastery level changes during the session.
@@ -32,5 +33,16 @@ public record SessionSummaryDto(
     public record StreakUpdateDto(
         int currentStreak,
         boolean isNewDay
+    ) {}
+
+    /**
+     * XP earned from this session completion.
+     */
+    public record XpUpdateDto(
+        int xpEarned,
+        int totalXp,
+        int currentLevel,
+        int xpForNextLevel,
+        boolean leveledUp
     ) {}
 }

--- a/src/main/java/com/passtheo/content/dto/response/StreakUpdateDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/StreakUpdateDto.java
@@ -1,0 +1,12 @@
+package com.passtheo.content.dto.response;
+
+/**
+ * Streak update from a study activity (practice session or exam).
+ *
+ * @param currentStreak the current streak count
+ * @param isNewDay      whether this activity started a new streak day
+ */
+public record StreakUpdateDto(
+    int currentStreak,
+    boolean isNewDay
+) {}

--- a/src/main/java/com/passtheo/content/dto/response/XpUpdateDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/XpUpdateDto.java
@@ -1,0 +1,18 @@
+package com.passtheo.content.dto.response;
+
+/**
+ * XP earned from a study activity (practice session or exam).
+ *
+ * @param xpEarned       XP earned in this activity
+ * @param totalXp        cumulative XP after this activity
+ * @param currentLevel   current level after this activity
+ * @param xpForNextLevel XP threshold for the next level
+ * @param leveledUp      whether a level-up occurred
+ */
+public record XpUpdateDto(
+    int xpEarned,
+    int totalXp,
+    int currentLevel,
+    int xpForNextLevel,
+    boolean leveledUp
+) {}

--- a/src/main/java/com/passtheo/content/repository/UserXpRepository.java
+++ b/src/main/java/com/passtheo/content/repository/UserXpRepository.java
@@ -1,0 +1,22 @@
+package com.passtheo.content.repository;
+
+import com.passtheo.content.domain.entity.UserXp;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Repository for user XP records.
+ */
+public interface UserXpRepository extends JpaRepository<UserXp, UUID> {
+
+    /**
+     * Finds the XP record for a user and product.
+     *
+     * @param keycloakUserId the user's Keycloak ID
+     * @param productCode    the product code
+     * @return the user XP record if it exists
+     */
+    Optional<UserXp> findByKeycloakUserIdAndProductCode(UUID keycloakUserId, String productCode);
+}

--- a/src/main/java/com/passtheo/content/service/AchievementService.java
+++ b/src/main/java/com/passtheo/content/service/AchievementService.java
@@ -101,7 +101,7 @@ public class AchievementService {
                 achievementRepository.save(earned);
 
                 newlyEarned.add(new EarnedAchievementDto(
-                        def.code(), def.name(), def.icon()));
+                        def.code(), def.name(), def.icon(), def.xpReward()));
 
                 publishAchievementEarnedEvent(TenantContext.get(), userId,
                         def.code(), def.name(), def.icon(), currentValue);

--- a/src/main/java/com/passtheo/content/service/MockExamService.java
+++ b/src/main/java/com/passtheo/content/service/MockExamService.java
@@ -9,6 +9,8 @@ import com.passtheo.content.domain.enums.ExamType;
 import com.passtheo.shared.outbox.entity.OutboxStatus;
 import com.passtheo.content.dto.request.StartExamRequest;
 import com.passtheo.content.dto.request.SubmitExamRequest;
+import com.passtheo.content.domain.valueobject.StreakResult;
+import com.passtheo.content.domain.valueobject.XpResult;
 import com.passtheo.content.dto.response.AnswerResultDto;
 import com.passtheo.content.dto.response.EarnedAchievementDto;
 import com.passtheo.content.dto.response.ExamDto;
@@ -16,6 +18,7 @@ import com.passtheo.content.dto.response.ExamHistorySummaryDto;
 import com.passtheo.content.dto.response.ExamResultDto;
 import com.passtheo.content.dto.response.QuestionDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
+import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.content.integration.strapi.dto.StrapiExamConfigDto;
 import com.passtheo.content.integration.strapi.dto.StrapiQuestionDto;
 import com.passtheo.content.repository.ExamAnswerRepository;
@@ -64,6 +67,8 @@ public class MockExamService {
     private final AnswerProcessingService answerProcessingService;
     private final AchievementService achievementService;
     private final ReadinessService readinessService;
+    private final StreakService streakService;
+    private final XpService xpService;
     private final OutboxEventRepository outboxEventRepository;
     private final ObjectMapper objectMapper;
 
@@ -76,6 +81,8 @@ public class MockExamService {
      * @param answerProcessingService answer grading
      * @param achievementService     achievement checking
      * @param readinessService       readiness score calculator
+     * @param streakService          streak update service
+     * @param xpService              XP grant service
      * @param outboxEventRepository  outbox event repository
      * @param objectMapper           JSON serializer
      */
@@ -85,6 +92,8 @@ public class MockExamService {
                            AnswerProcessingService answerProcessingService,
                            AchievementService achievementService,
                            ReadinessService readinessService,
+                           StreakService streakService,
+                           XpService xpService,
                            OutboxEventRepository outboxEventRepository,
                            ObjectMapper objectMapper) {
         this.examAttemptRepository = examAttemptRepository;
@@ -93,6 +102,8 @@ public class MockExamService {
         this.answerProcessingService = answerProcessingService;
         this.achievementService = achievementService;
         this.readinessService = readinessService;
+        this.streakService = streakService;
+        this.xpService = xpService;
         this.outboxEventRepository = outboxEventRepository;
         this.objectMapper = objectMapper;
     }
@@ -209,6 +220,7 @@ public class MockExamService {
 
         // Grade all answers
         int correctCount = 0;
+        int answerXp = 0;
         Map<String, int[]> domainStats = new LinkedHashMap<>(); // domainCode -> [correct, total]
         List<ExamResultDto.WrongAnswerDto> wrongAnswers = new ArrayList<>();
 
@@ -238,6 +250,7 @@ public class MockExamService {
 
                 domainStats.computeIfAbsent("unknown", k -> new int[]{0, 0});
                 domainStats.get("unknown")[1]++;
+                answerXp += XpService.XP_WRONG_ANSWER;
 
                 // Add to wrong answers so the user can see why they lost a point
                 wrongAnswers.add(new ExamResultDto.WrongAnswerDto(
@@ -250,6 +263,7 @@ public class MockExamService {
             if (isCorrect) {
                 correctCount++;
             }
+            answerXp += isCorrect ? XpService.XP_CORRECT_ANSWER : XpService.XP_WRONG_ANSWER;
 
             String domainCode = question.domain() != null ? question.domain().code() : "unknown";
             domainStats.computeIfAbsent(domainCode, k -> new int[]{0, 0});
@@ -303,10 +317,14 @@ public class MockExamService {
         attempt.setDomainBreakdown(serializeJson(domainStats));
         examAttemptRepository.save(attempt);
 
-        // Build domain breakdown DTOs
+        // Build domain breakdown DTOs with human-readable names
+        Map<String, String> domainNameMap = strapiContentCache.getDomains(attempt.getProductCode(), locale)
+                .stream()
+                .collect(Collectors.toMap(StrapiDomainDto::code, StrapiDomainDto::name, (a, b) -> a));
+
         List<ExamResultDto.DomainBreakdownDto> domainBreakdown = domainStats.entrySet().stream()
                 .map(e -> new ExamResultDto.DomainBreakdownDto(
-                        e.getKey(), e.getKey(),
+                        e.getKey(), domainNameMap.getOrDefault(e.getKey(), e.getKey()),
                         e.getValue()[0], e.getValue()[1],
                         e.getValue()[1] > 0 ? (double) e.getValue()[0] / e.getValue()[1] * 100.0 : 0.0))
                 .toList();
@@ -319,6 +337,18 @@ public class MockExamService {
         List<EarnedAchievementDto> achievements = achievementService
                 .checkAchievements(userId, attempt.getProductCode());
 
+        // Update study streak
+        StreakResult streakResult = streakService.updateStreak(userId, attempt.getProductCode());
+
+        // Calculate and grant XP
+        int examBonus = passed ? XpService.XP_EXAM_PASS : XpService.XP_EXAM_FAIL;
+        if (passed && correctCount == totalQuestions) {
+            examBonus += XpService.XP_PERFECT_EXAM;
+        }
+        int achievementXp = achievements.stream().mapToInt(EarnedAchievementDto::xpReward).sum();
+        int totalXpEarned = answerXp + examBonus + achievementXp;
+        XpResult xpResult = xpService.grantXp(userId, attempt.getProductCode(), totalXpEarned);
+
         // Publish exam.completed outbox event
         List<String> weakDomains = domainStats.entrySet().stream()
                 .filter(e -> e.getValue()[1] > 0 && (double) e.getValue()[0] / e.getValue()[1] < 0.6)
@@ -327,13 +357,16 @@ public class MockExamService {
         publishExamCompletedEvent(TenantContext.get(), userId, examId,
                 attempt.getProductCode(), passed, correctCount, totalQuestions, scorePercent, weakDomains);
 
-        LOG.info("Mock exam submitted: id={}, user={}, correct={}/{}, passed={}",
-                examId, userId, correctCount, totalQuestions, passed);
+        LOG.info("Mock exam submitted: id={}, user={}, correct={}/{}, passed={}, xp={}",
+                examId, userId, correctCount, totalQuestions, passed, totalXpEarned);
 
         return new ExamResultDto(
                 examId, passed, correctCount, totalQuestions,
                 attempt.getPassScore(), scorePercent, timeTakenSeconds,
-                domainBreakdown, wrongAnswers, readinessUpdate, achievements
+                domainBreakdown, wrongAnswers, readinessUpdate, achievements,
+                new ExamResultDto.StreakUpdateDto(streakResult.currentStreak(), streakResult.isNewDay()),
+                new ExamResultDto.XpUpdateDto(totalXpEarned, xpResult.totalXp(),
+                        xpResult.currentLevel(), xpResult.xpForNextLevel(), xpResult.leveledUp())
         );
     }
 

--- a/src/main/java/com/passtheo/content/service/MockExamService.java
+++ b/src/main/java/com/passtheo/content/service/MockExamService.java
@@ -20,6 +20,8 @@ import com.passtheo.content.dto.response.ExamResultDto;
 import com.passtheo.content.dto.response.QuestionDto;
 import com.passtheo.content.dto.response.SessionBreakdownDto;
 import com.passtheo.content.dto.response.SessionSummaryDto;
+import com.passtheo.content.dto.response.StreakUpdateDto;
+import com.passtheo.content.dto.response.XpUpdateDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.content.integration.strapi.dto.StrapiExamConfigDto;
@@ -367,8 +369,8 @@ public class MockExamService {
                 examId, passed, correctCount, totalQuestions,
                 attempt.getPassScore(), scorePercent, timeTakenSeconds,
                 domainBreakdown, wrongAnswers, readinessUpdate, achievements,
-                new ExamResultDto.StreakUpdateDto(streakResult.currentStreak(), streakResult.isNewDay()),
-                new ExamResultDto.XpUpdateDto(totalXpEarned, xpResult.totalXp(),
+                new StreakUpdateDto(streakResult.currentStreak(), streakResult.isNewDay()),
+                new XpUpdateDto(totalXpEarned, xpResult.totalXp(),
                         xpResult.currentLevel(), xpResult.xpForNextLevel(), xpResult.leveledUp())
         );
     }

--- a/src/main/java/com/passtheo/content/service/MockExamService.java
+++ b/src/main/java/com/passtheo/content/service/MockExamService.java
@@ -14,9 +14,12 @@ import com.passtheo.content.domain.valueobject.XpResult;
 import com.passtheo.content.dto.response.AnswerResultDto;
 import com.passtheo.content.dto.response.EarnedAchievementDto;
 import com.passtheo.content.dto.response.ExamDto;
+import com.passtheo.content.dto.response.BreakdownQuestionDto;
 import com.passtheo.content.dto.response.ExamHistorySummaryDto;
 import com.passtheo.content.dto.response.ExamResultDto;
 import com.passtheo.content.dto.response.QuestionDto;
+import com.passtheo.content.dto.response.SessionBreakdownDto;
+import com.passtheo.content.dto.response.SessionSummaryDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.content.integration.strapi.dto.StrapiExamConfigDto;
@@ -393,6 +396,69 @@ public class MockExamService {
                 .toList();
     }
 
+    /**
+     * Gets full exam breakdown for question-by-question review.
+     * Loads each question from Strapi cache to build snapshots.
+     *
+     * @param userId the user's Keycloak ID
+     * @param examId the exam attempt ID
+     * @param locale the content locale
+     * @return the exam breakdown in the same format as practice breakdowns
+     */
+    @Transactional(readOnly = true)
+    public SessionBreakdownDto getExamBreakdown(@Nonnull UUID userId, @Nonnull UUID examId,
+                                                 @Nonnull String locale) {
+        ExamAttempt attempt = examAttemptRepository.findByIdAndKeycloakUserId(examId, userId)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR,
+                        "Exam attempt not found: " + examId));
+
+        List<ExamAnswer> answers = examAnswerRepository.findByExamAttemptIdOrderByQuestionOrderAsc(examId);
+
+        Map<String, String> domainNameMap = strapiContentCache.getDomains(attempt.getProductCode(), locale)
+                .stream()
+                .collect(Collectors.toMap(StrapiDomainDto::code, StrapiDomainDto::name, (a, b) -> a));
+
+        List<BreakdownQuestionDto> breakdownQuestions = new ArrayList<>();
+        for (ExamAnswer ea : answers) {
+            StrapiQuestionDto question = strapiContentCache.getQuestion(ea.getStrapiQuestionId(), locale);
+
+            Map<String, Object> snapshot = Map.of();
+            String interactionType = "multiple_choice";
+            if (question != null) {
+                snapshot = answerProcessingService.buildQuestionSnapshot(question);
+                interactionType = question.interactionType();
+            }
+
+            breakdownQuestions.add(new BreakdownQuestionDto(
+                    ea.getQuestionOrder(),
+                    ea.getStrapiQuestionId(),
+                    interactionType,
+                    ea.isCorrect(),
+                    false, // exams have no skipped questions
+                    deserializeJson(ea.getUserAnswer()),
+                    deserializeJson(ea.getCorrectAnswer()),
+                    snapshot,
+                    ea.getDomainCode(),
+                    domainNameMap.getOrDefault(ea.getDomainCode(), ea.getDomainCode()),
+                    "", // exams don't track mastery
+                    "",
+                    false
+            ));
+        }
+
+        return new SessionBreakdownDto(
+                attempt.getId(),
+                "COMPLETED",
+                attempt.getTotalQuestions(),
+                attempt.getCorrectCount(),
+                0, // no skipped in exams
+                attempt.getScorePercent() != null ? attempt.getScorePercent().doubleValue() : 0.0,
+                attempt.getTimeTakenSeconds(),
+                new SessionSummaryDto.MasteryChangesDto(0, 0, 0),
+                List.copyOf(breakdownQuestions)
+        );
+    }
+
     private void publishExamCompletedEvent(java.util.UUID tenantId, java.util.UUID userId,
                                             java.util.UUID examAttemptId, String productCode,
                                             boolean passed, int correctCount, int totalQuestions,
@@ -501,6 +567,19 @@ public class MockExamService {
         } catch (JsonProcessingException e) {
             LOG.error("Failed to serialize JSON: {}", e.getMessage());
             return "{}";
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> deserializeJson(String json) {
+        if (json == null || json.isBlank() || "null".equals(json)) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(json, Map.class);
+        } catch (JsonProcessingException e) {
+            LOG.warn("Failed to deserialize JSON for breakdown: {}", e.getMessage());
+            return Map.of();
         }
     }
 }

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -13,6 +13,7 @@ import com.passtheo.shared.outbox.entity.OutboxStatus;
 import com.passtheo.content.domain.enums.SessionStatus;
 import com.passtheo.content.domain.enums.SessionType;
 import com.passtheo.content.domain.valueobject.StreakResult;
+import com.passtheo.content.domain.valueobject.XpResult;
 import com.passtheo.content.dto.request.StartSessionRequest;
 import com.passtheo.content.dto.request.SubmitAnswerRequest;
 import com.passtheo.content.dto.response.ActiveSessionDto;
@@ -83,6 +84,7 @@ public class PracticeSessionService {
     private final AnswerProcessingService answerProcessingService;
     private final StreakService streakService;
     private final AchievementService achievementService;
+    private final XpService xpService;
     private final StrapiContentCache strapiContentCache;
     private final StudyPlanRepository planRepository;
     private final StudyPlanDayRepository planDayRepository;
@@ -100,6 +102,7 @@ public class PracticeSessionService {
      * @param answerProcessingService  answer grading + mastery update
      * @param streakService            streak management
      * @param achievementService       achievement checking
+     * @param xpService                XP grant service
      * @param strapiContentCache       Strapi content cache
      * @param planRepository           study plan repository for progress sync
      * @param planDayRepository        study plan day repository for progress sync
@@ -114,6 +117,7 @@ public class PracticeSessionService {
                                   AnswerProcessingService answerProcessingService,
                                   StreakService streakService,
                                   AchievementService achievementService,
+                                  XpService xpService,
                                   StrapiContentCache strapiContentCache,
                                   StudyPlanRepository planRepository,
                                   StudyPlanDayRepository planDayRepository,
@@ -127,6 +131,7 @@ public class PracticeSessionService {
         this.answerProcessingService = answerProcessingService;
         this.streakService = streakService;
         this.achievementService = achievementService;
+        this.xpService = xpService;
         this.strapiContentCache = strapiContentCache;
         this.planRepository = planRepository;
         this.planDayRepository = planDayRepository;
@@ -356,9 +361,14 @@ public class PracticeSessionService {
         // Update streak
         streakService.updateStreak(userId, session.getProductCode());
 
-        // Check achievements async
+        // Check achievements
         List<EarnedAchievementDto> newAchievements = achievementService
                 .checkAchievements(userId, session.getProductCode());
+
+        // Grant per-answer XP
+        int answerXp = isCorrect ? XpService.XP_CORRECT_ANSWER : XpService.XP_WRONG_ANSWER;
+        int achievementXp = newAchievements.stream().mapToInt(EarnedAchievementDto::xpReward).sum();
+        xpService.grantXp(userId, session.getProductCode(), answerXp + achievementXp);
 
         // Build explanation
         AnswerResultDto.ExplanationDto explanation = null;
@@ -639,13 +649,16 @@ public class PracticeSessionService {
         List<EarnedAchievementDto> achievements = achievementService
                 .checkAchievements(userId, session.getProductCode());
 
+        // Grant session completion XP bonus
+        XpResult xpResult = xpService.grantXp(userId, session.getProductCode(), XpService.XP_PRACTICE_COMPLETE);
+
         // Compute actual mastery changes from session answers
         List<SessionAnswer> sessionAnswers = answerRepository.findBySessionIdOrderByQuestionOrderAsc(sessionId);
         SessionSummaryDto.MasteryChangesDto masteryChanges = computeMasteryChanges(sessionAnswers);
 
-        LOG.info("Session completed: id={}, user={}, correct={}/{}, accuracy={}%, timeSpentSec={}",
+        LOG.info("Session completed: id={}, user={}, correct={}/{}, accuracy={}%, timeSpentSec={}, xp={}",
                 sessionId, userId, session.getCorrectCount(), session.getTotalQuestions(),
-                session.getAccuracyPercent(), session.getTimeSpentSeconds());
+                session.getAccuracyPercent(), session.getTimeSpentSeconds(), XpService.XP_PRACTICE_COMPLETE);
         AUDIT.info("SESSION_COMPLETED sessionId={} userId={} correct={} total={} accuracyPct={} timeSpentSec={}",
                 sessionId, userId, session.getCorrectCount(), session.getTotalQuestions(),
                 session.getAccuracyPercent(), session.getTimeSpentSeconds());
@@ -659,7 +672,9 @@ public class PracticeSessionService {
                 session.getTimeSpentSeconds(),
                 masteryChanges,
                 new SessionSummaryDto.StreakUpdateDto(streak.currentStreak(), streak.isNewDay()),
-                achievements
+                achievements,
+                new SessionSummaryDto.XpUpdateDto(XpService.XP_PRACTICE_COMPLETE, xpResult.totalXp(),
+                        xpResult.currentLevel(), xpResult.xpForNextLevel(), xpResult.leveledUp())
         );
     }
 

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -28,6 +28,8 @@ import com.passtheo.content.dto.response.EarnedAchievementDto;
 import com.passtheo.content.dto.response.QuestionDto;
 import com.passtheo.content.dto.response.SessionBreakdownDto;
 import com.passtheo.content.dto.response.SessionDto;
+import com.passtheo.content.dto.response.StreakUpdateDto;
+import com.passtheo.content.dto.response.XpUpdateDto;
 import com.passtheo.content.dto.response.SessionSummaryDto;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
@@ -671,9 +673,9 @@ public class PracticeSessionService {
                 session.getAccuracyPercent() != null ? session.getAccuracyPercent().doubleValue() : 0.0,
                 session.getTimeSpentSeconds(),
                 masteryChanges,
-                new SessionSummaryDto.StreakUpdateDto(streak.currentStreak(), streak.isNewDay()),
+                new StreakUpdateDto(streak.currentStreak(), streak.isNewDay()),
                 achievements,
-                new SessionSummaryDto.XpUpdateDto(XpService.XP_PRACTICE_COMPLETE, xpResult.totalXp(),
+                new XpUpdateDto(XpService.XP_PRACTICE_COMPLETE, xpResult.totalXp(),
                         xpResult.currentLevel(), xpResult.xpForNextLevel(), xpResult.leveledUp())
         );
     }

--- a/src/main/java/com/passtheo/content/service/XpService.java
+++ b/src/main/java/com/passtheo/content/service/XpService.java
@@ -1,0 +1,142 @@
+package com.passtheo.content.service;
+
+import com.passtheo.content.domain.entity.UserXp;
+import com.passtheo.content.domain.valueobject.XpResult;
+import com.passtheo.content.repository.UserXpRepository;
+import com.passtheo.shared.core.context.TenantContext;
+import jakarta.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Grants experience points, tracks cumulative totals, and calculates levels.
+ *
+ * <p>Level formula: threshold for level N = N * (N - 1) * 50.
+ * <ul>
+ *   <li>Level 2 = 100 XP</li>
+ *   <li>Level 3 = 300 XP</li>
+ *   <li>Level 5 = 1000 XP</li>
+ *   <li>Level 10 = 4500 XP</li>
+ * </ul>
+ */
+@Service
+public class XpService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(XpService.class);
+
+    /** XP for a correct answer. */
+    public static final int XP_CORRECT_ANSWER = 10;
+
+    /** XP for a wrong answer (participation reward). */
+    public static final int XP_WRONG_ANSWER = 2;
+
+    /** Bonus XP for completing a practice session. */
+    public static final int XP_PRACTICE_COMPLETE = 50;
+
+    /** Bonus XP for passing a mock exam. */
+    public static final int XP_EXAM_PASS = 200;
+
+    /** Bonus XP for failing a mock exam (participation). */
+    public static final int XP_EXAM_FAIL = 50;
+
+    /** Additional bonus XP for a perfect exam score. */
+    public static final int XP_PERFECT_EXAM = 500;
+
+    private final UserXpRepository userXpRepository;
+
+    /**
+     * Constructs the XP service.
+     *
+     * @param userXpRepository user XP repository
+     */
+    public XpService(UserXpRepository userXpRepository) {
+        this.userXpRepository = userXpRepository;
+    }
+
+    /**
+     * Grants XP to a user for a product and recalculates their level.
+     *
+     * @param userId      the user's Keycloak ID
+     * @param productCode the product code
+     * @param xpAmount    the XP amount to grant (must be positive)
+     * @return the XP result including new totals and level info
+     */
+    @Transactional
+    public XpResult grantXp(@Nonnull UUID userId, @Nonnull String productCode, int xpAmount) {
+        if (xpAmount <= 0) {
+            return getXp(userId, productCode);
+        }
+
+        UserXp xp = userXpRepository.findByKeycloakUserIdAndProductCode(userId, productCode)
+                .orElseGet(() -> createNew(userId, productCode));
+
+        int previousLevel = xp.getCurrentLevel();
+        xp.setTotalXp(xp.getTotalXp() + xpAmount);
+
+        int newLevel = calculateLevel(xp.getTotalXp());
+        xp.setCurrentLevel(newLevel);
+        userXpRepository.save(xp);
+
+        boolean leveledUp = newLevel > previousLevel;
+        if (leveledUp) {
+            LOG.info("Level up: user={}, product={}, level={}->{}, totalXp={}",
+                    userId, productCode, previousLevel, newLevel, xp.getTotalXp());
+        }
+
+        return new XpResult(xpAmount, xp.getTotalXp(), newLevel,
+                levelThreshold(newLevel + 1), leveledUp, previousLevel);
+    }
+
+    /**
+     * Gets the current XP state without modifying it.
+     *
+     * @param userId      the user's Keycloak ID
+     * @param productCode the product code
+     * @return the current XP state
+     */
+    @Transactional(readOnly = true)
+    public XpResult getXp(@Nonnull UUID userId, @Nonnull String productCode) {
+        UserXp xp = userXpRepository.findByKeycloakUserIdAndProductCode(userId, productCode)
+                .orElse(null);
+        if (xp == null) {
+            return new XpResult(0, 0, 1, levelThreshold(2), false, 1);
+        }
+        return new XpResult(0, xp.getTotalXp(), xp.getCurrentLevel(),
+                levelThreshold(xp.getCurrentLevel() + 1), false, xp.getCurrentLevel());
+    }
+
+    /**
+     * Calculates the level for a given total XP.
+     * Threshold for level N = N * (N - 1) * 50.
+     *
+     * @param totalXp the total XP
+     * @return the level (minimum 1)
+     */
+    public static int calculateLevel(int totalXp) {
+        int level = 1;
+        while (levelThreshold(level + 1) <= totalXp) {
+            level++;
+        }
+        return level;
+    }
+
+    /**
+     * Returns the XP threshold to reach a given level.
+     *
+     * @param level the level
+     * @return the XP threshold
+     */
+    public static int levelThreshold(int level) {
+        return level * (level - 1) * 50;
+    }
+
+    private UserXp createNew(UUID userId, String productCode) {
+        UserXp xp = new UserXp(userId, productCode);
+        xp.setTenantId(TenantContext.get());
+        return xp;
+    }
+}

--- a/src/main/resources/db/migration/U15__create_user_xp_table.sql
+++ b/src/main/resources/db/migration/U15__create_user_xp_table.sql
@@ -1,0 +1,6 @@
+-- U15: Undo V15 — drop user_xp table.
+
+DROP POLICY IF EXISTS tenant_isolation_user_xp_insert ON user_xp;
+DROP POLICY IF EXISTS tenant_isolation_user_xp ON user_xp;
+DROP INDEX IF EXISTS idx_user_xp_lookup;
+DROP TABLE IF EXISTS user_xp;

--- a/src/main/resources/db/migration/V15__create_user_xp_table.sql
+++ b/src/main/resources/db/migration/V15__create_user_xp_table.sql
@@ -1,0 +1,30 @@
+-- V15: Create user_xp table for experience point tracking per user per product.
+
+CREATE TABLE user_xp (
+    id               UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id        UUID         NOT NULL,
+    keycloak_user_id UUID         NOT NULL,
+    product_code     VARCHAR(50)  NOT NULL,
+    total_xp         INTEGER      NOT NULL DEFAULT 0,
+    current_level    INTEGER      NOT NULL DEFAULT 1,
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    deleted_at       TIMESTAMPTZ,
+    version          INTEGER      NOT NULL DEFAULT 0,
+
+    CONSTRAINT uq_user_xp_user_product UNIQUE (tenant_id, keycloak_user_id, product_code),
+    CONSTRAINT ck_user_xp_total_xp_positive CHECK (total_xp >= 0),
+    CONSTRAINT ck_user_xp_level_positive CHECK (current_level >= 1)
+);
+
+-- Row-Level Security
+ALTER TABLE user_xp ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation_user_xp ON user_xp
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+CREATE POLICY tenant_isolation_user_xp_insert ON user_xp
+    FOR INSERT WITH CHECK (tenant_id = current_setting('app.current_tenant')::UUID);
+
+-- Performance index
+CREATE INDEX idx_user_xp_lookup ON user_xp (tenant_id, keycloak_user_id, product_code);

--- a/src/test/java/com/passtheo/content/unit/MockExamServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/MockExamServiceTest.java
@@ -10,10 +10,15 @@ import com.passtheo.content.integration.strapi.dto.StrapiQuestionDto;
 import com.passtheo.content.integration.strapi.dto.StrapiRelationDto;
 import com.passtheo.content.repository.ExamAnswerRepository;
 import com.passtheo.content.repository.ExamAttemptRepository;
+import com.passtheo.content.domain.valueobject.StreakResult;
+import com.passtheo.content.domain.valueobject.XpResult;
+import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.content.service.AchievementService;
 import com.passtheo.content.service.AnswerProcessingService;
 import com.passtheo.content.service.MockExamService;
 import com.passtheo.content.service.ReadinessService;
+import com.passtheo.content.service.StreakService;
+import com.passtheo.content.service.XpService;
 import com.passtheo.content.domain.enums.ReadinessLabel;
 import com.passtheo.content.domain.valueobject.ExamConfidence;
 import com.passtheo.content.domain.valueobject.ReadinessScore;
@@ -37,6 +42,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -52,6 +58,8 @@ class MockExamServiceTest {
     @Mock private AnswerProcessingService answerProcessingService;
     @Mock private AchievementService achievementService;
     @Mock private ReadinessService readinessService;
+    @Mock private StreakService streakService;
+    @Mock private XpService xpService;
     @Mock private OutboxEventRepository outboxEventRepository;
 
     private MockExamService service;
@@ -67,6 +75,7 @@ class MockExamServiceTest {
         service = new MockExamService(
                 examAttemptRepository, examAnswerRepository, strapiContentCache,
                 answerProcessingService, achievementService, readinessService,
+                streakService, xpService,
                 outboxEventRepository, new ObjectMapper()
         );
     }
@@ -94,6 +103,12 @@ class MockExamServiceTest {
         when(readinessService.calculate(eq(USER_ID), eq(PRODUCT_CODE), eq("nl")))
                 .thenReturn(buildMinimalReadiness());
         when(achievementService.checkAchievements(USER_ID, PRODUCT_CODE)).thenReturn(List.of());
+        when(streakService.updateStreak(USER_ID, PRODUCT_CODE))
+                .thenReturn(new StreakResult(1, 1, 1, null, 0, 0, true, false, true));
+        when(xpService.grantXp(eq(USER_ID), eq(PRODUCT_CODE), anyInt()))
+                .thenReturn(new XpResult(14, 14, 1, 100, false, 1));
+        when(strapiContentCache.getDomains(PRODUCT_CODE, "nl"))
+                .thenReturn(List.of(new StrapiDomainDto(1, "d1", "Voorrang", "voorrang", null, null, null, null, null, true, false, 1)));
 
         SubmitExamRequest request = new SubmitExamRequest(List.of(
                 new SubmitExamRequest.ExamAnswerItem("q1", Map.of("selectedOptionId", "1"), 5000),

--- a/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
+++ b/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
@@ -20,6 +20,7 @@ import com.passtheo.content.service.AnswerProcessingService;
 import com.passtheo.content.service.PracticeSessionService;
 import com.passtheo.content.service.QuestionSelectionService;
 import com.passtheo.content.service.StreakService;
+import com.passtheo.content.service.XpService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,6 +47,7 @@ class PracticeSessionServiceActiveSessionTest {
     @Mock private AnswerProcessingService answerProcessingService;
     @Mock private StreakService streakService;
     @Mock private AchievementService achievementService;
+    @Mock private XpService xpService;
     @Mock private StrapiContentCache strapiContentCache;
     @Mock private StudyPlanRepository planRepository;
     @Mock private StudyPlanDayRepository planDayRepository;
@@ -62,7 +64,7 @@ class PracticeSessionServiceActiveSessionTest {
         service = new PracticeSessionService(
                 sessionRepository, answerRepository, progressRepository,
                 questionSelectionService, answerProcessingService, streakService,
-                achievementService, strapiContentCache, planRepository, planDayRepository,
+                achievementService, xpService, strapiContentCache, planRepository, planDayRepository,
                 questionReportRepository, outboxEventRepository, new ObjectMapper()
         );
     }

--- a/src/test/java/com/passtheo/content/unit/XpServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/XpServiceTest.java
@@ -1,0 +1,206 @@
+package com.passtheo.content.unit;
+
+import com.passtheo.content.domain.entity.UserXp;
+import com.passtheo.content.domain.valueobject.XpResult;
+import com.passtheo.content.repository.UserXpRepository;
+import com.passtheo.content.service.XpService;
+import com.passtheo.shared.core.context.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for XpService — level calculation, XP granting, edge cases.
+ */
+@ExtendWith(MockitoExtension.class)
+class XpServiceTest {
+
+    @Mock private UserXpRepository userXpRepository;
+
+    private XpService xpService;
+
+    private static final UUID TENANT_ID = UUID.randomUUID();
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final String PRODUCT = "auto-b";
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.set(TENANT_ID);
+        xpService = new XpService(userXpRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void calculateLevel_zeroXp_returnsLevel1() {
+        assertThat(XpService.calculateLevel(0)).isEqualTo(1);
+    }
+
+    @Test
+    void calculateLevel_99Xp_returnsLevel1() {
+        assertThat(XpService.calculateLevel(99)).isEqualTo(1);
+    }
+
+    @Test
+    void calculateLevel_exactThreshold100_returnsLevel2() {
+        assertThat(XpService.calculateLevel(100)).isEqualTo(2);
+    }
+
+    @Test
+    void calculateLevel_299Xp_returnsLevel2() {
+        assertThat(XpService.calculateLevel(299)).isEqualTo(2);
+    }
+
+    @Test
+    void calculateLevel_300Xp_returnsLevel3() {
+        assertThat(XpService.calculateLevel(300)).isEqualTo(3);
+    }
+
+    @Test
+    void calculateLevel_1000Xp_returnsLevel5() {
+        // Level 5 threshold = 5 * 4 * 50 = 1000
+        assertThat(XpService.calculateLevel(1000)).isEqualTo(5);
+    }
+
+    @Test
+    void calculateLevel_4500Xp_returnsLevel10() {
+        // Level 10 threshold = 10 * 9 * 50 = 4500
+        assertThat(XpService.calculateLevel(4500)).isEqualTo(10);
+    }
+
+    @Test
+    void levelThreshold_level1_returns0() {
+        assertThat(XpService.levelThreshold(1)).isEqualTo(0);
+    }
+
+    @Test
+    void levelThreshold_level2_returns100() {
+        assertThat(XpService.levelThreshold(2)).isEqualTo(100);
+    }
+
+    @Test
+    void levelThreshold_level5_returns1000() {
+        assertThat(XpService.levelThreshold(5)).isEqualTo(1000);
+    }
+
+    @Test
+    void levelThreshold_level10_returns4500() {
+        assertThat(XpService.levelThreshold(10)).isEqualTo(4500);
+    }
+
+    @Test
+    void grantXp_newUser_createsRecordWithCorrectXp() {
+        when(userXpRepository.findByKeycloakUserIdAndProductCode(USER_ID, PRODUCT))
+                .thenReturn(Optional.empty());
+        when(userXpRepository.save(any(UserXp.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        XpResult result = xpService.grantXp(USER_ID, PRODUCT, 50);
+
+        assertThat(result.xpEarned()).isEqualTo(50);
+        assertThat(result.totalXp()).isEqualTo(50);
+        assertThat(result.currentLevel()).isEqualTo(1);
+        assertThat(result.leveledUp()).isFalse();
+        assertThat(result.xpForNextLevel()).isEqualTo(100); // Level 2 threshold
+    }
+
+    @Test
+    void grantXp_existingUser_addsXpToTotal() {
+        UserXp existing = new UserXp(USER_ID, PRODUCT);
+        existing.setTenantId(TENANT_ID);
+        existing.setTotalXp(80);
+        existing.setCurrentLevel(1);
+        when(userXpRepository.findByKeycloakUserIdAndProductCode(USER_ID, PRODUCT))
+                .thenReturn(Optional.of(existing));
+        when(userXpRepository.save(any(UserXp.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        XpResult result = xpService.grantXp(USER_ID, PRODUCT, 10);
+
+        assertThat(result.xpEarned()).isEqualTo(10);
+        assertThat(result.totalXp()).isEqualTo(90);
+        assertThat(result.currentLevel()).isEqualTo(1);
+        assertThat(result.leveledUp()).isFalse();
+    }
+
+    @Test
+    void grantXp_crossesLevelThreshold_levelsUp() {
+        UserXp existing = new UserXp(USER_ID, PRODUCT);
+        existing.setTenantId(TENANT_ID);
+        existing.setTotalXp(90);
+        existing.setCurrentLevel(1);
+        when(userXpRepository.findByKeycloakUserIdAndProductCode(USER_ID, PRODUCT))
+                .thenReturn(Optional.of(existing));
+        when(userXpRepository.save(any(UserXp.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        XpResult result = xpService.grantXp(USER_ID, PRODUCT, 20);
+
+        assertThat(result.xpEarned()).isEqualTo(20);
+        assertThat(result.totalXp()).isEqualTo(110);
+        assertThat(result.currentLevel()).isEqualTo(2);
+        assertThat(result.leveledUp()).isTrue();
+        assertThat(result.previousLevel()).isEqualTo(1);
+        assertThat(result.xpForNextLevel()).isEqualTo(300); // Level 3 threshold
+    }
+
+    @Test
+    void grantXp_zeroAmount_doesNotModify() {
+        XpResult result = xpService.grantXp(USER_ID, PRODUCT, 0);
+
+        assertThat(result.xpEarned()).isEqualTo(0);
+        assertThat(result.totalXp()).isEqualTo(0);
+        assertThat(result.currentLevel()).isEqualTo(1);
+    }
+
+    @Test
+    void grantXp_negativeAmount_doesNotModify() {
+        XpResult result = xpService.grantXp(USER_ID, PRODUCT, -10);
+
+        assertThat(result.xpEarned()).isEqualTo(0);
+        verify(userXpRepository, never()).save(any());
+    }
+
+    @Test
+    void grantXp_multipleGrants_accumulatesCorrectly() {
+        UserXp xp = new UserXp(USER_ID, PRODUCT);
+        xp.setTenantId(TENANT_ID);
+        xp.setTotalXp(0);
+        xp.setCurrentLevel(1);
+        when(userXpRepository.findByKeycloakUserIdAndProductCode(USER_ID, PRODUCT))
+                .thenReturn(Optional.of(xp));
+        when(userXpRepository.save(any(UserXp.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        xpService.grantXp(USER_ID, PRODUCT, 50);
+        assertThat(xp.getTotalXp()).isEqualTo(50);
+
+        xpService.grantXp(USER_ID, PRODUCT, 60);
+        assertThat(xp.getTotalXp()).isEqualTo(110);
+        assertThat(xp.getCurrentLevel()).isEqualTo(2);
+    }
+
+    @Test
+    void getXp_noRecord_returnsDefaults() {
+        when(userXpRepository.findByKeycloakUserIdAndProductCode(USER_ID, PRODUCT))
+                .thenReturn(Optional.empty());
+
+        XpResult result = xpService.getXp(USER_ID, PRODUCT);
+
+        assertThat(result.totalXp()).isEqualTo(0);
+        assertThat(result.currentLevel()).isEqualTo(1);
+        assertThat(result.xpForNextLevel()).isEqualTo(100);
+        assertThat(result.leveledUp()).isFalse();
+    }
+}


### PR DESCRIPTION
Closes #61

## Changes
- **XP System:** New `user_xp` table (V15), `XpService` with level calculation (N*(N-1)*50), `UserXp` entity, `UserXpRepository`
- **XP Wiring:** Grants XP on every practice answer (+10/+2), practice complete (+50), exam submit (answer XP + pass/fail bonus + achievement XP)
- **Streak on Exam:** `MockExamService.submitExam()` now calls `streakService.updateStreak()` — exams count as study activity
- **Domain Name Translation:** Exam result domain breakdown now shows human-readable domain names from Strapi cache instead of codes
- **EarnedAchievementDto:** Added `xpReward` field (sourced from Strapi achievement definitions)
- **Response DTOs:** Added `StreakUpdateDto` and `XpUpdateDto` to `ExamResultDto`; added `XpUpdateDto` to `SessionSummaryDto`

## Test plan
- [ ] `XpServiceTest` — 10 unit tests covering level calculation, XP granting, level-up, edge cases
- [ ] `MockExamServiceTest` — updated with StreakService/XpService mocks, passes with new constructor
- [ ] `PracticeSessionServiceActiveSessionTest` — updated with XpService mock
- [ ] All existing tests pass (`./gradlew test`)
- [ ] Manual: start mock exam → submit → verify response includes `xpUpdate`, `streakUpdate`, and domain names