### PR TITLE
feat(content): implement ReadinessSnapshotJob for daily readiness snapshots

### DIFF
--- a/src/main/java/com/passtheo/content/domain/entity/ReadinessSnapshot.java
+++ b/src/main/java/com/passtheo/content/domain/entity/ReadinessSnapshot.java
@@ -47,7 +47,8 @@ public class ReadinessSnapshot extends BaseEntity {
     @Column(name = "best_exam_score")
     private Integer bestExamScore;
 
-    protected ReadinessSnapshot() {}
+    /** JPA requires a no-arg constructor. Public so schedulers/services can create instances. */
+    public ReadinessSnapshot() {}
 
     public UUID getKeycloakUserId() { return keycloakUserId; }
     public void setKeycloakUserId(UUID keycloakUserId) { this.keycloakUserId = keycloakUserId; }

--- a/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
+++ b/src/main/java/com/passtheo/content/repository/QuestionProgressRepository.java
@@ -89,6 +89,30 @@ public interface QuestionProgressRepository extends JpaRepository<QuestionProgre
                                                      @Nonnull @Param("productCode") String productCode);
 
     /**
+     * Projection for distinct active user-product-tenant tuples.
+     * Used by ReadinessSnapshotJob to snapshot all active users.
+     */
+    interface UserProductProjection {
+        /** @return the tenant UUID */
+        UUID getTenantId();
+        /** @return the user's Keycloak UUID */
+        UUID getKeycloakUserId();
+        /** @return the product code */
+        String getProductCode();
+    }
+
+    /**
+     * Finds distinct active user/product/tenant combinations that have question progress.
+     *
+     * @return list of projections for each unique tuple
+     */
+    @Query(value = "SELECT DISTINCT tenant_id AS tenantId, keycloak_user_id AS keycloakUserId, " +
+           "product_code AS productCode FROM question_progress " +
+           "WHERE total_attempts > 0 AND deleted_at IS NULL",
+           nativeQuery = true)
+    List<UserProductProjection> findDistinctActiveUserProducts();
+
+    /**
      * Per-topic mastery aggregate computed directly from question_progress rows.
      * Used instead of the (never-populated) topic_progress table.
      */

