### PR TITLE
feat(content): hide correct answers for skipped questions in exam breakdown

### DIFF
--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -2029,14 +2029,25 @@ components:
 
     BreakdownQuestionDto:
       type: object
+      description: >
+        Per-question detail in the session/exam breakdown. When isSkipped is true,
+        userAnswer is null and correctAnswer is an empty object (answer not revealed
+        for unanswered questions).
       properties:
         questionOrder: { type: integer }
         strapiQuestionId: { type: string }
         interactionType: { type: string }
         isCorrect: { type: boolean }
-        isSkipped: { type: boolean }
-        userAnswer: { type: object }
-        correctAnswer: { type: object }
+        isSkipped:
+          type: boolean
+          description: True when the question was not answered (skipped or timer expired)
+        userAnswer:
+          type: object
+          nullable: true
+          description: The user's submitted answer, or null if skipped
+        correctAnswer:
+          type: object
+          description: The correct answer. Empty object when isSkipped is true (not revealed)
         questionSnapshot: { type: object }
         domainCode: { type: string }
         domainName: { type: string }

--- a/src/main/java/com/passtheo/content/service/MockExamService.java
+++ b/src/main/java/com/passtheo/content/service/MockExamService.java
@@ -293,8 +293,8 @@ public class MockExamService {
                 continue;
             }
 
