### PR TITLE
feat(content): add locale-aware exam config preview endpoint

### DIFF
--- a/src/main/java/com/passtheo/content/controller/ExamController.java
+++ b/src/main/java/com/passtheo/content/controller/ExamController.java
@@ -2,6 +2,7 @@ package com.passtheo.content.controller;
 
 import com.passtheo.content.dto.request.StartExamRequest;
 import com.passtheo.content.dto.request.SubmitExamRequest;
+import com.passtheo.content.dto.response.ExamConfigPreviewDto;
 import com.passtheo.content.dto.response.ExamDto;
 import com.passtheo.content.dto.response.ExamHistorySummaryDto;
 import com.passtheo.content.dto.response.ExamResultDto;
@@ -52,6 +53,22 @@ public class ExamController {
                           EntitlementChecker entitlementChecker) {
         this.mockExamService = mockExamService;
         this.entitlementChecker = entitlementChecker;
+    }
+
+    /**
+     * Returns exam configuration preview for the intro screen.
+     *
+     * @param productCode the product code
+     * @param locale      the content locale
+     * @return exam config preview
+     */
+    @GetMapping("/config")
+    public ResponseEntity<ApiResponse<ExamConfigPreviewDto>> getExamConfig(
+            @RequestParam @Nonnull String productCode,
+            @RequestParam(defaultValue = "nl") String locale) {
+
+        ExamConfigPreviewDto config = mockExamService.getExamConfigPreview(productCode, locale);
+        return ResponseEntity.ok(ApiResponse.success(config, MDC.get("traceId")));
     }
 
     /**

--- a/src/main/java/com/passtheo/content/dto/response/ExamConfigPreviewDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/ExamConfigPreviewDto.java
@@ -1,0 +1,16 @@
+package com.passtheo.content.dto.response;
+
+import java.util.List;
+
+/**
+ * Lightweight exam configuration preview for the intro screen.
+ * Contains only the fields needed for display — no internal config like domain weights.
+ */
+public record ExamConfigPreviewDto(
+    String title,
+    String description,
+    int totalQuestions,
+    int timeLimitMinutes,
+    int passScore,
+    List<String> rules
+) {}