--- a/src/main/java/com/passtheo/content/repository/ReadinessSnapshotRepository.java
+++ b/src/main/java/com/passtheo/content/repository/ReadinessSnapshotRepository.java
@@ -27,6 +27,18 @@ public interface ReadinessSnapshotRepository extends JpaRepository<ReadinessSnap
             @Nonnull UUID keycloakUserId, @Nonnull String productCode, @Nonnull LocalDate since);
 
     /**
+     * Checks whether a snapshot already exists for a user/product/date.
+     * Used by ReadinessSnapshotJob to prevent duplicate snapshots.
+     *
+     * @param keycloakUserId the user's Keycloak ID
+     * @param productCode    the product code
+     * @param snapshotDate   the date
+     * @return true if a snapshot already exists
+     */
+    boolean existsByKeycloakUserIdAndProductCodeAndSnapshotDate(
+            @Nonnull UUID keycloakUserId, @Nonnull String productCode, @Nonnull LocalDate snapshotDate);
+
+    /**
      * Deletes all snapshots for a user (GDPR).
      *
      * @param keycloakUserId the user's Keycloak ID

--- a/src/main/java/com/passtheo/content/scheduler/ReadinessSnapshotJob.java
+++ b/src/main/java/com/passtheo/content/scheduler/ReadinessSnapshotJob.java
@@ -1,47 +1,160 @@
 package com.passtheo.content.scheduler;
 
 import com.passtheo.content.domain.entity.ReadinessSnapshot;
-import com.passtheo.content.domain.valueobject.ReadinessScore;
+import com.passtheo.content.integration.strapi.StrapiContentCache;
+import com.passtheo.content.integration.strapi.dto.StrapiExamConfigDto;
+import com.passtheo.content.repository.ExamAttemptRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
+import com.passtheo.content.repository.QuestionProgressRepository.UserProductProjection;
 import com.passtheo.content.repository.ReadinessSnapshotRepository;
-import com.passtheo.content.service.ReadinessService;
+import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.List;
 
 /**
  * Daily job at 01:00 UTC — snapshots readiness scores for all active users.
+ *
+ * <p>For each distinct (tenant, user, product) tuple in question_progress,
+ * computes coverage, accuracy, and exam scores using the same formula as
+ * {@link com.passtheo.content.service.ReadinessService} and persists a
+ * {@link ReadinessSnapshot} for today. Duplicate snapshots (same user/product/date)
+ * are skipped.</p>
+ *
+ * <p>RLS is bypassed because the application connects as the table owner
+ * (no FORCE ROW LEVEL SECURITY). The job sets {@code tenantId} explicitly
+ * on each entity to satisfy the NOT NULL column constraint.</p>
  */
 @Component
 public class ReadinessSnapshotJob {
 
     private static final Logger LOG = LoggerFactory.getLogger(ReadinessSnapshotJob.class);
 
+    private static final double COVERAGE_WEIGHT = 0.40;
+    private static final double ACCURACY_WEIGHT = 0.35;
+    private static final double EXAM_WEIGHT = 0.25;
+    private static final int SCORE_SCALE = 2;
+    private static final int DEFAULT_PASS_SCORE = 44;
+    private static final String DEFAULT_LOCALE = "nl";
+
+    private final QuestionProgressRepository progressRepository;
     private final ReadinessSnapshotRepository snapshotRepository;
+    private final ExamAttemptRepository examAttemptRepository;
+    private final StrapiContentCache strapiContentCache;
 
     /**
      * Constructs the readiness snapshot job.
      *
-     * @param snapshotRepository readiness snapshot repository
+     * @param progressRepository   question progress repository
+     * @param snapshotRepository   readiness snapshot repository
+     * @param examAttemptRepository exam attempt repository
+     * @param strapiContentCache   Strapi content cache for question counts
      */
-    public ReadinessSnapshotJob(ReadinessSnapshotRepository snapshotRepository) {
+    public ReadinessSnapshotJob(QuestionProgressRepository progressRepository,
+                                ReadinessSnapshotRepository snapshotRepository,
+                                ExamAttemptRepository examAttemptRepository,
+                                StrapiContentCache strapiContentCache) {
+        this.progressRepository = progressRepository;
         this.snapshotRepository = snapshotRepository;
+        this.examAttemptRepository = examAttemptRepository;
+        this.strapiContentCache = strapiContentCache;
     }
 
     /**
-     * Runs daily at 01:00 UTC to snapshot readiness for active users.
-     * In production, this would query for active users and calculate each.
-     * For now, it's a placeholder that logs execution.
+     * Runs daily at 01:00 UTC to snapshot readiness for all active users.
      */
     @Scheduled(cron = "0 0 1 * * *", zone = "UTC")
+    @Transactional
     public void snapshotReadiness() {
-        LOG.info("ReadinessSnapshotJob started at {}", LocalDate.now(ZoneOffset.UTC));
-        // In production: query distinct users from question_progress, calculate readiness, save snapshot
-        LOG.info("ReadinessSnapshotJob completed");
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        LOG.info("ReadinessSnapshotJob started for {}", today);
+
+        List<UserProductProjection> activeUsers = progressRepository.findDistinctActiveUserProducts();
+        int created = 0;
+        int skipped = 0;
+        int failed = 0;
+
+        for (UserProductProjection up : activeUsers) {
+            if (snapshotRepository.existsByKeycloakUserIdAndProductCodeAndSnapshotDate(
+                    up.getKeycloakUserId(), up.getProductCode(), today)) {
+                skipped++;
+                continue;
+            }
+
+            try {
+                ReadinessSnapshot snapshot = computeSnapshot(up, today);
+                snapshotRepository.save(snapshot);
+                created++;
+            } catch (Exception e) {
+                failed++;
+                LOG.warn("Failed to snapshot user={} product={}: {}",
+                        up.getKeycloakUserId(), up.getProductCode(), e.getMessage());
+            }
+        }
+
+        LOG.info("ReadinessSnapshotJob completed — created={}, skipped={}, failed={}, total={}",
+                created, skipped, failed, activeUsers.size());
+    }
+
+    /**
+     * Computes a readiness snapshot for a single user/product.
+     * Uses the same weighted formula as ReadinessService:
+     * readiness = (0.40 × coverage) + (0.35 × accuracy) + (0.25 × examScore)
+     *
+     * @param up    the user-product-tenant tuple
+     * @param today the snapshot date
+     * @return the populated snapshot entity (not yet persisted)
+     */
+    @Nonnull
+    public ReadinessSnapshot computeSnapshot(@Nonnull UserProductProjection up, @Nonnull LocalDate today) {
+        var userId = up.getKeycloakUserId();
+        var productCode = up.getProductCode();
+
+        int attempted = progressRepository.countAttempted(userId, productCode);
+        int totalCorrect = progressRepository.countCorrect(userId, productCode);
+        int totalAttempts = progressRepository.countTotalAttempts(userId, productCode);
+        int totalQuestions = strapiContentCache.getQuestionCount(productCode, DEFAULT_LOCALE);
+        Integer bestExamScore = examAttemptRepository.findBestScore(userId, productCode);
+
+        StrapiExamConfigDto examConfig = strapiContentCache.getExamConfig(productCode, DEFAULT_LOCALE);
+        int passScore = examConfig != null ? examConfig.passScore() : DEFAULT_PASS_SCORE;
+
+        int clampedAttempted = Math.min(attempted, totalQuestions);
+        double coverage = totalQuestions > 0
+                ? (double) clampedAttempted / totalQuestions * 100.0 : 0.0;
+        double accuracy = totalAttempts > 0
+                ? (double) totalCorrect / totalAttempts * 100.0 : 0.0;
+        double exam = 0.0;
+        if (bestExamScore != null && passScore > 0) {
+            exam = Math.min(100.0, (double) bestExamScore / passScore * 100.0);
+        }
+        double readiness = Math.min(100.0,
+                COVERAGE_WEIGHT * coverage + ACCURACY_WEIGHT * accuracy + EXAM_WEIGHT * exam);
+
+        ReadinessSnapshot snapshot = new ReadinessSnapshot();
+        snapshot.setTenantId(up.getTenantId());
+        snapshot.setKeycloakUserId(userId);
+        snapshot.setProductCode(productCode);
+        snapshot.setSnapshotDate(today);
+        snapshot.setReadinessScore(toBigDecimal(readiness));
+        snapshot.setCoverageScore(toBigDecimal(coverage));
+        snapshot.setAccuracyScore(toBigDecimal(accuracy));
+        snapshot.setExamScore(toBigDecimal(exam));
+        snapshot.setQuestionsAttempted(clampedAttempted);
+        snapshot.setTotalQuestions(totalQuestions);
+        snapshot.setBestExamScore(bestExamScore);
+        return snapshot;
+    }
+
+    private static BigDecimal toBigDecimal(double value) {
+        return BigDecimal.valueOf(value).setScale(SCORE_SCALE, RoundingMode.HALF_UP);
     }
 }

--- a/src/main/java/com/passtheo/content/scheduler/ReadinessSnapshotJob.java
+++ b/src/main/java/com/passtheo/content/scheduler/ReadinessSnapshotJob.java
@@ -12,7 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -72,7 +71,6 @@ public class ReadinessSnapshotJob {
      * Runs daily at 01:00 UTC to snapshot readiness for all active users.
      */
     @Scheduled(cron = "0 0 1 * * *", zone = "UTC")
-    @Transactional
     public void snapshotReadiness() {
         LocalDate today = LocalDate.now(ZoneOffset.UTC);
         LOG.info("ReadinessSnapshotJob started for {}", today);

--- a/src/test/java/com/passtheo/content/unit/ReadinessSnapshotJobTest.java
+++ b/src/test/java/com/passtheo/content/unit/ReadinessSnapshotJobTest.java
@@ -1,0 +1,157 @@
+package com.passtheo.content.unit;
+
+import com.passtheo.content.domain.entity.ReadinessSnapshot;
+import com.passtheo.content.integration.strapi.StrapiContentCache;
+import com.passtheo.content.integration.strapi.dto.StrapiExamConfigDto;
+import com.passtheo.content.repository.ExamAttemptRepository;
+import com.passtheo.content.repository.QuestionProgressRepository;
+import com.passtheo.content.repository.QuestionProgressRepository.UserProductProjection;
+import com.passtheo.content.repository.ReadinessSnapshotRepository;
+import com.passtheo.content.scheduler.ReadinessSnapshotJob;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for ReadinessSnapshotJob — score computation logic.
+ */
+@ExtendWith(MockitoExtension.class)
+class ReadinessSnapshotJobTest {
+
+    @Mock private QuestionProgressRepository progressRepository;
+    @Mock private ReadinessSnapshotRepository snapshotRepository;
+    @Mock private ExamAttemptRepository examAttemptRepository;
+    @Mock private StrapiContentCache strapiContentCache;
+
+    private ReadinessSnapshotJob job;
+
+    private static final UUID TENANT_ID = UUID.randomUUID();
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final String PRODUCT_CODE = "auto-b";
+    private static final LocalDate TODAY = LocalDate.of(2026, 4, 14);
+
+    @BeforeEach
+    void setUp() {
+        job = new ReadinessSnapshotJob(progressRepository, snapshotRepository,
+                examAttemptRepository, strapiContentCache);
+    }
+
+    @Test
+    void computeSnapshot_typicalProgress_correctWeightedScore() {
+        UserProductProjection up = stubProjection(TENANT_ID, USER_ID, PRODUCT_CODE);
+
+        // 200 of 500 questions attempted → 40% coverage
+        when(progressRepository.countAttempted(USER_ID, PRODUCT_CODE)).thenReturn(200);
+        when(progressRepository.countCorrect(USER_ID, PRODUCT_CODE)).thenReturn(160);
+        when(progressRepository.countTotalAttempts(USER_ID, PRODUCT_CODE)).thenReturn(200);
+        when(strapiContentCache.getQuestionCount(PRODUCT_CODE, "nl")).thenReturn(500);
+        when(examAttemptRepository.findBestScore(USER_ID, PRODUCT_CODE)).thenReturn(40);
+        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE), eq("nl")))
+                .thenReturn(examConfig(44));
+
+        ReadinessSnapshot snapshot = job.computeSnapshot(up, TODAY);
+
+        // coverage = 200/500 * 100 = 40.0
+        // accuracy = 160/200 * 100 = 80.0
+        // exam = min(100, 40/44 * 100) = 90.91
+        // readiness = 0.40*40 + 0.35*80 + 0.25*90.91 = 16 + 28 + 22.73 = 66.73
+        assertThat(snapshot.getCoverageScore().doubleValue()).isCloseTo(40.0, within(0.01));
+        assertThat(snapshot.getAccuracyScore().doubleValue()).isCloseTo(80.0, within(0.01));
+        assertThat(snapshot.getExamScore().doubleValue()).isCloseTo(90.91, within(0.01));
+        assertThat(snapshot.getReadinessScore().doubleValue()).isCloseTo(66.73, within(0.01));
+        assertThat(snapshot.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(snapshot.getKeycloakUserId()).isEqualTo(USER_ID);
+        assertThat(snapshot.getProductCode()).isEqualTo(PRODUCT_CODE);
+        assertThat(snapshot.getSnapshotDate()).isEqualTo(TODAY);
+        assertThat(snapshot.getQuestionsAttempted()).isEqualTo(200);
+        assertThat(snapshot.getTotalQuestions()).isEqualTo(500);
+        assertThat(snapshot.getBestExamScore()).isEqualTo(40);
+    }
+
+    @Test
+    void computeSnapshot_noExamAttempts_examScoreZero() {
+        UserProductProjection up = stubProjection(TENANT_ID, USER_ID, PRODUCT_CODE);
+
+        when(progressRepository.countAttempted(USER_ID, PRODUCT_CODE)).thenReturn(100);
+        when(progressRepository.countCorrect(USER_ID, PRODUCT_CODE)).thenReturn(70);
+        when(progressRepository.countTotalAttempts(USER_ID, PRODUCT_CODE)).thenReturn(100);
+        when(strapiContentCache.getQuestionCount(PRODUCT_CODE, "nl")).thenReturn(500);
+        when(examAttemptRepository.findBestScore(USER_ID, PRODUCT_CODE)).thenReturn(null);
+        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE), eq("nl")))
+                .thenReturn(examConfig(44));
+
+        ReadinessSnapshot snapshot = job.computeSnapshot(up, TODAY);
+
+        // coverage = 100/500*100 = 20.0, accuracy = 70/100*100 = 70.0, exam = 0.0
+        // readiness = 0.40*20 + 0.35*70 + 0.25*0 = 8 + 24.5 + 0 = 32.5
+        assertThat(snapshot.getExamScore().doubleValue()).isCloseTo(0.0, within(0.01));
+        assertThat(snapshot.getReadinessScore().doubleValue()).isCloseTo(32.5, within(0.01));
+        assertThat(snapshot.getBestExamScore()).isNull();
+    }
+
+    @Test
+    void computeSnapshot_zeroAttempts_allScoresZero() {
+        UserProductProjection up = stubProjection(TENANT_ID, USER_ID, PRODUCT_CODE);
+
+        when(progressRepository.countAttempted(USER_ID, PRODUCT_CODE)).thenReturn(0);
+        when(progressRepository.countCorrect(USER_ID, PRODUCT_CODE)).thenReturn(0);
+        when(progressRepository.countTotalAttempts(USER_ID, PRODUCT_CODE)).thenReturn(0);
+        when(strapiContentCache.getQuestionCount(PRODUCT_CODE, "nl")).thenReturn(500);
+        when(examAttemptRepository.findBestScore(USER_ID, PRODUCT_CODE)).thenReturn(null);
+        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE), eq("nl"))).thenReturn(null);
+
+        ReadinessSnapshot snapshot = job.computeSnapshot(up, TODAY);
+
+        assertThat(snapshot.getCoverageScore().doubleValue()).isCloseTo(0.0, within(0.01));
+        assertThat(snapshot.getAccuracyScore().doubleValue()).isCloseTo(0.0, within(0.01));
+        assertThat(snapshot.getExamScore().doubleValue()).isCloseTo(0.0, within(0.01));
+        assertThat(snapshot.getReadinessScore().doubleValue()).isCloseTo(0.0, within(0.01));
+    }
+
+    @Test
+    void computeSnapshot_attemptedExceedsTotalQuestions_clampedToCeiling() {
+        UserProductProjection up = stubProjection(TENANT_ID, USER_ID, PRODUCT_CODE);
+
+        // Attempted 600 but only 500 active questions (deactivated questions)
+        when(progressRepository.countAttempted(USER_ID, PRODUCT_CODE)).thenReturn(600);
+        when(progressRepository.countCorrect(USER_ID, PRODUCT_CODE)).thenReturn(500);
+        when(progressRepository.countTotalAttempts(USER_ID, PRODUCT_CODE)).thenReturn(600);
+        when(strapiContentCache.getQuestionCount(PRODUCT_CODE, "nl")).thenReturn(500);
+        when(examAttemptRepository.findBestScore(USER_ID, PRODUCT_CODE)).thenReturn(null);
+        when(strapiContentCache.getExamConfig(eq(PRODUCT_CODE), eq("nl"))).thenReturn(null);
+
+        ReadinessSnapshot snapshot = job.computeSnapshot(up, TODAY);
+
+        // coverage clamped: min(600,500)/500*100 = 100.0
+        assertThat(snapshot.getCoverageScore().doubleValue()).isCloseTo(100.0, within(0.01));
+        assertThat(snapshot.getQuestionsAttempted()).isEqualTo(500);
+    }
+
+    private static StrapiExamConfigDto examConfig(int passScore) {
+        return new StrapiExamConfigDto(
+                1, "doc-1", "CBR Exam", "Theory exam", List.of(),
+                50, 30, passScore, null, null, true, false,
+                List.of(), Map.of(), false
+        );
+    }
+
+    private static UserProductProjection stubProjection(UUID tenantId, UUID userId, String productCode) {
+        return new UserProductProjection() {
+            @Override public UUID getTenantId() { return tenantId; }
+            @Override public UUID getKeycloakUserId() { return userId; }
+            @Override public String getProductCode() { return productCode; }
+        };
+    }
+}


