### PR TITLE
feat(content): add GET /api/progress/xp endpoint

### DIFF
--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -919,6 +919,40 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponse_ReadinessTrend'
 
+  /api/progress/xp:
+    get:
+      operationId: getUserXp
+      tags: [Progress]
+      summary: Get current XP and level for the authenticated user
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TenantHeader'
+        - $ref: '#/components/parameters/UserHeader'
+        - name: productCode
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Current XP state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_XpUpdate'
+              example:
+                success: true
+                data:
+                  xpEarned: 0
+                  totalXp: 1340
+                  currentLevel: 7
+                  xpForNextLevel: 2800
+                  leveledUp: false
+                timestamp: "2026-04-14T10:00:00Z"
+        '401':
+          description: Missing or invalid JWT
+
   /api/progress/domains:
     get:
       operationId: getDomainProgress
@@ -2065,3 +2099,30 @@ components:
         comment:
           type: string
           nullable: true
+
+    XpUpdateDto:
+      type: object
+      properties:
+        xpEarned:
+          type: integer
+          description: XP earned in this operation (0 for GET)
+        totalXp:
+          type: integer
+          description: Cumulative total XP
+        currentLevel:
+          type: integer
+          description: Current level
+        xpForNextLevel:
+          type: integer
+          description: XP threshold for the next level
+        leveledUp:
+          type: boolean
+          description: Whether a level-up occurred (false for GET)
+
+    ApiResponse_XpUpdate:
+      type: object
+      properties:
+        success: { type: boolean }
+        data:
+          $ref: '#/components/schemas/XpUpdateDto'
+        timestamp: { type: string, format: date-time }

--- a/src/main/java/com/passtheo/content/controller/ProgressController.java
+++ b/src/main/java/com/passtheo/content/controller/ProgressController.java
@@ -2,13 +2,16 @@ package com.passtheo.content.controller;
 
 import com.passtheo.content.domain.valueobject.ExamConfidence;
 import com.passtheo.content.domain.valueobject.ReadinessScore;
+import com.passtheo.content.domain.valueobject.XpResult;
 import com.passtheo.content.dto.response.DomainProgressDto;
 import com.passtheo.content.dto.response.MasteryStatsDto;
 import com.passtheo.content.dto.response.ReadinessDto;
 import com.passtheo.content.dto.response.ReadinessSnapshotDto;
+import com.passtheo.content.dto.response.XpUpdateDto;
 import com.passtheo.content.service.PracticeSessionService;
 import com.passtheo.content.service.ProgressService;
 import com.passtheo.content.service.ReadinessService;
+import com.passtheo.content.service.XpService;
 import com.passtheo.shared.core.dto.ApiResponse;
 import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -39,6 +42,7 @@ public class ProgressController {
     private final ReadinessService readinessService;
     private final ProgressService progressService;
     private final PracticeSessionService practiceSessionService;
+    private final XpService xpService;
 
     /**
      * Constructs the progress controller.
@@ -46,12 +50,14 @@ public class ProgressController {
      * @param readinessService       readiness score service
      * @param progressService        progress aggregation service
      * @param practiceSessionService practice session service (for flag/unflag)
+     * @param xpService              XP and level service
      */
     public ProgressController(ReadinessService readinessService, ProgressService progressService,
-                              PracticeSessionService practiceSessionService) {
+                              PracticeSessionService practiceSessionService, XpService xpService) {
         this.readinessService = readinessService;
         this.progressService = progressService;
         this.practiceSessionService = practiceSessionService;
+        this.xpService = xpService;
     }
 
     /**
@@ -106,6 +112,25 @@ public class ProgressController {
 
         List<ReadinessSnapshotDto> trend = progressService.getReadinessTrend(userId, productCode, days);
         return ResponseEntity.ok(ApiResponse.success(trend, MDC.get("traceId")));
+    }
+
+    /**
+     * Gets the current XP and level for the authenticated user.
+     *
+     * @param userId      user ID from header
+     * @param productCode the product code
+     * @return current XP state
+     */
+    @GetMapping("/xp")
+    public ResponseEntity<ApiResponse<XpUpdateDto>> getUserXp(
+            @RequestHeader("X-Keycloak-User-ID") UUID userId,
+            @RequestParam @Nonnull String productCode) {
+
+        XpResult result = xpService.getXp(userId, productCode);
+        XpUpdateDto dto = new XpUpdateDto(
+                result.xpEarned(), result.totalXp(), result.currentLevel(),
+                result.xpForNextLevel(), result.leveledUp());
+        return ResponseEntity.ok(ApiResponse.success(dto, MDC.get("traceId")));
     }
 
     /**


### PR DESCRIPTION
Closes #73

## Changes
- Added `GET /api/progress/xp?productCode={code}` endpoint to `ProgressController`
- Injects existing `XpService` and calls `getXp()` — reads `UserXp` entity, no new tables
- Returns `XpUpdateDto` with `totalXp`, `currentLevel`, `xpForNextLevel` (xpEarned=0, leveledUp=false for GET)
- Returns level 1 / 0 XP for users with no record
- Updated OpenAPI spec with endpoint, `XpUpdateDto` schema, and `ApiResponse_XpUpdate` wrapper

## Test plan
- [ ] `GET /api/progress/xp?productCode=auto-b` with valid JWT returns 200 with XP data
- [ ] Returns `{ totalXp: 0, currentLevel: 1, xpForNextLevel: 100 }` for new users
- [ ] `./gradlew test` passes
- [ ] No migration needed — reads existing `user_xp` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)