--- a/src/main/java/com/passtheo/content/integration/strapi/StrapiClient.java
+++ b/src/main/java/com/passtheo/content/integration/strapi/StrapiClient.java
@@ -193,13 +193,15 @@ public class StrapiClient {
      * Fetches exam config for a product.
      *
      * @param productCode the product code
+     * @param locale      the content locale
      * @return the exam config
      */
-    public StrapiExamConfigDto getExamConfig(@Nonnull String productCode) {
-        LOG.debug("Fetching exam config from Strapi, product={}", productCode);
+    public StrapiExamConfigDto getExamConfig(@Nonnull String productCode, @Nonnull String locale) {
+        LOG.debug("Fetching exam config from Strapi, product={}, locale={}", productCode, locale);
         List<StrapiExamConfigDto> configs = fetchCollection(
                 "/api/exam-configs?filters[product][code][$eq]=" + productCode
-                        + "&populate=domainWeights",
+                        + "&populate=domainWeights"
+                        + "&locale=" + locale,
                 new ParameterizedTypeReference<StrapiResponse<StrapiExamConfigDto>>() {
                 });
         return configs.isEmpty() ? null : configs.getFirst();

--- a/src/main/java/com/passtheo/content/integration/strapi/StrapiContentCache.java
+++ b/src/main/java/com/passtheo/content/integration/strapi/StrapiContentCache.java
@@ -267,10 +267,11 @@ public class StrapiContentCache {
      * Gets exam config for a product with caching.
      *
      * @param productCode the product code
+     * @param locale      the content locale
      * @return the exam config
      */
-    public StrapiExamConfigDto getExamConfig(@Nonnull String productCode) {
-        String cacheKey = CACHE_PREFIX + "examConfig:" + productCode;
+    public StrapiExamConfigDto getExamConfig(@Nonnull String productCode, @Nonnull String locale) {
+        String cacheKey = CACHE_PREFIX + "examConfig:" + productCode + ":" + locale;
         String cached = redisTemplate.opsForValue().get(cacheKey);
         if (cached != null) {
             try {
@@ -280,7 +281,7 @@ public class StrapiContentCache {
             }
         }
 
-        StrapiExamConfigDto config = strapiClient.getExamConfig(productCode);
+        StrapiExamConfigDto config = strapiClient.getExamConfig(productCode, locale);
         if (config != null) {
             cacheValue(cacheKey, config);
         }

--- a/src/main/java/com/passtheo/content/integration/strapi/dto/StrapiExamConfigDto.java
+++ b/src/main/java/com/passtheo/content/integration/strapi/dto/StrapiExamConfigDto.java
@@ -12,6 +12,9 @@ import java.util.Map;
 public record StrapiExamConfigDto(
     int id,
     String documentId,
+    String title,
+    String description,
+    List<String> rules,
     int totalQuestions,
     int timeLimitMinutes,
     int passScore,

--- a/src/main/java/com/passtheo/content/service/MockExamService.java
+++ b/src/main/java/com/passtheo/content/service/MockExamService.java
@@ -13,6 +13,7 @@ import com.passtheo.content.domain.valueobject.StreakResult;
 import com.passtheo.content.domain.valueobject.XpResult;
 import com.passtheo.content.dto.response.AnswerResultDto;
 import com.passtheo.content.dto.response.EarnedAchievementDto;
+import com.passtheo.content.dto.response.ExamConfigPreviewDto;
 import com.passtheo.content.dto.response.ExamDto;
 import com.passtheo.content.dto.response.BreakdownQuestionDto;
 import com.passtheo.content.dto.response.ExamHistorySummaryDto;
@@ -114,6 +115,31 @@ public class MockExamService {
     }
 
     /**
+     * Returns a lightweight preview of the exam configuration for the intro screen.
+     *
+     * @param productCode the product code
+     * @param locale      the content locale
+     * @return exam config preview with display text and numeric parameters
+     */
+    @Transactional(readOnly = true)
+    public ExamConfigPreviewDto getExamConfigPreview(@Nonnull String productCode, @Nonnull String locale) {
+        StrapiExamConfigDto config = strapiContentCache.getExamConfig(productCode, locale);
+        if (config == null) {
+            LOG.error("Exam config not found for preview: product={}", productCode);
+            throw new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR,
+                    "Exam config not found for product: " + productCode);
+        }
+        return new ExamConfigPreviewDto(
+                config.title(),
+                config.description(),
+                config.totalQuestions(),
+                config.timeLimitMinutes(),
+                config.passScore(),
+                config.rules()
+        );
+    }
+
+    /**
      * Starts a mock exam — generates questions across all domains, shuffled.
      *
      * @param userId  the user's Keycloak ID
@@ -124,7 +150,7 @@ public class MockExamService {
     public ExamDto startExam(@Nonnull UUID userId, @Nonnull StartExamRequest request) {
         String locale = request.locale() != null ? request.locale() : "nl";
 
-        StrapiExamConfigDto examConfig = strapiContentCache.getExamConfig(request.productCode());
+        StrapiExamConfigDto examConfig = strapiContentCache.getExamConfig(request.productCode(), locale);
         if (examConfig == null) {
             LOG.error("Exam config not found: product={}", request.productCode());
             throw new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR, "Exam config not found for product: " + request.productCode());

--- a/src/main/java/com/passtheo/content/service/MockExamService.java
+++ b/src/main/java/com/passtheo/content/service/MockExamService.java
@@ -121,21 +121,20 @@ public class MockExamService {
      * @param locale      the content locale
      * @return exam config preview with display text and numeric parameters
      */
-    @Transactional(readOnly = true)
     public ExamConfigPreviewDto getExamConfigPreview(@Nonnull String productCode, @Nonnull String locale) {
         StrapiExamConfigDto config = strapiContentCache.getExamConfig(productCode, locale);
         if (config == null) {
             LOG.error("Exam config not found for preview: product={}", productCode);
-            throw new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR,
+            throw new AppException(HttpStatus.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                     "Exam config not found for product: " + productCode);
         }
         return new ExamConfigPreviewDto(
-                config.title(),
-                config.description(),
+                config.title() != null ? config.title() : "",
+                config.description() != null ? config.description() : "",
                 config.totalQuestions(),
                 config.timeLimitMinutes(),
                 config.passScore(),
-                config.rules()
+                config.rules() != null ? List.copyOf(config.rules()) : List.of()
         );
     }
 

--- a/src/main/java/com/passtheo/content/service/OnboardingCatalogService.java
+++ b/src/main/java/com/passtheo/content/service/OnboardingCatalogService.java
@@ -104,7 +104,7 @@ public class OnboardingCatalogService {
     }
 
     private CatalogProductDto toProductDto(StrapiProductDto product) {
-        StrapiExamConfigDto strapiExamConfig = strapiContentCache.getExamConfig(product.code());
+        StrapiExamConfigDto strapiExamConfig = strapiContentCache.getExamConfig(product.code(), DEFAULT_LOCALE);
         CatalogExamConfigDto examConfig = null;
         if (strapiExamConfig != null) {
             examConfig = new CatalogExamConfigDto(

--- a/src/main/java/com/passtheo/content/service/ReadinessService.java
+++ b/src/main/java/com/passtheo/content/service/ReadinessService.java
@@ -114,7 +114,7 @@ public class ReadinessService {
         int totalAttempts = progressRepository.countTotalAttempts(userId, productCode);
         Integer bestExamScore = examAttemptRepository.findBestScore(userId, productCode);
 
-        StrapiExamConfigDto examConfig = strapiContentCache.getExamConfig(productCode);
+        StrapiExamConfigDto examConfig = strapiContentCache.getExamConfig(productCode, locale);
         int passScore = examConfig != null ? examConfig.passScore() : 44;
 
         // Clamp attempted count to active total — progress records may reference

--- a/src/test/java/com/passtheo/content/KarateRunner.java
+++ b/src/test/java/com/passtheo/content/KarateRunner.java
@@ -170,8 +170,8 @@ class KarateRunner {
                     String documentId = questionId.startsWith("doc-") ? questionId : "doc-" + questionId;
                     return buildSingleQuestion(questionId, documentId, "verkeersborden");
                 });
-        when(strapiClient.getExamConfig(anyString()))
-                .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, 44, null, null, true, false, null, null, false));
+        when(strapiClient.getExamConfig(anyString(), anyString()))
+                .thenReturn(new StrapiExamConfigDto(0, null, "Theory Exam", "Test description", List.of("Rule 1"), 50, 30, 44, null, null, true, false, null, null, false));
         when(strapiClient.getAchievements(anyString()))
                 .thenReturn(buildAchievements());
         when(strapiClient.getRoadSigns(anyString(), anyString(), any()))
@@ -196,7 +196,7 @@ class KarateRunner {
         return List.of(new StrapiProductDto(
                 1, null, "Auto B", "auto-b", "B", "Auto rijbewijs theorie",
                 null, null, true, false, 1,
-                new StrapiExamConfigDto(0, null, 50, 30, 44, null, null, true, false, null, null, false),
+                new StrapiExamConfigDto(0, null, "Theory Exam", "Test description", List.of("Rule 1"), 50, 30, 44, null, null, true, false, null, null, false),
                 8, 500));
     }
 

--- a/src/test/java/com/passtheo/content/unit/ExamControllerTest.java
+++ b/src/test/java/com/passtheo/content/unit/ExamControllerTest.java
@@ -96,4 +96,23 @@ class ExamControllerTest {
         assertThat(response.getBody().getData().rules()).hasSize(2);
         verify(mockExamService).getExamConfigPreview("auto-b", "en");
     }
+
+    @Test
+    void getExamConfig_noLocaleParam_usesDefaultNl() {
+        ExamConfigPreviewDto preview = new ExamConfigPreviewDto(
+                "Theorie-examen",
+                "Simuleer het echte theorie-examen.",
+                50, 30, 44,
+                List.of("Regel 1")
+        );
+        when(mockExamService.getExamConfigPreview("auto-b", "nl")).thenReturn(preview);
+
+        ResponseEntity<ApiResponse<ExamConfigPreviewDto>> response =
+                controller.getExamConfig("auto-b", "nl");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getData().title()).isEqualTo("Theorie-examen");
+        verify(mockExamService).getExamConfigPreview("auto-b", "nl");
+    }
 }

--- a/src/test/java/com/passtheo/content/unit/ExamControllerTest.java
+++ b/src/test/java/com/passtheo/content/unit/ExamControllerTest.java
@@ -2,10 +2,12 @@ package com.passtheo.content.unit;
 
 import com.passtheo.shared.core.dto.AccessGrant;
 import com.passtheo.content.dto.request.StartExamRequest;
+import com.passtheo.content.dto.response.ExamConfigPreviewDto;
 import com.passtheo.content.dto.response.ExamDto;
 import com.passtheo.content.service.EntitlementChecker;
 import com.passtheo.content.service.MockExamService;
 import com.passtheo.content.controller.ExamController;
+import com.passtheo.shared.core.dto.ApiResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,5 +74,26 @@ class ExamControllerTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         verify(mockExamService).startExam(USER_ID, request);
+    }
+
+    @Test
+    void getExamConfig_returnsPreview() {
+        ExamConfigPreviewDto preview = new ExamConfigPreviewDto(
+                "Theory Exam",
+                "Simulate the real theory exam experience under authentic conditions.",
+                50, 30, 44,
+                List.of("Rule 1", "Rule 2")
+        );
+        when(mockExamService.getExamConfigPreview("auto-b", "en")).thenReturn(preview);
+
+        ResponseEntity<ApiResponse<ExamConfigPreviewDto>> response =
+                controller.getExamConfig("auto-b", "en");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getData().title()).isEqualTo("Theory Exam");
+        assertThat(response.getBody().getData().totalQuestions()).isEqualTo(50);
+        assertThat(response.getBody().getData().rules()).hasSize(2);
+        verify(mockExamService).getExamConfigPreview("auto-b", "en");
     }
 }

--- a/src/test/java/com/passtheo/content/unit/MockExamServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/MockExamServiceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.passtheo.content.domain.entity.ExamAttempt;
 import com.passtheo.content.domain.enums.ExamType;
 import com.passtheo.content.dto.request.SubmitExamRequest;
+import com.passtheo.content.dto.response.ExamConfigPreviewDto;
 import com.passtheo.content.dto.response.ExamResultDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiQuestionDto;
@@ -40,7 +41,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.passtheo.content.integration.strapi.dto.StrapiExamConfigDto;
+import com.passtheo.shared.core.exception.AppException;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -155,6 +160,34 @@ class MockExamServiceTest {
                 new StrapiRelationDto(0, null, domainCode, null),
                 new StrapiRelationDto(0, null, "topic", null),
                 null);
+    }
+
+    @Test
+    void getExamConfigPreview_returnsPreviewFromCache() {
+        StrapiExamConfigDto config = new StrapiExamConfigDto(
+                1, "doc1", "Theory Exam", "Simulate the real exam.", List.of("Rule 1", "Rule 2"),
+                50, 30, 44, 45, null, true, false,
+                List.of(), Map.of("easy", 0.2, "medium", 0.5, "hard", 0.3), false
+        );
+        when(strapiContentCache.getExamConfig(PRODUCT_CODE, "en")).thenReturn(config);
+
+        ExamConfigPreviewDto preview = service.getExamConfigPreview(PRODUCT_CODE, "en");
+
+        assertThat(preview.title()).isEqualTo("Theory Exam");
+        assertThat(preview.description()).isEqualTo("Simulate the real exam.");
+        assertThat(preview.totalQuestions()).isEqualTo(50);
+        assertThat(preview.timeLimitMinutes()).isEqualTo(30);
+        assertThat(preview.passScore()).isEqualTo(44);
+        assertThat(preview.rules()).containsExactly("Rule 1", "Rule 2");
+    }
+
+    @Test
+    void getExamConfigPreview_notFound_throwsAppException() {
+        when(strapiContentCache.getExamConfig(PRODUCT_CODE, "en")).thenReturn(null);
+
+        assertThatThrownBy(() -> service.getExamConfigPreview(PRODUCT_CODE, "en"))
+                .isInstanceOf(AppException.class)
+                .hasMessageContaining("Exam config not found");
     }
 
     private ReadinessScore buildMinimalReadiness() {

--- a/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/ReadinessServiceTest.java
@@ -195,8 +195,8 @@ class ReadinessServiceTest {
         when(progressRepository.countCorrect(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(22);
         when(progressRepository.countTotalAttempts(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(30);
         when(examAttemptRepository.findBestScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
-        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE)))
-                .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, 44, null, null, true, false, null, null, false));
+        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE), eq("nl")))
+                .thenReturn(new StrapiExamConfigDto(0, null, null, null, null, 50, 30, 44, null, null, true, false, null, null, false));
         when(userServiceClient.getProfile(any(), any())).thenReturn(Optional.empty());
         when(examAttemptRepository.findAverageScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
         when(examAttemptRepository.findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
@@ -221,8 +221,8 @@ class ReadinessServiceTest {
         when(progressRepository.countCorrect(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(20);
         when(progressRepository.countTotalAttempts(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(30);
         when(examAttemptRepository.findBestScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
-        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE)))
-                .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, 44, null, null, true, false, null, null, false));
+        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE), eq("nl")))
+                .thenReturn(new StrapiExamConfigDto(0, null, null, null, null, 50, 30, 44, null, null, true, false, null, null, false));
         when(progressRepository.aggregateByDomain(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(List.of());
         when(strapiContentCache.getDomains(eq(PRODUCT_CODE), eq(LOCALE))).thenReturn(List.of());
         when(examAttemptRepository.findAverageScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
@@ -488,8 +488,8 @@ class ReadinessServiceTest {
         when(progressRepository.countCorrect(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(20);
         when(progressRepository.countTotalAttempts(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(30);
         when(examAttemptRepository.findBestScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
-        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE)))
-                .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, 44, null, null, true, false, null, null, false));
+        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE), eq("nl")))
+                .thenReturn(new StrapiExamConfigDto(0, null, null, null, null, 50, 30, 44, null, null, true, false, null, null, false));
         when(userServiceClient.getProfile(any(), any())).thenReturn(Optional.empty());
         when(examAttemptRepository.findAverageScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(null);
         when(examAttemptRepository.findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
@@ -540,8 +540,8 @@ class ReadinessServiceTest {
         when(progressRepository.countCorrect(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(correct);
         when(progressRepository.countTotalAttempts(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(attempted);
         when(examAttemptRepository.findBestScore(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(bestExam);
-        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE)))
-                .thenReturn(new StrapiExamConfigDto(0, null, 50, 30, passScore, null, null, true, false, null, null, false));
+        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE), eq("nl")))
+                .thenReturn(new StrapiExamConfigDto(0, null, null, null, null, 50, 30, passScore, null, null, true, false, null, null, false));
         when(progressRepository.aggregateByDomain(eq(USER_ID), eq(PRODUCT_CODE))).thenReturn(List.of());
         when(strapiContentCache.getDomains(eq(PRODUCT_CODE), eq(LOCALE))).thenReturn(List.of());
         // Exam confidence mocks (lenient because individual tests may override)


### PR DESCRIPTION
Closes #63

## Changes
- Added `title`, `description`, `rules` fields to `StrapiExamConfigDto`
- Added `locale` parameter to `StrapiClient.getExamConfig()` and `StrapiContentCache.getExamConfig()`
- Created `ExamConfigPreviewDto` response record
- Added `GET /api/exams/config` endpoint to `ExamController`
- Added `getExamConfigPreview()` to `MockExamService`
- Updated all callers (`ReadinessService`, `OnboardingCatalogService`) for new locale param
- Updated all tests for new constructor + added 3 new tests

## Test plan
- [ ] `./gradlew test` passes
- [ ] `curl GET /api/exams/config?productCode=auto-b&locale=en` returns config
- [ ] Cache key includes locale suffix

## Cross-service
- passtheo/strapi-app-content#10 — Strapi schema adds the fields this reads
- passtheo/passtheo-ui#49 — Flutter calls this new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)