-            // Null answer means skipped (e.g. timer expired) — treat as incorrect, no grading
-            boolean isSkipped = item.answer() == null;
+            // Null or empty answer means skipped (e.g. timer expired) — treat as incorrect, no grading
+            boolean isSkipped = item.answer() == null || item.answer().isEmpty();
             boolean isCorrect = !isSkipped && answerProcessingService.gradeAnswer(question, item.answer());
             if (isCorrect) {
                 correctCount++;
@@ -455,7 +455,8 @@ public class MockExamService {
         int skippedCount = 0;
         List<BreakdownQuestionDto> breakdownQuestions = new ArrayList<>();
         for (ExamAnswer ea : answers) {
-            boolean isSkipped = SKIP_ANSWER_JSON.equals(ea.getUserAnswer());
+            boolean isSkipped = SKIP_ANSWER_JSON.equals(ea.getUserAnswer())
+                    || "{}".equals(ea.getUserAnswer());
             if (isSkipped) {
                 skippedCount++;
             }

--- a/src/main/java/com/passtheo/content/service/MockExamService.java
+++ b/src/main/java/com/passtheo/content/service/MockExamService.java
@@ -67,6 +67,9 @@ public class MockExamService {
     private static final Logger LOG = LoggerFactory.getLogger(MockExamService.class);
     private static final Logger AUDIT = LoggerFactory.getLogger("AUDIT");
 
+    /** JSON representation of a skipped answer stored in exam_answers.user_answer. */
+    private static final String SKIP_ANSWER_JSON = "null";
+
     private final ExamAttemptRepository examAttemptRepository;
     private final ExamAnswerRepository examAnswerRepository;
     private final StrapiContentCache strapiContentCache;
@@ -290,7 +293,9 @@ public class MockExamService {
                 continue;
             }
 
-            boolean isCorrect = answerProcessingService.gradeAnswer(question, item.answer());
+            // Null answer means skipped (e.g. timer expired) — treat as incorrect, no grading
+            boolean isSkipped = item.answer() == null;
+            boolean isCorrect = !isSkipped && answerProcessingService.gradeAnswer(question, item.answer());
             if (isCorrect) {
                 correctCount++;
             }
@@ -303,7 +308,8 @@ public class MockExamService {
                 domainStats.get(domainCode)[0]++;
             }
 
-            // Save exam answer
+            // Save exam answer — use SKIP_ANSWER_JSON for skips (JSONB accepts JSON null)
+            String userAnswerJson = isSkipped ? SKIP_ANSWER_JSON : serializeJson(item.answer());
             ExamAnswer examAnswer = new ExamAnswer();
             examAnswer.setTenantId(TenantContext.get());
             examAnswer.setExamAttemptId(examId);
@@ -311,15 +317,15 @@ public class MockExamService {
             examAnswer.setQuestionVersion(question.version());
             examAnswer.setDomainCode(domainCode);
             examAnswer.setCorrect(isCorrect);
-            examAnswer.setUserAnswer(serializeJson(item.answer()));
+            examAnswer.setUserAnswer(userAnswerJson);
             examAnswer.setCorrectAnswer(serializeJson(answerProcessingService.buildCorrectAnswer(question)));
             examAnswer.setTimeTakenMs(item.timeTakenMs());
             examAnswer.setQuestionOrder(i + 1);
             examAnswer.setAnsweredAt(Instant.now());
             examAnswerRepository.save(examAnswer);
 
-            // Collect wrong answers for review
-            if (!isCorrect) {
+            // Collect wrong answers for review (skipped questions are not "wrong", just unanswered)
+            if (!isCorrect && !isSkipped) {
                 AnswerResultDto.ExplanationDto explanation = question.explanation() != null
                         ? new AnswerResultDto.ExplanationDto(
                         question.explanation().text(), question.explanation().tip(),
@@ -446,8 +452,14 @@ public class MockExamService {
                 .stream()
                 .collect(Collectors.toMap(StrapiDomainDto::code, StrapiDomainDto::name, (a, b) -> a));
 
+        int skippedCount = 0;
         List<BreakdownQuestionDto> breakdownQuestions = new ArrayList<>();
         for (ExamAnswer ea : answers) {
+            boolean isSkipped = SKIP_ANSWER_JSON.equals(ea.getUserAnswer());
+            if (isSkipped) {
+                skippedCount++;
+            }
+
             StrapiQuestionDto question = strapiContentCache.getQuestion(ea.getStrapiQuestionId(), locale);
 
             Map<String, Object> snapshot = Map.of();
@@ -457,14 +469,18 @@ public class MockExamService {
                 interactionType = question.interactionType();
             }
 
+            // For skipped questions: don't reveal the correct answer, same as practice breakdowns
+            Map<String, Object> userAnswer = isSkipped ? null : deserializeJson(ea.getUserAnswer());
+            Map<String, Object> correctAnswer = isSkipped ? Map.of() : deserializeJson(ea.getCorrectAnswer());
+
             breakdownQuestions.add(new BreakdownQuestionDto(
                     ea.getQuestionOrder(),
                     ea.getStrapiQuestionId(),
                     interactionType,
                     ea.isCorrect(),
-                    false, // exams have no skipped questions
-                    deserializeJson(ea.getUserAnswer()),
-                    deserializeJson(ea.getCorrectAnswer()),
+                    isSkipped,
+                    userAnswer,
+                    correctAnswer,
                     snapshot,
                     ea.getDomainCode(),
                     domainNameMap.getOrDefault(ea.getDomainCode(), ea.getDomainCode()),
@@ -479,7 +495,7 @@ public class MockExamService {
                 "COMPLETED",
                 attempt.getTotalQuestions(),
                 attempt.getCorrectCount(),
-                0, // no skipped in exams
+                skippedCount,
                 attempt.getScorePercent() != null ? attempt.getScorePercent().doubleValue() : 0.0,
                 attempt.getTimeTakenSeconds(),
                 new SessionSummaryDto.MasteryChangesDto(0, 0, 0),

--- a/src/test/java/com/passtheo/content/unit/MockExamServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/MockExamServiceTest.java
@@ -1,11 +1,13 @@
 package com.passtheo.content.unit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.passtheo.content.domain.entity.ExamAnswer;
 import com.passtheo.content.domain.entity.ExamAttempt;
 import com.passtheo.content.domain.enums.ExamType;
 import com.passtheo.content.dto.request.SubmitExamRequest;
 import com.passtheo.content.dto.response.ExamConfigPreviewDto;
 import com.passtheo.content.dto.response.ExamResultDto;
+import com.passtheo.content.dto.response.SessionBreakdownDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiQuestionDto;
 import com.passtheo.content.integration.strapi.dto.StrapiRelationDto;
@@ -197,6 +199,103 @@ class MockExamServiceTest {
         assertThat(result.domainBreakdown()).hasSize(1);
         assertThat(result.domainBreakdown().get(0).domainCode()).isEqualTo("voorrang");
         assertThat(result.domainBreakdown().get(0).domainName()).isEqualTo("Voorrang");
+    }
+
+    @Test
+    void submitExam_skippedQuestion_recordedAsIncorrectNotInWrongAnswers() {
+        ExamAttempt attempt = buildAttempt();
+        when(examAttemptRepository.findByIdAndKeycloakUserId(EXAM_ID, USER_ID))
+                .thenReturn(Optional.of(attempt));
+        when(examAttemptRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(examAnswerRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        // q1 answered correctly, q2 skipped (null answer)
+        StrapiQuestionDto q1 = buildQuestion("q1", "voorrang");
+        StrapiQuestionDto q2 = buildQuestion("q2", "voorrang");
+        when(strapiContentCache.getQuestion("q1", "nl")).thenReturn(q1);
+        when(strapiContentCache.getQuestion("q2", "nl")).thenReturn(q2);
+        when(answerProcessingService.gradeAnswer(eq(q1), any())).thenReturn(true);
+        when(answerProcessingService.buildCorrectAnswer(q1)).thenReturn(Map.of("selectedOptionId", "1"));
+        when(answerProcessingService.buildCorrectAnswer(q2)).thenReturn(Map.of("selectedOptionId", "2"));
+
+        when(readinessService.calculate(eq(USER_ID), eq(PRODUCT_CODE), eq("nl")))
+                .thenReturn(buildMinimalReadiness());
+        when(achievementService.checkAchievements(USER_ID, PRODUCT_CODE)).thenReturn(List.of());
+        when(streakService.updateStreak(USER_ID, PRODUCT_CODE))
+                .thenReturn(new StreakResult(1, 1, 1, null, 0, 0, true, false, true));
+        when(xpService.grantXp(eq(USER_ID), eq(PRODUCT_CODE), anyInt()))
+                .thenReturn(new XpResult(14, 14, 1, 100, false, 1));
+        when(strapiContentCache.getDomains(PRODUCT_CODE, "nl"))
+                .thenReturn(List.of(new StrapiDomainDto(1, "d1", "Voorrang", "voorrang", null, null, null, null, null, true, false, 1)));
+
+        SubmitExamRequest request = new SubmitExamRequest(List.of(
+                new SubmitExamRequest.ExamAnswerItem("q1", Map.of("selectedOptionId", "1"), 5000),
+                new SubmitExamRequest.ExamAnswerItem("q2", null, null) // skipped
+        ));
+
+        ExamResultDto result = service.submitExam(USER_ID, EXAM_ID, request, "nl");
+
+        // q1 correct, q2 skipped (treated as incorrect) → 1/2
+        assertThat(result.correctCount()).isEqualTo(1);
+        assertThat(result.totalQuestions()).isEqualTo(2);
+        // Skipped questions should NOT appear in wrongAnswers
+        assertThat(result.wrongAnswers()).isEmpty();
+    }
+
+    @Test
+    void getExamBreakdown_skippedQuestion_hidesCorrectAnswer() {
+        ExamAttempt attempt = buildAttempt();
+        attempt.setCorrectCount(1);
+        attempt.setScorePercent(BigDecimal.valueOf(50.0));
+        attempt.setTimeTakenSeconds(120);
+        when(examAttemptRepository.findByIdAndKeycloakUserId(EXAM_ID, USER_ID))
+                .thenReturn(Optional.of(attempt));
+
+        // q1 answered, q2 skipped (userAnswer stored as "null")
+        ExamAnswer answered = new ExamAnswer();
+        answered.setQuestionOrder(1);
+        answered.setStrapiQuestionId("q1");
+        answered.setCorrect(true);
+        answered.setUserAnswer("{\"selectedOptionId\":\"1\"}");
+        answered.setCorrectAnswer("{\"selectedOptionId\":\"1\"}");
+        answered.setDomainCode("voorrang");
+
+        ExamAnswer skipped = new ExamAnswer();
+        skipped.setQuestionOrder(2);
+        skipped.setStrapiQuestionId("q2");
+        skipped.setCorrect(false);
+        skipped.setUserAnswer("null"); // SKIP_ANSWER_JSON
+        skipped.setCorrectAnswer("{\"selectedOptionId\":\"2\"}");
+        skipped.setDomainCode("voorrang");
+
+        when(examAnswerRepository.findByExamAttemptIdOrderByQuestionOrderAsc(EXAM_ID))
+                .thenReturn(List.of(answered, skipped));
+        when(strapiContentCache.getDomains(PRODUCT_CODE, "nl"))
+                .thenReturn(List.of(new StrapiDomainDto(1, "d1", "Voorrang", "voorrang", null, null, null, null, null, true, false, 1)));
+
+        StrapiQuestionDto q1 = buildQuestion("q1", "voorrang");
+        StrapiQuestionDto q2 = buildQuestion("q2", "voorrang");
+        when(strapiContentCache.getQuestion("q1", "nl")).thenReturn(q1);
+        when(strapiContentCache.getQuestion("q2", "nl")).thenReturn(q2);
+        when(answerProcessingService.buildQuestionSnapshot(q1)).thenReturn(Map.of("text", "Q1"));
+        when(answerProcessingService.buildQuestionSnapshot(q2)).thenReturn(Map.of("text", "Q2"));
+
+        SessionBreakdownDto breakdown = service.getExamBreakdown(USER_ID, EXAM_ID, "nl");
+
+        assertThat(breakdown.skippedCount()).isEqualTo(1);
+        assertThat(breakdown.questions()).hasSize(2);
+
+        // Answered question — shows both user and correct answer
+        var q1Dto = breakdown.questions().get(0);
+        assertThat(q1Dto.isSkipped()).isFalse();
+        assertThat(q1Dto.userAnswer()).isNotNull();
+        assertThat(q1Dto.correctAnswer()).isNotEmpty();
+
+        // Skipped question — hides correct answer, null user answer
+        var q2Dto = breakdown.questions().get(1);
+        assertThat(q2Dto.isSkipped()).isTrue();
+        assertThat(q2Dto.userAnswer()).isNull();
+        assertThat(q2Dto.correctAnswer()).isEmpty(); // empty map, not revealed
     }
 
     @Test


### PR DESCRIPTION
Closes #67

## Changes
- Updated `MockExamService.submitExam()` to detect skipped/unanswered questions (`answer == null`) and store them with `"null"` user answer JSON (same sentinel as practice sessions)
- Updated `MockExamService.getExamBreakdown()` to check for skipped answers and set `isSkipped = true`, return null `userAnswer` and empty `correctAnswer` (don't reveal the answer)
- Updated `skippedCount` in breakdown summary to reflect actual skipped questions
- Skipped questions are NOT included in the `wrongAnswers` list (they're unanswered, not wrong)
- Updated OpenAPI spec with descriptions for `isSkipped`, `userAnswer`, and `correctAnswer` fields
- Added 2 unit tests: submit with skipped questions, breakdown with skipped questions

## Test plan
- [ ] Submit a mock exam with some null answers (simulating timer expiry) — verify skipped answers stored correctly
- [ ] Fetch exam breakdown — verify skipped questions have `isSkipped: true`, null `userAnswer`, empty `correctAnswer`
- [ ] Verify answered questions still show correct answers as before
- [ ] Verify Flutter UI shows "Skipped" label for skipped exam questions (shared widget already handles this)