### PR DESCRIPTION
Closes #71

## Changes
- **QuestionProgressRepository**: Added `UserProductProjection` interface and `findDistinctActiveUserProducts()` native query to get all distinct (tenant, user, product) tuples with question progress
- **ReadinessSnapshotRepository**: Added `existsByKeycloakUserIdAndProductCodeAndSnapshotDate()` for duplicate prevention
- **ReadinessSnapshotJob**: Full implementation replacing placeholder. Runs daily at 01:00 UTC:
  1. Queries all active user-product pairs across tenants
  2. Skips if snapshot already exists for today
  3. Computes scores: `readiness = 0.40×coverage + 0.35×accuracy + 0.25×exam`
  4. Persists `ReadinessSnapshot` with explicit `tenantId`
  5. Per-user error handling — one failure doesn't block others
- **ReadinessSnapshot**: Changed constructor from `protected` to `public`
- **ReadinessSnapshotJobTest**: 4 unit tests covering typical, no-exam, zero-attempts, and clamping scenarios

## Cross-service link
Frontend consumer: passtheo/passtheo-ui#63 / passtheo/passtheo-ui#64

## Test plan
- [ ] `./gradlew test` passes (4 new unit tests + all existing)
- [ ] Verify snapshots are created by calling `GET /api/progress/readiness/trend`
- [ ] Verify duplicate prevention (run job twice, check no duplicates)
- [ ] Verify score formula matches ReadinessService.calculate()