### PR TITLE
fix(content): fix achievement trigger system — case mismatch and missing handlers

### DIFF
--- a/src/main/java/com/passtheo/content/controller/AchievementController.java
+++ b/src/main/java/com/passtheo/content/controller/AchievementController.java
@@ -5,6 +5,7 @@ import com.passtheo.content.dto.response.AchievementDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiAchievementDefDto;
 import com.passtheo.content.repository.EarnedAchievementRepository;
+import com.passtheo.content.service.AchievementService;
 import com.passtheo.shared.core.dto.ApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +23,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
- * Achievement gallery endpoint: earned + locked achievements.
+ * Achievement gallery endpoint: earned + locked achievements with live progress.
  */
 @RestController
 @RequestMapping("/api/achievements")
@@ -32,25 +33,29 @@ public class AchievementController {
 
     private final EarnedAchievementRepository earnedAchievementRepository;
     private final StrapiContentCache strapiContentCache;
+    private final AchievementService achievementService;
 
     /**
      * Constructs the achievement controller.
      *
      * @param earnedAchievementRepository earned achievement repository
      * @param strapiContentCache          Strapi content cache
+     * @param achievementService          achievement service for live progress
      */
     public AchievementController(EarnedAchievementRepository earnedAchievementRepository,
-                                 StrapiContentCache strapiContentCache) {
+                                 StrapiContentCache strapiContentCache,
+                                 AchievementService achievementService) {
         this.earnedAchievementRepository = earnedAchievementRepository;
         this.strapiContentCache = strapiContentCache;
+        this.achievementService = achievementService;
     }
 
     /**
-     * Gets the achievement gallery (earned + locked).
+     * Gets the achievement gallery (earned + locked with live progress).
      *
      * @param userId      user ID from header
      * @param productCode product code (optional)
-     * @return list of all achievements with earn status
+     * @return list of all achievements with earn status and progress
      */
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<List<AchievementDto>>> getMyAchievements(
@@ -66,10 +71,25 @@ public class AchievementController {
         List<AchievementDto> result = allDefs.stream().map(def -> {
             EarnedAchievement earned = earnedMap.get(def.code());
             boolean isEarned = earned != null;
-            int currentProgress = earned != null && earned.getTriggerValue() != null
-                    ? earned.getTriggerValue() : 0;
-            double progressPercent = def.triggerValue() > 0
-                    ? Math.min(100.0, (double) currentProgress / def.triggerValue() * 100.0) : 0.0;
+
+            int currentProgress;
+            if (isEarned && earned.getTriggerValue() != null) {
+                currentProgress = earned.getTriggerValue();
+            } else {
+                currentProgress = achievementService.getCurrentValue(
+                        def.triggerType(), userId, resolvedProductCode);
+            }
+
+            double progressPercent;
+            if ("AVG_ANSWER_TIME_BELOW".equals(def.triggerType())) {
+                // Inverted: lower is better. 100% when at or below threshold, 0% when no data.
+                progressPercent = currentProgress > 0 && currentProgress <= def.triggerValue()
+                        ? 100.0 : (currentProgress > 0 ? Math.max(0.0,
+                        (1.0 - (double) (currentProgress - def.triggerValue()) / def.triggerValue()) * 100.0) : 0.0);
+            } else {
+                progressPercent = def.triggerValue() > 0
+                        ? Math.min(100.0, (double) currentProgress / def.triggerValue() * 100.0) : 0.0;
+            }
 
             return new AchievementDto(
                     def.code(), def.name(), def.description(),

--- a/src/main/java/com/passtheo/content/repository/ExamAttemptRepository.java
+++ b/src/main/java/com/passtheo/content/repository/ExamAttemptRepository.java
@@ -77,6 +77,17 @@ public interface ExamAttemptRepository extends JpaRepository<ExamAttempt, UUID> 
                           @Param("cutoff") Instant cutoff);
 
     /**
+     * Counts total completed exams for a user/product (regardless of pass/fail).
+     *
+     * @param keycloakUserId the user's Keycloak ID
+     * @param productCode    the product code
+     * @return count of completed exams
+     */
+    @Query("SELECT COUNT(ea) FROM ExamAttempt ea WHERE ea.keycloakUserId = :userId " +
+           "AND ea.productCode = :productCode AND ea.deletedAt IS NULL")
+    long countCompletedExams(@Param("userId") UUID keycloakUserId, @Param("productCode") String productCode);
+
+    /**
      * Finds an exam attempt by ID and user.
      *
      * @param id             the exam attempt ID

--- a/src/main/java/com/passtheo/content/repository/ReadinessSnapshotRepository.java
+++ b/src/main/java/com/passtheo/content/repository/ReadinessSnapshotRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -37,6 +38,16 @@ public interface ReadinessSnapshotRepository extends JpaRepository<ReadinessSnap
      */
     boolean existsByKeycloakUserIdAndProductCodeAndSnapshotDate(
             @Nonnull UUID keycloakUserId, @Nonnull String productCode, @Nonnull LocalDate snapshotDate);
+
+    /**
+     * Finds the most recent readiness snapshot for a user/product.
+     *
+     * @param keycloakUserId the user's Keycloak ID
+     * @param productCode    the product code
+     * @return the latest snapshot, or empty if none exists
+     */
+    Optional<ReadinessSnapshot> findTopByKeycloakUserIdAndProductCodeOrderBySnapshotDateDesc(
+            @Nonnull UUID keycloakUserId, @Nonnull String productCode);
 
     /**
      * Deletes all snapshots for a user (GDPR).

--- a/src/main/java/com/passtheo/content/repository/SessionAnswerRepository.java
+++ b/src/main/java/com/passtheo/content/repository/SessionAnswerRepository.java
@@ -69,4 +69,24 @@ public interface SessionAnswerRepository extends JpaRepository<SessionAnswer, UU
             @Param("productCode") String productCode,
             @Param("startDate") Instant startDate,
             @Param("endDate") Instant endDate);
+
+    /**
+     * Computes the average answer time in milliseconds for a user/product.
+     *
+     * @param keycloakUserId the user's Keycloak ID
+     * @param productCode    the product code
+     * @return average time in ms, or null if no answers
+     */
+    @Query(value = """
+            SELECT AVG(sa.time_taken_ms)
+            FROM session_answers sa
+            JOIN study_sessions ss ON sa.session_id = ss.id
+            WHERE ss.keycloak_user_id = :userId
+              AND ss.product_code = :productCode
+              AND sa.deleted_at IS NULL
+              AND ss.deleted_at IS NULL
+            """, nativeQuery = true)
+    Double averageTimeTakenMs(
+            @Param("userId") UUID keycloakUserId,
+            @Param("productCode") String productCode);
 }

--- a/src/main/java/com/passtheo/content/repository/StudySessionRepository.java
+++ b/src/main/java/com/passtheo/content/repository/StudySessionRepository.java
@@ -59,4 +59,18 @@ public interface StudySessionRepository extends JpaRepository<StudySession, UUID
      */
     long countByKeycloakUserIdAndProductCodeAndStatus(
             @Nonnull UUID keycloakUserId, @Nonnull String productCode, @Nonnull SessionStatus status);
+
+    /**
+     * Counts completed sessions where the user answered every question correctly.
+     *
+     * @param keycloakUserId the user's Keycloak ID
+     * @param productCode    the product code
+     * @return count of perfect sessions
+     */
+    @Query("SELECT COUNT(ss) FROM StudySession ss WHERE ss.keycloakUserId = :userId " +
+           "AND ss.productCode = :productCode " +
+           "AND ss.status = com.passtheo.content.domain.enums.SessionStatus.COMPLETED " +
+           "AND ss.correctCount = ss.totalQuestions AND ss.totalQuestions > 0 " +
+           "AND ss.deletedAt IS NULL")
+    long countPerfectSessions(@Param("userId") UUID keycloakUserId, @Param("productCode") String productCode);
 }

--- a/src/main/java/com/passtheo/content/service/AchievementService.java
+++ b/src/main/java/com/passtheo/content/service/AchievementService.java
@@ -3,6 +3,8 @@ package com.passtheo.content.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.passtheo.content.domain.entity.EarnedAchievement;
+import com.passtheo.content.domain.entity.ExamAttempt;
+import com.passtheo.content.domain.entity.ReadinessSnapshot;
 import com.passtheo.shared.outbox.entity.OutboxEvent;
 import com.passtheo.content.domain.enums.DomainStrength;
 import com.passtheo.shared.outbox.entity.OutboxStatus;
@@ -11,6 +13,9 @@ import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiAchievementDefDto;
 import com.passtheo.content.repository.EarnedAchievementRepository;
 import com.passtheo.content.repository.ExamAttemptRepository;
+import com.passtheo.content.repository.ReadinessSnapshotRepository;
+import com.passtheo.content.repository.SessionAnswerRepository;
+import com.passtheo.content.repository.StudySessionRepository;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.repository.StreakRepository;
@@ -20,6 +25,7 @@ import com.passtheo.shared.events.content.AchievementEarnedEvent;
 import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,7 +37,10 @@ import java.util.UUID;
 
 /**
  * Checks and awards achievements after every answer submission.
- * 23 achievement triggers defined in Strapi, checked against current user stats.
+ * Achievement definitions are fetched from Strapi with trigger types and thresholds.
+ *
+ * <p>TODO: Performance — currently checks all achievements on every call. Consider
+ * partitioning by trigger category so only relevant checks run per event type.
  */
 @Service
 public class AchievementService {
@@ -43,33 +52,48 @@ public class AchievementService {
     /** Default locale used when computing domain mastery (content-agnostic — counts don't differ by locale). */
     private static final String DEFAULT_LOCALE = "nl";
 
+    /** Number of recent exams to fetch for consecutive pass calculation. */
+    private static final int CONSECUTIVE_PASS_WINDOW = 20;
+
     private final EarnedAchievementRepository achievementRepository;
     private final QuestionProgressRepository progressRepository;
     private final StreakRepository streakRepository;
     private final ExamAttemptRepository examAttemptRepository;
+    private final StudySessionRepository sessionRepository;
+    private final SessionAnswerRepository answerRepository;
+    private final ReadinessSnapshotRepository readinessSnapshotRepository;
     private final StrapiContentCache strapiContentCache;
     private final OutboxEventRepository outboxEventRepository;
 
     /**
      * Constructs the achievement service.
      *
-     * @param achievementRepository earned achievement repository
-     * @param progressRepository    question progress repository
-     * @param streakRepository      streak repository
-     * @param examAttemptRepository exam attempt repository
-     * @param strapiContentCache    Strapi content cache
-     * @param outboxEventRepository outbox event repository
+     * @param achievementRepository       earned achievement repository
+     * @param progressRepository          question progress repository
+     * @param streakRepository            streak repository
+     * @param examAttemptRepository       exam attempt repository
+     * @param sessionRepository           study session repository
+     * @param answerRepository            session answer repository
+     * @param readinessSnapshotRepository readiness snapshot repository
+     * @param strapiContentCache          Strapi content cache
+     * @param outboxEventRepository       outbox event repository
      */
     public AchievementService(EarnedAchievementRepository achievementRepository,
                               QuestionProgressRepository progressRepository,
                               StreakRepository streakRepository,
                               ExamAttemptRepository examAttemptRepository,
+                              StudySessionRepository sessionRepository,
+                              SessionAnswerRepository answerRepository,
+                              ReadinessSnapshotRepository readinessSnapshotRepository,
                               StrapiContentCache strapiContentCache,
                               OutboxEventRepository outboxEventRepository) {
         this.achievementRepository = achievementRepository;
         this.progressRepository = progressRepository;
         this.streakRepository = streakRepository;
         this.examAttemptRepository = examAttemptRepository;
+        this.sessionRepository = sessionRepository;
+        this.answerRepository = answerRepository;
+        this.readinessSnapshotRepository = readinessSnapshotRepository;
         this.strapiContentCache = strapiContentCache;
         this.outboxEventRepository = outboxEventRepository;
     }
@@ -94,7 +118,7 @@ public class AchievementService {
 
             int currentValue = getCurrentValue(def.triggerType(), userId, productCode);
 
-            if (currentValue >= def.triggerValue()) {
+            if (isThresholdMet(def.triggerType(), currentValue, def.triggerValue())) {
                 EarnedAchievement earned = new EarnedAchievement(
                         userId, def.code(), Instant.now(), currentValue);
                 earned.setTenantId(TenantContext.get());
@@ -133,42 +157,131 @@ public class AchievementService {
     }
 
     /**
-     * Gets the current value for a trigger type.
+     * Gets the current value for a trigger type. Public so the gallery endpoint
+     * can show live progress for unearned achievements.
      *
-     * @param triggerType the trigger type string
+     * @param triggerType the trigger type string (UPPERCASE Strapi enum)
      * @param userId      the user's Keycloak ID
      * @param productCode the product code
      * @return the current value for comparison against triggerValue
      */
-    private int getCurrentValue(String triggerType, UUID userId, String productCode) {
+    public int getCurrentValue(@Nonnull String triggerType, @Nonnull UUID userId,
+                               @Nonnull String productCode) {
         return switch (triggerType) {
-            case "questions_answered" -> progressRepository.countAttempted(userId, productCode);
-            case "correct_streak" -> progressRepository.maxConsecutiveCorrect(userId, productCode);
-            case "study_days_streak" -> streakRepository.findByKeycloakUserIdAndProductCode(userId, productCode)
+            case "QUESTIONS_ANSWERED" -> progressRepository.countAttempted(userId, productCode);
+
+            case "PERFECT_SESSION", "PERFECT_SESSIONS" ->
+                    (int) sessionRepository.countPerfectSessions(userId, productCode);
+
+            case "EXAMS_COMPLETED" -> (int) examAttemptRepository.countCompletedExams(userId, productCode);
+
+            case "EXAMS_PASSED" -> (int) examAttemptRepository
+                    .countByKeycloakUserIdAndProductCodeAndPassedTrue(userId, productCode);
+
+            case "CONSECUTIVE_PASSES" -> countConsecutivePasses(userId, productCode);
+
+            case "EXAM_SCORE" -> {
+                Integer best = examAttemptRepository.findBestScore(userId, productCode);
+                yield best != null ? best : 0;
+            }
+
+            case "STREAK_DAYS" -> streakRepository.findByKeycloakUserIdAndProductCode(userId, productCode)
                     .map(s -> s.getCurrentStreak())
                     .orElse(0);
-            case "exams_passed" -> (int) examAttemptRepository
-                    .countByKeycloakUserIdAndProductCodeAndPassedTrue(userId, productCode);
-            case "perfect_exam" -> (int) examAttemptRepository.countPerfect(userId, productCode);
-            case "domain_mastered" -> (int) progressRepository.aggregateByDomain(userId, productCode).stream()
-                    .filter(agg -> {
-                        int total = strapiContentCache.getQuestionCountByDomain(agg.getDomainCode(), DEFAULT_LOCALE);
-                        double accuracy = agg.getTotalAttempts() > 0
-                                ? (double) agg.getCorrectCount() / agg.getTotalAttempts() * 100.0 : 0.0;
-                        // Clamp attempted count to active total — progress records may reference
-                        // deactivated questions no longer in the Strapi active pool.
-                        long clampedAttempted = Math.min(agg.getAttemptedCount(), total);
-                        double coverage = total > 0
-                                ? (double) clampedAttempted / total * 100.0 : 0.0;
-                        return ReadinessService.classifyDomainStrength(accuracy, coverage) == DomainStrength.MASTERED;
-                    })
-                    .count();
-            case "readiness_score" -> 0; // calculated separately to avoid circular dependency
-            case "fast_correct" -> 0; // tracked inline during answer processing
+
+            case "DOMAIN_MASTERED" -> countMasteredDomains(userId, productCode);
+
+            case "ALL_DOMAINS_MASTERED" -> {
+                int mastered = countMasteredDomains(userId, productCode);
+                int totalDomains = strapiContentCache.getDomains(productCode, DEFAULT_LOCALE).size();
+                // Yields 1 (threshold met) if all domains are mastered, 0 otherwise
+                yield (totalDomains > 0 && mastered >= totalDomains) ? 1 : 0;
+            }
+
+            case "READINESS_SCORE" -> readinessSnapshotRepository
+                    .findTopByKeycloakUserIdAndProductCodeOrderBySnapshotDateDesc(userId, productCode)
+                    .map(ReadinessSnapshot::getReadinessScore)
+                    .map(score -> score.intValue())
+                    .orElse(0);
+
+            case "AVG_ANSWER_TIME_BELOW" -> {
+                Double avgMs = answerRepository.averageTimeTakenMs(userId, productCode);
+                // Returns average answer time in whole seconds. The isThresholdMet method
+                // handles the inverted comparison (lower is better) for this trigger type.
+                if (avgMs == null) {
+                    yield 0;
+                }
+                yield (int) (avgMs / 1000.0);
+            }
+
             default -> {
                 LOG.warn("Unknown achievement trigger type: {}", triggerType);
                 yield 0;
             }
         };
+    }
+
+    /**
+     * Checks whether the current value meets the trigger threshold.
+     * Most triggers use {@code currentValue >= triggerValue}, but "below" triggers
+     * (e.g. AVG_ANSWER_TIME_BELOW) use an inverted comparison where lower is better.
+     *
+     * @param triggerType  the trigger type
+     * @param currentValue the current measured value
+     * @param triggerValue the threshold from the achievement definition
+     * @return true if the achievement condition is met
+     */
+    public static boolean isThresholdMet(@Nonnull String triggerType, int currentValue, int triggerValue) {
+        if ("AVG_ANSWER_TIME_BELOW".equals(triggerType)) {
+            // currentValue is average seconds, triggerValue is the ceiling.
+            // Earned when average > 0 (has data) and average <= threshold.
+            return currentValue > 0 && currentValue <= triggerValue;
+        }
+        return currentValue >= triggerValue;
+    }
+
+    /**
+     * Counts domains where the user has achieved MASTERED strength.
+     *
+     * @param userId      the user's Keycloak ID
+     * @param productCode the product code
+     * @return number of mastered domains
+     */
+    private int countMasteredDomains(@Nonnull UUID userId, @Nonnull String productCode) {
+        return (int) progressRepository.aggregateByDomain(userId, productCode).stream()
+                .filter(agg -> {
+                    int total = strapiContentCache.getQuestionCountByDomain(agg.getDomainCode(), DEFAULT_LOCALE);
+                    double accuracy = agg.getTotalAttempts() > 0
+                            ? (double) agg.getCorrectCount() / agg.getTotalAttempts() * 100.0 : 0.0;
+                    long clampedAttempted = Math.min(agg.getAttemptedCount(), total);
+                    double coverage = total > 0
+                            ? (double) clampedAttempted / total * 100.0 : 0.0;
+                    return ReadinessService.classifyDomainStrength(accuracy, coverage) == DomainStrength.MASTERED;
+                })
+                .count();
+    }
+
+    /**
+     * Counts consecutive passed exams from the most recent backward.
+     *
+     * @param userId      the user's Keycloak ID
+     * @param productCode the product code
+     * @return number of consecutive passes from the most recent attempt
+     */
+    private int countConsecutivePasses(@Nonnull UUID userId, @Nonnull String productCode) {
+        List<ExamAttempt> recentExams = examAttemptRepository
+                .findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
+                        userId, productCode, PageRequest.of(0, CONSECUTIVE_PASS_WINDOW))
+                .getContent();
+
+        int count = 0;
+        for (ExamAttempt exam : recentExams) {
+            if (exam.isPassed()) {
+                count++;
+            } else {
+                break;
+            }
+        }
+        return count;
     }
 }

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -651,8 +651,10 @@ public class PracticeSessionService {
         List<EarnedAchievementDto> achievements = achievementService
                 .checkAchievements(userId, session.getProductCode());
 
-        // Grant session completion XP bonus
-        XpResult xpResult = xpService.grantXp(userId, session.getProductCode(), XpService.XP_PRACTICE_COMPLETE);
+        // Grant session completion XP bonus + any achievement XP
+        int achievementXp = achievements.stream().mapToInt(EarnedAchievementDto::xpReward).sum();
+        XpResult xpResult = xpService.grantXp(userId, session.getProductCode(),
+                XpService.XP_PRACTICE_COMPLETE + achievementXp);
 
         // Compute actual mastery changes from session answers
         List<SessionAnswer> sessionAnswers = answerRepository.findBySessionIdOrderByQuestionOrderAsc(sessionId);
@@ -660,7 +662,8 @@ public class PracticeSessionService {
 
         LOG.info("Session completed: id={}, user={}, correct={}/{}, accuracy={}%, timeSpentSec={}, xp={}",
                 sessionId, userId, session.getCorrectCount(), session.getTotalQuestions(),
-                session.getAccuracyPercent(), session.getTimeSpentSeconds(), XpService.XP_PRACTICE_COMPLETE);
+                session.getAccuracyPercent(), session.getTimeSpentSeconds(),
+                XpService.XP_PRACTICE_COMPLETE + achievementXp);
         AUDIT.info("SESSION_COMPLETED sessionId={} userId={} correct={} total={} accuracyPct={} timeSpentSec={}",
                 sessionId, userId, session.getCorrectCount(), session.getTotalQuestions(),
                 session.getAccuracyPercent(), session.getTimeSpentSeconds());
@@ -675,7 +678,7 @@ public class PracticeSessionService {
                 masteryChanges,
                 new StreakUpdateDto(streak.currentStreak(), streak.isNewDay()),
                 achievements,
-                new XpUpdateDto(XpService.XP_PRACTICE_COMPLETE, xpResult.totalXp(),
+                new XpUpdateDto(XpService.XP_PRACTICE_COMPLETE + achievementXp, xpResult.totalXp(),
                         xpResult.currentLevel(), xpResult.xpForNextLevel(), xpResult.leveledUp())
         );
     }

--- a/src/test/java/com/passtheo/content/KarateRunner.java
+++ b/src/test/java/com/passtheo/content/KarateRunner.java
@@ -272,13 +272,13 @@ class KarateRunner {
         return java.util.Arrays.asList(
                 new StrapiAchievementDefDto(1, null, "Eerste Stap", "first_question",
                         "Beantwoord je eerste vraag", "\uD83C\uDFAF", "\uD83D\uDD12",
-                        "questions_answered", 1, 10, true, 1, "auto-b"),
+                        "QUESTIONS_ANSWERED", 1, 10, true, 1, "auto-b"),
                 new StrapiAchievementDefDto(2, null, "Beginnersluk", "ten_questions",
                         "Beantwoord 10 vragen", "\u2B50", "\uD83D\uDD12",
-                        "questions_answered", 10, 50, true, 2, null),
+                        "QUESTIONS_ANSWERED", 10, 50, true, 2, null),
                 new StrapiAchievementDefDto(3, null, "Weekkampioen", "7_day_streak",
                         "7 dagen op rij gestudeerd", "\uD83D\uDD25", "\uD83D\uDD12",
-                        "study_days_streak", 7, 100, true, 3, null)
+                        "STREAK_DAYS", 7, 100, true, 3, null)
         );
     }
 }

--- a/src/test/java/com/passtheo/content/unit/AchievementServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/AchievementServiceTest.java
@@ -1,11 +1,17 @@
 package com.passtheo.content.unit;
 
 import com.passtheo.content.domain.entity.EarnedAchievement;
+import com.passtheo.content.domain.entity.ExamAttempt;
+import com.passtheo.content.domain.entity.ReadinessSnapshot;
 import com.passtheo.content.dto.response.EarnedAchievementDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiAchievementDefDto;
+import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.content.repository.EarnedAchievementRepository;
 import com.passtheo.content.repository.ExamAttemptRepository;
+import com.passtheo.content.repository.ReadinessSnapshotRepository;
+import com.passtheo.content.repository.SessionAnswerRepository;
+import com.passtheo.content.repository.StudySessionRepository;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.repository.StreakRepository;
@@ -18,15 +24,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -39,6 +50,9 @@ class AchievementServiceTest {
     @Mock private QuestionProgressRepository progressRepository;
     @Mock private StreakRepository streakRepository;
     @Mock private ExamAttemptRepository examAttemptRepository;
+    @Mock private StudySessionRepository sessionRepository;
+    @Mock private SessionAnswerRepository answerRepository;
+    @Mock private ReadinessSnapshotRepository readinessSnapshotRepository;
     @Mock private StrapiContentCache strapiContentCache;
     @Mock private OutboxEventRepository outboxEventRepository;
 
@@ -53,7 +67,8 @@ class AchievementServiceTest {
         TenantContext.set(TENANT_ID);
         achievementService = new AchievementService(
                 achievementRepository, progressRepository, streakRepository,
-                examAttemptRepository, strapiContentCache, outboxEventRepository);
+                examAttemptRepository, sessionRepository, answerRepository,
+                readinessSnapshotRepository, strapiContentCache, outboxEventRepository);
     }
 
     @AfterEach
@@ -61,28 +76,37 @@ class AchievementServiceTest {
         TenantContext.clear();
     }
 
+    // --- QUESTIONS_ANSWERED ---
+
     @Test
-    void firstQuestion_achievement_earned_when_threshold_met() {
-        StrapiAchievementDefDto def = new StrapiAchievementDefDto(
-                1, null, "Eerste Stap", "first_question", "desc", "🎯", "🔒",
-                "questions_answered", 1, 10, true, 1, null);
-        when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
-        when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
+    void questionsAnswered_achievement_earned_when_threshold_met() {
+        StrapiAchievementDefDto def = achievementDef("first_question", "QUESTIONS_ANSWERED", 1);
+        stubDefs(def);
         when(progressRepository.countAttempted(USER_ID, PRODUCT)).thenReturn(1);
-        when(achievementRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
 
         assertEquals(1, result.size());
         assertEquals("first_question", result.get(0).code());
-        assertEquals("Eerste Stap", result.get(0).name());
     }
 
     @Test
+    void questionsAnswered_not_earned_below_threshold() {
+        StrapiAchievementDefDto def = achievementDef("questions_50", "QUESTIONS_ANSWERED", 50);
+        stubDefs(def);
+        when(progressRepository.countAttempted(USER_ID, PRODUCT)).thenReturn(25);
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertTrue(result.isEmpty());
+        verify(achievementRepository, never()).save(any());
+    }
+
+    // --- Duplicate prevention ---
+
+    @Test
     void already_earned_achievement_not_awarded_again() {
-        StrapiAchievementDefDto def = new StrapiAchievementDefDto(
-                1, null, "Eerste Stap", "first_question", "desc", "🎯", "🔒",
-                "questions_answered", 1, 10, true, 1, null);
+        StrapiAchievementDefDto def = achievementDef("first_question", "QUESTIONS_ANSWERED", 1);
         when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
         when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of("first_question"));
 
@@ -92,98 +116,172 @@ class AchievementServiceTest {
         verify(achievementRepository, never()).save(any());
     }
 
+    // --- PERFECT_SESSION / PERFECT_SESSIONS ---
+
     @Test
-    void streak_achievement_uses_streak_repository() {
-        StrapiAchievementDefDto def = new StrapiAchievementDefDto(
-                1, null, "Weekkampioen", "7_day_streak", "desc", "🔥", "🔒",
-                "study_days_streak", 7, 100, true, 1, null);
-        when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
-        when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
+    void perfectSession_earned_when_one_perfect() {
+        StrapiAchievementDefDto def = achievementDef("first_perfect", "PERFECT_SESSION", 1);
+        stubDefs(def);
+        when(sessionRepository.countPerfectSessions(USER_ID, PRODUCT)).thenReturn(1L);
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void perfectSessions_earned_when_ten_perfect() {
+        StrapiAchievementDefDto def = achievementDef("perfect_10", "PERFECT_SESSIONS", 10);
+        stubDefs(def);
+        when(sessionRepository.countPerfectSessions(USER_ID, PRODUCT)).thenReturn(12L);
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertEquals(1, result.size());
+    }
+
+    // --- EXAMS_COMPLETED ---
+
+    @Test
+    void examsCompleted_earned_when_threshold_met() {
+        StrapiAchievementDefDto def = achievementDef("first_exam", "EXAMS_COMPLETED", 1);
+        stubDefs(def);
+        when(examAttemptRepository.countCompletedExams(USER_ID, PRODUCT)).thenReturn(1L);
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertEquals(1, result.size());
+    }
+
+    // --- EXAMS_PASSED ---
+
+    @Test
+    void examsPassed_earned_when_threshold_met() {
+        StrapiAchievementDefDto def = achievementDef("first_pass", "EXAMS_PASSED", 1);
+        stubDefs(def);
+        when(examAttemptRepository.countByKeycloakUserIdAndProductCodeAndPassedTrue(USER_ID, PRODUCT))
+                .thenReturn(1L);
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertEquals(1, result.size());
+    }
+
+    // --- CONSECUTIVE_PASSES ---
+
+    @Test
+    void consecutivePasses_earned_when_three_in_a_row() {
+        StrapiAchievementDefDto def = achievementDef("pass_streak_3", "CONSECUTIVE_PASSES", 3);
+        stubDefs(def);
+
+        ExamAttempt pass1 = mockExam(true);
+        ExamAttempt pass2 = mockExam(true);
+        ExamAttempt pass3 = mockExam(true);
+        ExamAttempt fail = mockExam(false);
+
+        when(examAttemptRepository.findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
+                eq(USER_ID), eq(PRODUCT), any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(List.of(pass1, pass2, pass3, fail)));
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void consecutivePasses_not_earned_when_broken_by_fail() {
+        StrapiAchievementDefDto def = achievementDef("pass_streak_3", "CONSECUTIVE_PASSES", 3);
+        stubDefs(def);
+
+        ExamAttempt pass1 = mockExam(true);
+        ExamAttempt fail = mockExam(false);
+        // pass2 comes after the fail, so the loop never reaches it
+        ExamAttempt pass2 = mock(ExamAttempt.class);
+
+        when(examAttemptRepository.findByKeycloakUserIdAndProductCodeOrderByCompletedAtDesc(
+                eq(USER_ID), eq(PRODUCT), any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(List.of(pass1, fail, pass2)));
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertTrue(result.isEmpty());
+    }
+
+    // --- EXAM_SCORE ---
+
+    @Test
+    void examScore_earned_when_best_score_meets_threshold() {
+        StrapiAchievementDefDto def = achievementDef("score_48", "EXAM_SCORE", 48);
+        stubDefs(def);
+        when(examAttemptRepository.findBestScore(USER_ID, PRODUCT)).thenReturn(49);
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void examScore_not_earned_when_no_exams() {
+        StrapiAchievementDefDto def = achievementDef("perfect_exam", "EXAM_SCORE", 50);
+        stubDefs(def);
+        when(examAttemptRepository.findBestScore(USER_ID, PRODUCT)).thenReturn(null);
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertTrue(result.isEmpty());
+    }
+
+    // --- STREAK_DAYS ---
+
+    @Test
+    void streakDays_earned_when_streak_meets_threshold() {
+        StrapiAchievementDefDto def = achievementDef("streak_7", "STREAK_DAYS", 7);
+        stubDefs(def);
 
         com.passtheo.content.domain.entity.Streak streak =
                 new com.passtheo.content.domain.entity.Streak(USER_ID, PRODUCT);
         streak.setCurrentStreak(10);
         when(streakRepository.findByKeycloakUserIdAndProductCode(USER_ID, PRODUCT))
                 .thenReturn(Optional.of(streak));
-        when(achievementRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
 
         assertEquals(1, result.size());
-        assertEquals("7_day_streak", result.get(0).code());
+        assertEquals("streak_7", result.get(0).code());
     }
 
-    @Test
-    void exam_passed_achievement_uses_exam_repository() {
-        StrapiAchievementDefDto def = new StrapiAchievementDefDto(
-                1, null, "Geslaagd", "first_pass", "desc", "🏆", "🔒",
-                "exams_passed", 1, 50, true, 1, null);
-        when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
-        when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
-        when(examAttemptRepository.countByKeycloakUserIdAndProductCodeAndPassedTrue(USER_ID, PRODUCT))
-                .thenReturn(1L);
-        when(achievementRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
-
-        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
-
-        assertEquals(1, result.size());
-    }
+    // --- DOMAIN_MASTERED ---
 
     @Test
-    void perfect_exam_achievement_uses_count_perfect() {
-        StrapiAchievementDefDto def = new StrapiAchievementDefDto(
-                1, null, "Perfectionist", "perfect_exam", "desc", "💯", "🔒",
-                "perfect_exam", 1, 100, true, 1, null);
-        when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
-        when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
-        when(examAttemptRepository.countPerfect(USER_ID, PRODUCT)).thenReturn(1L);
-        when(achievementRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    void domainMastered_earned_when_domain_has_mastered_strength() {
+        StrapiAchievementDefDto def = achievementDef("domain_master", "DOMAIN_MASTERED", 1);
+        stubDefs(def);
 
-        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
-
-        assertEquals(1, result.size());
-    }
-
-    @Test
-    void domain_mastered_achievement_uses_question_progress_aggregation() {
-        // A domain where accuracy >= 85% AND coverage >= 80% qualifies as MASTERED strength
-        StrapiAchievementDefDto def = new StrapiAchievementDefDto(
-                1, null, "Domeinmeester", "domain_mastered", "desc", "🎓", "🔒",
-                "domain_mastered", 1, 75, true, 1, null);
-        when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
-        when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
-
-        // Domain with accuracy 90% and coverage 90% → MASTERED strength
         QuestionProgressRepository.DomainMasteryProjection agg =
                 mock(QuestionProgressRepository.DomainMasteryProjection.class);
         when(agg.getDomainCode()).thenReturn("verkeersborden");
-        when(agg.getAttemptedCount()).thenReturn(27L);   // 27/30 = 90% coverage
+        when(agg.getAttemptedCount()).thenReturn(27L);
         when(agg.getCorrectCount()).thenReturn(27L);
-        when(agg.getTotalAttempts()).thenReturn(30L);    // 27/30 = 90% accuracy
+        when(agg.getTotalAttempts()).thenReturn(30L);
 
         when(progressRepository.aggregateByDomain(USER_ID, PRODUCT)).thenReturn(List.of(agg));
         when(strapiContentCache.getQuestionCountByDomain("verkeersborden", "nl")).thenReturn(30);
-        when(achievementRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
 
         assertEquals(1, result.size());
-        assertEquals("domain_mastered", result.get(0).code());
+        assertEquals("domain_master", result.get(0).code());
     }
 
     @Test
-    void domain_mastered_achievement_not_earned_if_no_mastered_domains() {
-        StrapiAchievementDefDto def = new StrapiAchievementDefDto(
-                1, null, "Domeinmeester", "domain_mastered", "desc", "🎓", "🔒",
-                "domain_mastered", 1, 75, true, 1, null);
-        when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
-        when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
+    void domainMastered_not_earned_when_low_coverage() {
+        StrapiAchievementDefDto def = achievementDef("domain_master", "DOMAIN_MASTERED", 1);
+        stubDefs(def);
 
-        // Domain with low coverage → not MASTERED
         QuestionProgressRepository.DomainMasteryProjection agg =
                 mock(QuestionProgressRepository.DomainMasteryProjection.class);
         when(agg.getDomainCode()).thenReturn("verkeersborden");
-        when(agg.getAttemptedCount()).thenReturn(10L);   // 10/30 = 33% coverage — too low
+        when(agg.getAttemptedCount()).thenReturn(10L);
         when(agg.getCorrectCount()).thenReturn(7L);
         when(agg.getTotalAttempts()).thenReturn(15L);
 
@@ -196,70 +294,193 @@ class AchievementServiceTest {
     }
 
     @Test
-    void domainMastered_clampsCoverageWhenQuestionsDeactivated() {
-        // Domain had 30 questions, user attempted 27 (90% coverage → MASTERED).
-        // After 10 questions deactivated, active pool is 20. Without clamping,
-        // coverage = 27/20 = 135% → still MASTERED. With clamping, coverage = 20/20 = 100%.
-        // Either way MASTERED, but verify the count is clamped correctly (no >100% coverage).
-        StrapiAchievementDefDto def = new StrapiAchievementDefDto(
-                1, null, "Domeinmeester", "domain_mastered", "desc", "🎓", "🔒",
-                "domain_mastered", 1, 75, true, 1, null);
-        when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
-        when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
+    void domainMastered_clamps_coverage_when_questions_deactivated() {
+        StrapiAchievementDefDto def = achievementDef("domain_master", "DOMAIN_MASTERED", 1);
+        stubDefs(def);
 
         QuestionProgressRepository.DomainMasteryProjection agg =
                 mock(QuestionProgressRepository.DomainMasteryProjection.class);
         when(agg.getDomainCode()).thenReturn("verkeersborden");
-        when(agg.getAttemptedCount()).thenReturn(27L);  // exceeds active pool of 20
+        when(agg.getAttemptedCount()).thenReturn(27L);
         when(agg.getCorrectCount()).thenReturn(25L);
-        when(agg.getTotalAttempts()).thenReturn(30L);   // 25/30 = 83.3% accuracy (not MASTERED alone)
-        // But coverage clamped to 20/20 = 100% → accuracy 83% + coverage 100% → MODERATE (< 85% accuracy)
-        // So with these numbers, it should NOT be MASTERED (accuracy 83.3% < 85%)
+        when(agg.getTotalAttempts()).thenReturn(30L);
 
         when(progressRepository.aggregateByDomain(USER_ID, PRODUCT)).thenReturn(List.of(agg));
         when(strapiContentCache.getQuestionCountByDomain("verkeersborden", "nl")).thenReturn(20);
 
         List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
 
-        // accuracy 83.3% < 85% threshold → NOT MASTERED → achievement not earned
+        // accuracy 83.3% < 85% threshold -> NOT MASTERED
         assertTrue(result.isEmpty(), "Should not earn domain_mastered when accuracy < 85%");
     }
 
+    // --- ALL_DOMAINS_MASTERED ---
+
     @Test
-    void below_threshold_achievement_not_earned() {
-        StrapiAchievementDefDto def = new StrapiAchievementDefDto(
-                1, null, "Beginnersluk", "ten_questions", "desc", "⭐", "🔒",
-                "questions_answered", 10, 50, true, 1, null);
-        when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
-        when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
-        when(progressRepository.countAttempted(USER_ID, PRODUCT)).thenReturn(5);
+    void allDomainsMastered_earned_when_all_domains_mastered() {
+        StrapiAchievementDefDto def = achievementDef("all_domains", "ALL_DOMAINS_MASTERED", 1);
+        stubDefs(def);
+
+        // Two domains total
+        StrapiDomainDto domain1 = mock(StrapiDomainDto.class);
+        StrapiDomainDto domain2 = mock(StrapiDomainDto.class);
+        when(strapiContentCache.getDomains(PRODUCT, "nl")).thenReturn(List.of(domain1, domain2));
+
+        // Both mastered: accuracy >= 85%, coverage >= 80%
+        QuestionProgressRepository.DomainMasteryProjection agg1 =
+                mock(QuestionProgressRepository.DomainMasteryProjection.class);
+        when(agg1.getDomainCode()).thenReturn("d1");
+        when(agg1.getAttemptedCount()).thenReturn(25L);
+        when(agg1.getCorrectCount()).thenReturn(25L);
+        when(agg1.getTotalAttempts()).thenReturn(28L);
+
+        QuestionProgressRepository.DomainMasteryProjection agg2 =
+                mock(QuestionProgressRepository.DomainMasteryProjection.class);
+        when(agg2.getDomainCode()).thenReturn("d2");
+        when(agg2.getAttemptedCount()).thenReturn(20L);
+        when(agg2.getCorrectCount()).thenReturn(20L);
+        when(agg2.getTotalAttempts()).thenReturn(22L);
+
+        when(progressRepository.aggregateByDomain(USER_ID, PRODUCT)).thenReturn(List.of(agg1, agg2));
+        when(strapiContentCache.getQuestionCountByDomain("d1", "nl")).thenReturn(28);
+        when(strapiContentCache.getQuestionCountByDomain("d2", "nl")).thenReturn(22);
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void allDomainsMastered_not_earned_when_one_domain_not_mastered() {
+        StrapiAchievementDefDto def = achievementDef("all_domains", "ALL_DOMAINS_MASTERED", 1);
+        stubDefs(def);
+
+        StrapiDomainDto domain1 = mock(StrapiDomainDto.class);
+        StrapiDomainDto domain2 = mock(StrapiDomainDto.class);
+        when(strapiContentCache.getDomains(PRODUCT, "nl")).thenReturn(List.of(domain1, domain2));
+
+        // Only one mastered
+        QuestionProgressRepository.DomainMasteryProjection agg1 =
+                mock(QuestionProgressRepository.DomainMasteryProjection.class);
+        when(agg1.getDomainCode()).thenReturn("d1");
+        when(agg1.getAttemptedCount()).thenReturn(25L);
+        when(agg1.getCorrectCount()).thenReturn(25L);
+        when(agg1.getTotalAttempts()).thenReturn(28L);
+
+        when(progressRepository.aggregateByDomain(USER_ID, PRODUCT)).thenReturn(List.of(agg1));
+        when(strapiContentCache.getQuestionCountByDomain("d1", "nl")).thenReturn(28);
 
         List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
 
         assertTrue(result.isEmpty());
-        verify(achievementRepository, never()).save(any());
     }
+
+    // --- READINESS_SCORE ---
+
+    @Test
+    void readinessScore_earned_when_snapshot_meets_threshold() {
+        StrapiAchievementDefDto def = achievementDef("readiness_80", "READINESS_SCORE", 80);
+        stubDefs(def);
+
+        ReadinessSnapshot snapshot = new ReadinessSnapshot();
+        snapshot.setReadinessScore(BigDecimal.valueOf(85.5));
+        when(readinessSnapshotRepository.findTopByKeycloakUserIdAndProductCodeOrderBySnapshotDateDesc(
+                USER_ID, PRODUCT)).thenReturn(Optional.of(snapshot));
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void readinessScore_not_earned_when_no_snapshot() {
+        StrapiAchievementDefDto def = achievementDef("readiness_80", "READINESS_SCORE", 80);
+        stubDefs(def);
+
+        when(readinessSnapshotRepository.findTopByKeycloakUserIdAndProductCodeOrderBySnapshotDateDesc(
+                USER_ID, PRODUCT)).thenReturn(Optional.empty());
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertTrue(result.isEmpty());
+    }
+
+    // --- AVG_ANSWER_TIME_BELOW ---
+
+    @Test
+    void avgAnswerTimeBelow_earned_when_fast_enough() {
+        StrapiAchievementDefDto def = achievementDef("speed_demon", "AVG_ANSWER_TIME_BELOW", 8);
+        stubDefs(def);
+        when(answerRepository.averageTimeTakenMs(USER_ID, PRODUCT)).thenReturn(6500.0); // 6.5 seconds
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void avgAnswerTimeBelow_not_earned_when_too_slow() {
+        StrapiAchievementDefDto def = achievementDef("speed_demon", "AVG_ANSWER_TIME_BELOW", 8);
+        stubDefs(def);
+        when(answerRepository.averageTimeTakenMs(USER_ID, PRODUCT)).thenReturn(12000.0); // 12 seconds
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void avgAnswerTimeBelow_not_earned_when_no_answers() {
+        StrapiAchievementDefDto def = achievementDef("speed_demon", "AVG_ANSWER_TIME_BELOW", 8);
+        stubDefs(def);
+        when(answerRepository.averageTimeTakenMs(USER_ID, PRODUCT)).thenReturn(null);
+
+        List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
+
+        assertTrue(result.isEmpty());
+    }
+
+    // --- isThresholdMet ---
+
+    @Test
+    void isThresholdMet_standard_uses_greater_equal() {
+        assertTrue(AchievementService.isThresholdMet("QUESTIONS_ANSWERED", 10, 10));
+        assertTrue(AchievementService.isThresholdMet("QUESTIONS_ANSWERED", 15, 10));
+        assertFalse(AchievementService.isThresholdMet("QUESTIONS_ANSWERED", 9, 10));
+    }
+
+    @Test
+    void isThresholdMet_avgTimeBelow_uses_less_equal() {
+        // 6 seconds avg, threshold 8 -> earned
+        assertTrue(AchievementService.isThresholdMet("AVG_ANSWER_TIME_BELOW", 6, 8));
+        // 8 seconds avg, threshold 8 -> earned (equal counts)
+        assertTrue(AchievementService.isThresholdMet("AVG_ANSWER_TIME_BELOW", 8, 8));
+        // 10 seconds avg, threshold 8 -> NOT earned
+        assertFalse(AchievementService.isThresholdMet("AVG_ANSWER_TIME_BELOW", 10, 8));
+        // 0 (no data), threshold 8 -> NOT earned
+        assertFalse(AchievementService.isThresholdMet("AVG_ANSWER_TIME_BELOW", 0, 8));
+    }
+
+    // --- Unknown trigger type ---
 
     @Test
     void unknown_trigger_type_returns_zero_does_not_earn() {
         StrapiAchievementDefDto def = new StrapiAchievementDefDto(
                 1, null, "Unknown", "unknown_ach", "desc", "?", "?",
-                "unknown_trigger_xyz", 1, 0, true, 1, null);
-        when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
-        when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
+                "UNKNOWN_TRIGGER_XYZ", 1, 0, true, 1, null);
+        stubDefs(def);
 
         List<EarnedAchievementDto> result = achievementService.checkAchievements(USER_ID, PRODUCT);
 
         assertTrue(result.isEmpty());
     }
 
+    // --- Tenant isolation ---
+
     @Test
     void saved_achievement_has_correct_tenant_id() {
-        StrapiAchievementDefDto def = new StrapiAchievementDefDto(
-                1, null, "Eerste Stap", "first_question", "desc", "🎯", "🔒",
-                "questions_answered", 1, 10, true, 1, null);
-        when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(def));
-        when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
+        StrapiAchievementDefDto def = achievementDef("first_question", "QUESTIONS_ANSWERED", 1);
+        stubDefs(def);
         when(progressRepository.countAttempted(USER_ID, PRODUCT)).thenReturn(1);
         ArgumentCaptor<EarnedAchievement> captor = ArgumentCaptor.forClass(EarnedAchievement.class);
         when(achievementRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
@@ -267,5 +488,26 @@ class AchievementServiceTest {
         achievementService.checkAchievements(USER_ID, PRODUCT);
 
         assertEquals(TENANT_ID, captor.getValue().getTenantId());
+    }
+
+    // --- Helpers ---
+
+    private StrapiAchievementDefDto achievementDef(String code, String triggerType, int triggerValue) {
+        return new StrapiAchievementDefDto(
+                1, null, "Achievement " + code, code, "desc", "icon", "locked",
+                triggerType, triggerValue, 50, true, 1, null);
+    }
+
+    private void stubDefs(StrapiAchievementDefDto... defs) {
+        when(strapiContentCache.getAchievements(PRODUCT)).thenReturn(List.of(defs));
+        when(achievementRepository.findEarnedCodes(USER_ID)).thenReturn(Set.of());
+        org.mockito.Mockito.lenient().when(achievementRepository.save(any()))
+                .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private ExamAttempt mockExam(boolean passed) {
+        ExamAttempt exam = mock(ExamAttempt.class);
+        when(exam.isPassed()).thenReturn(passed);
+        return exam;
     }
 }


### PR DESCRIPTION
Closes #75

## Changes
- **P0:** Fixed case mismatch — all 12 switch cases now use UPPERCASE to match Strapi enum values
- **P1:** Added 5 missing trigger handlers: `PERFECT_SESSION`, `PERFECT_SESSIONS`, `EXAMS_COMPLETED`, `ALL_DOMAINS_MASTERED`, `AVG_ANSWER_TIME_BELOW`
- **P1:** Fixed 3 wrong trigger queries:
  - `CONSECUTIVE_PASSES` — now counts consecutive passed exams (was counting per-question correct streaks)
  - `EXAM_SCORE` — now uses `findBestScore()` (was counting perfect exams)
  - `STREAK_DAYS` — corrected trigger name
- **P2:** `READINESS_SCORE` now reads from `ReadinessSnapshotRepository` (was always returning 0 due to circular dependency)
- **P2:** `completeSession()` now grants achievement XP (was only granting session bonus)
- **P3:** Gallery endpoint shows live progress for unearned achievements via `getCurrentValue()`
- **P3:** Added TODO for performance optimization
- Added `isThresholdMet()` for inverted comparison (AVG_ANSWER_TIME_BELOW)
- New repository queries: `countPerfectSessions`, `countCompletedExams`, `averageTimeTakenMs`, `findLatestSnapshot`
- 26 unit tests (was 11), all passing

## Test plan
- [ ] `./gradlew test` passes (196 tests, 0 failures)
- [ ] Answer a question → `first_question` achievement earned
- [ ] Complete a perfect session → `first_perfect` achievement earned
- [ ] Pass a mock exam → `first_pass` achievement earned
- [ ] Gallery shows live progress % for unearned achievements
- [ ] Achievement XP granted on session completion
- [ ] No duplicate achievements possible (unique constraint + application check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)