### PR TITLE
fix(content): report validation, exam submit null answers

### DIFF
--- a/src/main/java/com/passtheo/content/dto/request/QuestionReportRequest.java
+++ b/src/main/java/com/passtheo/content/dto/request/QuestionReportRequest.java
@@ -1,12 +1,15 @@
 package com.passtheo.content.dto.request;
 
 import com.passtheo.content.domain.enums.ReportType;
-import jakarta.annotation.Nonnull;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * Request to report an error in a question.
+ *
+ * @param reportType the type of report (INCORRECT_ANSWER, UNCLEAR_QUESTION, WRONG_IMAGE, WRONG_EXPLANATION, OTHER)
+ * @param comment optional comment with additional details
  */
 public record QuestionReportRequest(
-    @Nonnull ReportType reportType,
+    @NotNull ReportType reportType,
     String comment
 ) {}

--- a/src/main/java/com/passtheo/content/service/MockExamService.java
+++ b/src/main/java/com/passtheo/content/service/MockExamService.java
@@ -290,7 +290,8 @@ public class MockExamService {
                 continue;
             }
 
-            boolean isCorrect = answerProcessingService.gradeAnswer(question, item.answer());
+            boolean isCorrect = item.answer() != null && !item.answer().isEmpty()
+                    && answerProcessingService.gradeAnswer(question, item.answer());
             if (isCorrect) {
                 correctCount++;
             }


### PR DESCRIPTION
Closes #69

## Changes
- **QuestionReportRequest**: Changed `@Nonnull` (documentation hint) to `@NotNull` (Bean Validation) on `reportType` field — missing `reportType` now returns 400 instead of 500 `DataIntegrityViolationException`
- **MockExamService.submitExam**: Added null/empty check on `item.answer()` before calling `gradeAnswer()` — skipped questions (answer=null) in exam submit were causing NPE at `AnswerProcessingService.gradeTapOnImage()`

## Test plan
- [x] `POST /api/content/questions/{id}/report` with missing `reportType` returns 400
- [x] Mock exam submit with skipped questions no longer returns 500
- [x] Full API flow test: 345/345 pass