### PR TITLE
fix(content): resolve domain via topic fallback in exam submit

### DIFF
--- a/src/main/java/com/passtheo/content/service/MockExamService.java
+++ b/src/main/java/com/passtheo/content/service/MockExamService.java
@@ -295,7 +295,7 @@ public class MockExamService {
             }
             answerXp += isCorrect ? XpService.XP_CORRECT_ANSWER : XpService.XP_WRONG_ANSWER;
 
-            String domainCode = question.domain() != null ? question.domain().code() : "unknown";
+            String domainCode = resolveDomainCode(question, attempt.getProductCode(), locale);
             domainStats.computeIfAbsent(domainCode, k -> new int[]{0, 0});
             domainStats.get(domainCode)[1]++;
             if (isCorrect) {
@@ -595,6 +595,24 @@ public class MockExamService {
             LOG.error("Failed to serialize JSON: {}", e.getMessage());
             return "{}";
         }
+    }
+
+    /**
+     * Resolves the domain code for a question, falling back to the topic-to-domain mapping cache.
+     *
+     * @param question    the Strapi question
+     * @param productCode the product code for the exam
+     * @param locale      the locale
+     * @return the domain code, or "unknown" if unresolvable
+     */
+    private String resolveDomainCode(StrapiQuestionDto question, String productCode, String locale) {
+        String domainCode = question.domain() != null ? question.domain().code() : null;
+        if ((domainCode == null || domainCode.isBlank())
+                && question.topic() != null && question.topic().code() != null) {
+            domainCode = strapiContentCache.getDomainCodeForTopic(
+                    question.topic().code(), productCode, locale);
+        }
+        return domainCode != null && !domainCode.isBlank() ? domainCode : "unknown";
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/passtheo/content/service/MockExamService.java
+++ b/src/main/java/com/passtheo/content/service/MockExamService.java
@@ -167,7 +167,8 @@ public class MockExamService {
         }
 
         // Select questions using domain weights + difficulty distribution
-        List<StrapiQuestionDto> examQuestions = selectQuestions(allQuestions, examConfig);
+        List<StrapiQuestionDto> examQuestions = selectQuestions(
+                allQuestions, examConfig, request.productCode(), locale);
 
         // Create exam attempt (placeholder — completed on submit)
         UUID examId = UUID.randomUUID();
@@ -512,7 +513,8 @@ public class MockExamService {
      * Falls back to simple shuffle-and-limit if no domainWeights are configured.
      */
     private List<StrapiQuestionDto> selectQuestions(List<StrapiQuestionDto> allQuestions,
-                                                     StrapiExamConfigDto examConfig) {
+                                                     StrapiExamConfigDto examConfig,
+                                                     String productCode, String locale) {
         List<StrapiExamConfigDto.DomainWeightDto> weights = examConfig.domainWeights();
         Map<String, Double> difficultyDist = examConfig.difficultyDistribution();
         int totalTarget = examConfig.totalQuestions();
@@ -521,7 +523,10 @@ public class MockExamService {
         List<StrapiQuestionDto> domainSelected;
         if (weights != null && !weights.isEmpty()) {
             Map<String, List<StrapiQuestionDto>> byDomain = allQuestions.stream()
-                    .collect(Collectors.groupingBy(q -> q.domain() != null ? q.domain().code() : ""));
+                    .collect(Collectors.groupingBy(q -> {
+                        String code = resolveDomainCode(q, productCode, locale);
+                        return code != null && !"unknown".equals(code) ? code : "";
+                    }));
             List<StrapiQuestionDto> selected = new ArrayList<>();
             for (StrapiExamConfigDto.DomainWeightDto w : weights) {
                 List<StrapiQuestionDto> pool = new ArrayList<>(

--- a/src/test/java/com/passtheo/content/unit/MockExamServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/MockExamServiceTest.java
@@ -163,6 +163,43 @@ class MockExamServiceTest {
     }
 
     @Test
+    void submitExam_noDomainOnQuestion_resolvedViaTopic() {
+        ExamAttempt attempt = buildAttempt();
+        when(examAttemptRepository.findByIdAndKeycloakUserId(EXAM_ID, USER_ID))
+                .thenReturn(Optional.of(attempt));
+        when(examAttemptRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(examAnswerRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        // Question has no domain but has a topic
+        StrapiQuestionDto question = buildQuestionWithoutDomain("q1", "verkeersborden");
+        when(strapiContentCache.getQuestion("q1", "nl")).thenReturn(question);
+        when(answerProcessingService.gradeAnswer(eq(question), any())).thenReturn(true);
+        when(answerProcessingService.buildCorrectAnswer(question)).thenReturn(Map.of("answer", true));
+        when(strapiContentCache.getDomainCodeForTopic("verkeersborden", PRODUCT_CODE, "nl"))
+                .thenReturn("voorrang");
+
+        when(readinessService.calculate(eq(USER_ID), eq(PRODUCT_CODE), eq("nl")))
+                .thenReturn(buildMinimalReadiness());
+        when(achievementService.checkAchievements(USER_ID, PRODUCT_CODE)).thenReturn(List.of());
+        when(streakService.updateStreak(USER_ID, PRODUCT_CODE))
+                .thenReturn(new StreakResult(1, 1, 1, null, 0, 0, true, false, true));
+        when(xpService.grantXp(eq(USER_ID), eq(PRODUCT_CODE), anyInt()))
+                .thenReturn(new XpResult(14, 14, 1, 100, false, 1));
+        when(strapiContentCache.getDomains(PRODUCT_CODE, "nl"))
+                .thenReturn(List.of(new StrapiDomainDto(1, "d1", "Voorrang", "voorrang", null, null, null, null, null, true, false, 1)));
+
+        SubmitExamRequest request = new SubmitExamRequest(List.of(
+                new SubmitExamRequest.ExamAnswerItem("q1", Map.of("answer", true), 5000)
+        ));
+
+        ExamResultDto result = service.submitExam(USER_ID, EXAM_ID, request, "nl");
+
+        assertThat(result.domainBreakdown()).hasSize(1);
+        assertThat(result.domainBreakdown().get(0).domainCode()).isEqualTo("voorrang");
+        assertThat(result.domainBreakdown().get(0).domainName()).isEqualTo("Voorrang");
+    }
+
+    @Test
     void getExamConfigPreview_returnsPreviewFromCache() {
         StrapiExamConfigDto config = new StrapiExamConfigDto(
                 1, "doc1", "Theory Exam", "Simulate the real exam.", List.of("Rule 1", "Rule 2"),
@@ -188,6 +225,17 @@ class MockExamServiceTest {
         assertThatThrownBy(() -> service.getExamConfigPreview(PRODUCT_CODE, "en"))
                 .isInstanceOf(AppException.class)
                 .hasMessageContaining("Exam config not found");
+    }
+
+    private StrapiQuestionDto buildQuestionWithoutDomain(String docId, String topicCode) {
+        return new StrapiQuestionDto(
+                1, docId, "Question " + docId,
+                "yes_no", "medium",
+                null, null, null, null, 1, false, false, null, null,
+                List.of(), null, null, null, null, null,
+                null,
+                new StrapiRelationDto(0, null, topicCode, null),
+                null);
     }
 
     private ReadinessScore buildMinimalReadiness() {


### PR DESCRIPTION
Closes #65

## Changes
- Added `resolveDomainCode()` private method to `MockExamService` that resolves domain via `strapiContentCache.getDomainCodeForTopic()` when `question.domain()` is null — matching the existing approach in `PracticeSessionService`
- Replaced direct ternary fallback to `"unknown"` at line 298 with the new method
- Added unit test verifying topic-to-domain fallback works correctly

## Test plan
- [ ] Submit a mock exam — domain breakdown shows correct domain names (not "unknown")
- [ ] Questions with a direct domain relation still resolve correctly
- [ ] Questions with only a topic resolve via topic-to-domain cache
- [ ] Deactivated questions still show "unknown" (expected behavior)