### PR TITLE
fix(content): return full content for answered questions on session resume

### DIFF
--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -1706,7 +1706,14 @@ components:
           description: |
             Full content of each previously answered question so the client can
             rehydrate per-question state (user's selection, revealed correct
-            answer, explanation) when resuming a session. Ordered by questionOrder ascending.
+            answer, explanation) when resuming a session. Ordered by questionOrder
+            ascending.
+
+            Slot alignment: items whose underlying question has been deactivated
+            or deleted from Strapi are omitted, so this list may be shorter than
+            `answeredCount`. Clients must place each entry at
+            `questionOrder - 1` and treat any gap as an unreachable locked slot,
+            rather than using the array position.
           items:
             $ref: '#/components/schemas/AnsweredQuestionFullDto'
 

--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -1691,6 +1691,51 @@ components:
         correctCount: { type: integer }
         currentQuestion:
           $ref: '#/components/schemas/QuestionDto'
+        answeredQuestions:
+          type: array
+          description: Lightweight summary of previously answered questions for navigator grid.
+          items:
+            type: object
+            properties:
+              questionOrder: { type: integer }
+              strapiQuestionId: { type: string }
+              correct: { type: boolean }
+              skipped: { type: boolean }
+        answeredQuestionContents:
+          type: array
+          description: |
+            Full content of each previously answered question so the client can
+            rehydrate per-question state (user's selection, revealed correct
+            answer, explanation) when resuming a session. Ordered by questionOrder ascending.
+          items:
+            $ref: '#/components/schemas/AnsweredQuestionFullDto'
+
+    AnsweredQuestionFullDto:
+      type: object
+      properties:
+        questionOrder: { type: integer }
+        question:
+          $ref: '#/components/schemas/QuestionDto'
+        userAnswer:
+          type: object
+          additionalProperties: true
+          nullable: true
+          description: The user's submitted answer payload (shape varies by interactionType). Null when the question was skipped.
+        correctAnswer:
+          type: object
+          additionalProperties: true
+          description: The revealed correct answer payload (shape varies by interactionType).
+        explanation:
+          type: object
+          nullable: true
+          properties:
+            text: { type: string }
+            tip: { type: string, nullable: true }
+            imageUrl: { type: string, nullable: true }
+            legalReference: { type: string, nullable: true }
+        isCorrect: { type: boolean }
+        skipped: { type: boolean }
+        timeTakenMs: { type: integer }
 
     QuestionDto:
       type: object

--- a/src/main/java/com/passtheo/content/dto/response/AnsweredQuestionFullDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/AnsweredQuestionFullDto.java
@@ -1,0 +1,31 @@
+package com.passtheo.content.dto.response;
+
+import jakarta.annotation.Nullable;
+
+import java.util.Map;
+
+/**
+ * Full-content snapshot of a previously answered question within a session.
+ * Included in {@link SessionDto} on resume so the Flutter client can rehydrate
+ * per-question state (the user's original selection, the revealed correct
+ * answer, and the explanation) and allow the user to navigate back.
+ *
+ * @param questionOrder the 1-based order of the question within the session
+ * @param question      the full question payload (text, options, regions, ...)
+ * @param userAnswer    the user's submitted answer (null when skipped)
+ * @param correctAnswer the revealed correct answer payload
+ * @param explanation   the explanation revealed after answering
+ * @param isCorrect     whether the user's answer was correct
+ * @param skipped       whether the user skipped this question
+ * @param timeTakenMs   time taken by the user on this question in milliseconds
+ */
+public record AnsweredQuestionFullDto(
+    int questionOrder,
+    QuestionDto question,
+    @Nullable Map<String, Object> userAnswer,
+    Map<String, Object> correctAnswer,
+    @Nullable AnswerResultDto.ExplanationDto explanation,
+    boolean isCorrect,
+    boolean skipped,
+    int timeTakenMs
+) {}

--- a/src/main/java/com/passtheo/content/dto/response/SessionDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/SessionDto.java
@@ -15,6 +15,15 @@ import java.util.UUID;
  *       answer, explanation) so the client can rehydrate per-question state
  *       and allow the user to navigate back.</li>
  * </ul>
+ *
+ * <p><b>Slot alignment:</b> {@code answeredQuestionContents[i].questionOrder}
+ * (1-based) is the authoritative slot index — not the array position. Items
+ * whose underlying Strapi question has been deactivated or deleted are omitted,
+ * so {@code answeredQuestionContents.size()} may be less than
+ * {@code answeredCount}. Clients must place each entry at
+ * {@code questionOrder - 1} and leave any resulting gap as an unreachable
+ * "locked" slot. {@code answeredQuestions} always has one summary per real
+ * answer ({@code size() == answeredCount}).
  */
 public record SessionDto(
     UUID sessionId,

--- a/src/main/java/com/passtheo/content/dto/response/SessionDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/SessionDto.java
@@ -5,9 +5,16 @@ import java.util.UUID;
 
 /**
  * Session state response DTO.
- * On resume ({@code GET /api/practice/sessions/:id}), {@code answeredQuestions} contains
- * a summary of every previously answered question so the Flutter client can
- * reconstruct the navigator grid state (correct / wrong / skipped per slot).
+ *
+ * <p>On resume ({@code GET /api/practice/sessions/:id}):
+ * <ul>
+ *   <li>{@code answeredQuestions} is a lightweight summary of every previously
+ *       answered question so the client can colour the navigator grid.</li>
+ *   <li>{@code answeredQuestionContents} is the full content of each previously
+ *       answered question (question payload, user's answer, revealed correct
+ *       answer, explanation) so the client can rehydrate per-question state
+ *       and allow the user to navigate back.</li>
+ * </ul>
  */
 public record SessionDto(
     UUID sessionId,
@@ -16,5 +23,6 @@ public record SessionDto(
     int answeredCount,
     int correctCount,
     QuestionDto currentQuestion,
-    List<AnsweredQuestionSummaryDto> answeredQuestions
+    List<AnsweredQuestionSummaryDto> answeredQuestions,
+    List<AnsweredQuestionFullDto> answeredQuestionContents
 ) {}

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -609,18 +609,20 @@ public class PracticeSessionService {
         List<SessionAnswer> answers = answerRepository
                 .findBySessionIdOrderByQuestionOrderAsc(sessionId);
 
-        List<AnsweredQuestionSummaryDto> answeredQuestions = answers.stream()
-                .map(a -> new AnsweredQuestionSummaryDto(
-                        a.getQuestionOrder(),
-                        a.getStrapiQuestionId(),
-                        a.isCorrect(),
-                        SKIP_ANSWER_JSON.equals(a.getUserAnswer())))
-                .toList();
-
-        List<AnsweredQuestionFullDto> answeredQuestionContents = answers.stream()
-                .map(a -> buildAnsweredQuestionFull(a, locale))
-                .filter(java.util.Objects::nonNull)
-                .toList();
+        // Single pass over the answer rows to populate both projections.
+        List<AnsweredQuestionSummaryDto> answeredQuestions = new ArrayList<>(answers.size());
+        List<AnsweredQuestionFullDto> answeredQuestionContents = new ArrayList<>(answers.size());
+        for (SessionAnswer a : answers) {
+            answeredQuestions.add(new AnsweredQuestionSummaryDto(
+                    a.getQuestionOrder(),
+                    a.getStrapiQuestionId(),
+                    a.isCorrect(),
+                    SKIP_ANSWER_JSON.equals(a.getUserAnswer())));
+            AnsweredQuestionFullDto full = buildAnsweredQuestionFull(a, locale);
+            if (full != null) {
+                answeredQuestionContents.add(full);
+            }
+        }
 
         return new SessionDto(
                 session.getId(),

--- a/src/main/java/com/passtheo/content/service/PracticeSessionService.java
+++ b/src/main/java/com/passtheo/content/service/PracticeSessionService.java
@@ -19,6 +19,7 @@ import com.passtheo.content.dto.request.SubmitAnswerRequest;
 import com.passtheo.content.dto.response.ActiveSessionDto;
 import com.passtheo.content.dto.response.AnswerResultDto;
 import com.passtheo.shared.core.dto.AccessGrant;
+import com.passtheo.content.dto.response.AnsweredQuestionFullDto;
 import com.passtheo.content.dto.response.AnsweredQuestionSummaryDto;
 import com.passtheo.content.dto.response.DomainSummaryDto;
 import com.passtheo.content.domain.entity.QuestionReport;
@@ -216,6 +217,7 @@ public class PracticeSessionService {
                 session.getAnsweredCount(),
                 session.getCorrectCount(),
                 firstQuestion,
+                List.of(),
                 List.of()
         );
     }
@@ -604,13 +606,20 @@ public class PracticeSessionService {
             }
         }
 
-        List<AnsweredQuestionSummaryDto> answeredQuestions = answerRepository
-                .findBySessionIdOrderByQuestionOrderAsc(sessionId).stream()
+        List<SessionAnswer> answers = answerRepository
+                .findBySessionIdOrderByQuestionOrderAsc(sessionId);
+
+        List<AnsweredQuestionSummaryDto> answeredQuestions = answers.stream()
                 .map(a -> new AnsweredQuestionSummaryDto(
                         a.getQuestionOrder(),
                         a.getStrapiQuestionId(),
                         a.isCorrect(),
                         SKIP_ANSWER_JSON.equals(a.getUserAnswer())))
+                .toList();
+
+        List<AnsweredQuestionFullDto> answeredQuestionContents = answers.stream()
+                .map(a -> buildAnsweredQuestionFull(a, locale))
+                .filter(java.util.Objects::nonNull)
                 .toList();
 
         return new SessionDto(
@@ -620,7 +629,46 @@ public class PracticeSessionService {
                 session.getAnsweredCount(),
                 session.getCorrectCount(),
                 currentQuestion,
-                answeredQuestions
+                answeredQuestions,
+                answeredQuestionContents
+        );
+    }
+
+    /**
+     * Builds a full-content snapshot for a previously answered question. Returns
+     * null when the underlying question has been deleted or deactivated in
+     * Strapi (caller filters nulls). The explanation is translated from the
+     * {@link QuestionDto.ExplanationDto} shape (used on the question payload)
+     * to the {@link AnswerResultDto.ExplanationDto} shape (used on reveal).
+     */
+    @Nullable
+    private AnsweredQuestionFullDto buildAnsweredQuestionFull(@Nonnull SessionAnswer answer,
+                                                              @Nonnull String locale) {
+        QuestionDto question = loadQuestion(
+                answer.getStrapiQuestionId(), locale, answer.getQuestionOrder());
+        if (question == null) {
+            return null;
+        }
+        boolean skipped = SKIP_ANSWER_JSON.equals(answer.getUserAnswer());
+        Map<String, Object> userAnswer = skipped ? null : deserializeJson(answer.getUserAnswer());
+        Map<String, Object> correctAnswer = deserializeJson(answer.getCorrectAnswer());
+        AnswerResultDto.ExplanationDto explanation = null;
+        if (question.explanation() != null) {
+            explanation = new AnswerResultDto.ExplanationDto(
+                    question.explanation().text(),
+                    question.explanation().tip(),
+                    question.explanation().imageUrl(),
+                    question.explanation().legalReference());
+        }
+        return new AnsweredQuestionFullDto(
+                answer.getQuestionOrder(),
+                question,
+                userAnswer,
+                correctAnswer,
+                explanation,
+                answer.isCorrect(),
+                skipped,
+                answer.getTimeTakenMs()
         );
     }
 

--- a/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
+++ b/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
@@ -1,13 +1,17 @@
 package com.passtheo.content.unit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.passtheo.content.domain.entity.SessionAnswer;
 import com.passtheo.content.domain.entity.StudySession;
 import com.passtheo.content.domain.enums.SessionStatus;
 import com.passtheo.content.domain.enums.SessionType;
 import com.passtheo.content.dto.response.ActiveSessionDto;
+import com.passtheo.content.dto.response.AnsweredQuestionFullDto;
 import com.passtheo.content.dto.response.SessionDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
+import com.passtheo.content.integration.strapi.dto.StrapiQuestionDto;
+import com.passtheo.content.integration.strapi.dto.StrapiRelationDto;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.repository.QuestionReportRepository;
@@ -131,6 +135,101 @@ class PracticeSessionServiceActiveSessionTest {
         assertThat(result.currentQuestion()).isNull();
         // totalQuestions should be adjusted down to answeredCount
         assertThat(result.totalQuestions()).isEqualTo(5);
+    }
+
+    @Test
+    void getSession_withAnsweredQuestions_populatesAnsweredQuestionContents() {
+        // Session with 5 questions, 2 answered (1 correct multiple_choice, 1 skipped).
+        // getSession() should return both the legacy `answeredQuestions` summary list
+        // AND the new `answeredQuestionContents` list with full question content +
+        // user's answer + revealed correct answer + explanation, ordered by questionOrder.
+        UUID sessionId = UUID.randomUUID();
+        StudySession session = new StudySession(USER_ID, PRODUCT_CODE, "voorrang", null,
+                SessionType.PRACTICE, 5, "nl");
+        session.setId(sessionId);
+        session.setAnsweredCount(2);
+        session.setQuestionIdList(List.of("doc-q1", "doc-q2", "doc-q3", "doc-q4", "doc-q5"));
+
+        when(sessionRepository.findByIdAndKeycloakUserId(sessionId, USER_ID))
+                .thenReturn(Optional.of(session));
+
+        SessionAnswer correctAnswer = new SessionAnswer(
+                sessionId, USER_ID, "doc-q1", 1, "multiple_choice", true,
+                "{\"selectedOptionId\":\"opt-a\"}",
+                "{\"selectedOptionId\":\"opt-a\"}",
+                4200, 1);
+        SessionAnswer skippedAnswer = new SessionAnswer(
+                sessionId, USER_ID, "doc-q2", 1, "multiple_choice", false,
+                "null",
+                "{\"selectedOptionId\":\"opt-b\"}",
+                1500, 2);
+        when(answerRepository.findBySessionIdOrderByQuestionOrderAsc(sessionId))
+                .thenReturn(List.of(correctAnswer, skippedAnswer));
+
+        // Stub Strapi content for each answered question AND for the next
+        // unanswered question (index = answeredCount = 2 → questionId "doc-q3").
+        when(strapiContentCache.getQuestion("doc-q1", "nl"))
+                .thenReturn(buildStrapiQuestion("doc-q1", "What is Q1?"));
+        when(strapiContentCache.getQuestion("doc-q2", "nl"))
+                .thenReturn(buildStrapiQuestion("doc-q2", "What is Q2?"));
+        when(strapiContentCache.getQuestion("doc-q3", "nl"))
+                .thenReturn(buildStrapiQuestion("doc-q3", "What is Q3?"));
+
+        SessionDto result = service.getSession(USER_ID, sessionId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.answeredCount()).isEqualTo(2);
+        assertThat(result.totalQuestions()).isEqualTo(5);
+        assertThat(result.currentQuestion()).isNotNull();
+        assertThat(result.currentQuestion().strapiQuestionId()).isEqualTo("doc-q3");
+
+        // Legacy summary list still present.
+        assertThat(result.answeredQuestions()).hasSize(2);
+        assertThat(result.answeredQuestions().get(0).questionOrder()).isEqualTo(1);
+        assertThat(result.answeredQuestions().get(0).correct()).isTrue();
+        assertThat(result.answeredQuestions().get(1).skipped()).isTrue();
+
+        // New full-content list, ordered by questionOrder ascending.
+        assertThat(result.answeredQuestionContents()).hasSize(2);
+
+        AnsweredQuestionFullDto first = result.answeredQuestionContents().get(0);
+        assertThat(first.questionOrder()).isEqualTo(1);
+        assertThat(first.question().strapiQuestionId()).isEqualTo("doc-q1");
+        assertThat(first.question().questionText()).isEqualTo("What is Q1?");
+        assertThat(first.question().answerOptions()).isNotEmpty();
+        assertThat(first.userAnswer()).containsEntry("selectedOptionId", "opt-a");
+        assertThat(first.correctAnswer()).containsEntry("selectedOptionId", "opt-a");
+        assertThat(first.explanation()).isNotNull();
+        assertThat(first.explanation().text()).isNotBlank();
+        assertThat(first.isCorrect()).isTrue();
+        assertThat(first.skipped()).isFalse();
+        assertThat(first.timeTakenMs()).isEqualTo(4200);
+
+        AnsweredQuestionFullDto second = result.answeredQuestionContents().get(1);
+        assertThat(second.questionOrder()).isEqualTo(2);
+        assertThat(second.question().strapiQuestionId()).isEqualTo("doc-q2");
+        assertThat(second.userAnswer()).isNull();
+        assertThat(second.correctAnswer()).containsEntry("selectedOptionId", "opt-b");
+        assertThat(second.isCorrect()).isFalse();
+        assertThat(second.skipped()).isTrue();
+        assertThat(second.timeTakenMs()).isEqualTo(1500);
+    }
+
+    private StrapiQuestionDto buildStrapiQuestion(String documentId, String questionText) {
+        return new StrapiQuestionDto(
+                1, documentId, questionText, "multiple_choice", "medium",
+                null, null, null, null, 1, true, false, null, null,
+                List.of(
+                        new StrapiQuestionDto.AnswerOptionDto(1, "Option A", null, true, 1),
+                        new StrapiQuestionDto.AnswerOptionDto(2, "Option B", null, false, 2)
+                ),
+                new StrapiQuestionDto.ExplanationDto(
+                        "Because A is correct.", null, "Think carefully.",
+                        null, "RVV 1990 Art. 1"),
+                null, null, null, null,
+                new StrapiRelationDto(0, null, "voorrang", null),
+                null, null
+        );
     }
 
     @Test

--- a/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
+++ b/src/test/java/com/passtheo/content/unit/PracticeSessionServiceActiveSessionTest.java
@@ -215,6 +215,53 @@ class PracticeSessionServiceActiveSessionTest {
         assertThat(second.timeTakenMs()).isEqualTo(1500);
     }
 
+    @Test
+    void getSession_deactivatedAnsweredQuestion_filteredFromContentsKeptInSummary() {
+        // Session with 5 questions, 2 answered — Q1 loads normally, Q2 has been
+        // deactivated/deleted from Strapi. The summary list must still contain
+        // both entries (client needs counters), but answeredQuestionContents
+        // must omit Q2 since its content can no longer be rendered.
+        UUID sessionId = UUID.randomUUID();
+        StudySession session = new StudySession(USER_ID, PRODUCT_CODE, "voorrang", null,
+                SessionType.PRACTICE, 5, "nl");
+        session.setId(sessionId);
+        session.setAnsweredCount(2);
+        session.setQuestionIdList(List.of("doc-q1", "doc-q2", "doc-q3", "doc-q4", "doc-q5"));
+
+        when(sessionRepository.findByIdAndKeycloakUserId(sessionId, USER_ID))
+                .thenReturn(Optional.of(session));
+
+        SessionAnswer answered1 = new SessionAnswer(
+                sessionId, USER_ID, "doc-q1", 1, "multiple_choice", true,
+                "{\"selectedOptionId\":\"opt-a\"}",
+                "{\"selectedOptionId\":\"opt-a\"}",
+                4200, 1);
+        SessionAnswer answered2Deactivated = new SessionAnswer(
+                sessionId, USER_ID, "doc-q2", 1, "multiple_choice", false,
+                "{\"selectedOptionId\":\"opt-b\"}",
+                "{\"selectedOptionId\":\"opt-a\"}",
+                3100, 2);
+        when(answerRepository.findBySessionIdOrderByQuestionOrderAsc(sessionId))
+                .thenReturn(List.of(answered1, answered2Deactivated));
+
+        when(strapiContentCache.getQuestion("doc-q1", "nl"))
+                .thenReturn(buildStrapiQuestion("doc-q1", "What is Q1?"));
+        when(strapiContentCache.getQuestion("doc-q2", "nl")).thenReturn(null);
+        when(strapiContentCache.getQuestion("doc-q3", "nl"))
+                .thenReturn(buildStrapiQuestion("doc-q3", "What is Q3?"));
+
+        SessionDto result = service.getSession(USER_ID, sessionId);
+
+        assertThat(result.answeredCount()).isEqualTo(2);
+        assertThat(result.answeredQuestions()).hasSize(2);
+        assertThat(result.answeredQuestions().get(1).questionOrder()).isEqualTo(2);
+        // Only the still-live answered question surfaces in the full-content list.
+        assertThat(result.answeredQuestionContents()).hasSize(1);
+        assertThat(result.answeredQuestionContents().get(0).questionOrder()).isEqualTo(1);
+        assertThat(result.answeredQuestionContents().get(0).question().strapiQuestionId())
+                .isEqualTo("doc-q1");
+    }
+
     private StrapiQuestionDto buildStrapiQuestion(String documentId, String questionText) {
         return new StrapiQuestionDto(
                 1, documentId, questionText, "multiple_choice", "medium",

--- a/src/test/resources/karate/practice-sessions.feature
+++ b/src/test/resources/karate/practice-sessions.feature
@@ -159,6 +159,54 @@ Feature: Practice Sessions
     And match response.data.status == 'IN_PROGRESS'
     And match response.data.currentQuestion != null
 
+  Scenario: Resume returns full content for previously answered and skipped questions
+    # Start a 5-question session
+    Given path '/api/practice/sessions'
+    And headers paidHeaders
+    And request { productCode: 'auto-b', domainCode: 'verkeersborden', sessionType: 'PRACTICE', questionCount: 5, locale: 'nl' }
+    When method POST
+    Then status 200
+    * def sessionId = response.data.sessionId
+    * def q1Id = response.data.currentQuestion.strapiQuestionId
+    * def q1OptionId = response.data.currentQuestion.answerOptions[0].id
+    # Answer Q1 (whatever the first option is — correctness is irrelevant for the resume contract)
+    Given path '/api/practice/sessions/' + sessionId + '/answer'
+    And headers paidHeaders
+    And request { strapiQuestionId: '#(q1Id)', answer: { selectedOptionId: '#(q1OptionId)' }, timeTakenMs: 4200 }
+    When method POST
+    Then status 200
+    * def q2Id = response.data.nextQuestion.strapiQuestionId
+    # Skip Q2
+    Given path '/api/practice/sessions/' + sessionId + '/answer'
+    And headers paidHeaders
+    And request { strapiQuestionId: '#(q2Id)', answer: null, timeTakenMs: 1500 }
+    When method POST
+    Then status 200
+    # Now resume the session
+    Given path '/api/practice/sessions/' + sessionId
+    And headers paidHeaders
+    When method GET
+    Then status 200
+    And match response.data.answeredCount == 2
+    And match response.data.currentQuestion.questionOrder == 3
+    # Existing summary payload still present for backwards compatibility
+    And match response.data.answeredQuestions == '#[2]'
+    # New rich payload: two items ordered by questionOrder ascending
+    And match response.data.answeredQuestionContents == '#[2]'
+    And match response.data.answeredQuestionContents[0].questionOrder == 1
+    And match response.data.answeredQuestionContents[0].question.strapiQuestionId == q1Id
+    And match response.data.answeredQuestionContents[0].question.questionText == '#string'
+    And match response.data.answeredQuestionContents[0].userAnswer != null
+    And match response.data.answeredQuestionContents[0].correctAnswer != null
+    And match response.data.answeredQuestionContents[0].explanation != null
+    And match response.data.answeredQuestionContents[0].isCorrect == '#boolean'
+    And match response.data.answeredQuestionContents[0].skipped == false
+    And assert response.data.answeredQuestionContents[0].timeTakenMs >= 0
+    And match response.data.answeredQuestionContents[1].questionOrder == 2
+    And match response.data.answeredQuestionContents[1].question.strapiQuestionId == q2Id
+    And match response.data.answeredQuestionContents[1].skipped == true
+    And match response.data.answeredQuestionContents[1].isCorrect == false
+
   Scenario: Complete session returns summary
     Given path '/api/practice/sessions'
     And headers paidHeaders


### PR DESCRIPTION
Closes #77

## Changes
- New DTO `AnsweredQuestionFullDto(questionOrder, question, userAnswer, correctAnswer, explanation, isCorrect, skipped, timeTakenMs)` exposing the full payload the client needs to rehydrate per-question state.
- `SessionDto` gains `answeredQuestionContents: List<AnsweredQuestionFullDto>`; the existing `answeredQuestions` summary list is kept for backwards compatibility (breakdown and other consumers still use the lightweight shape).
- `PracticeSessionService.getSession()` now loads full content via `loadQuestion(...)` for every `SessionAnswer`, deserializes the stored user/correct answer JSON, and populates the new list. Questions that have been deactivated/deleted in Strapi are silently omitted (caller already tolerates this).
- OpenAPI schema updated (`SessionDto` + new `AnsweredQuestionFullDto`).
- New Karate scenario in `practice-sessions.feature` documenting the expected shape (note: this scenario currently hits the pre-existing shared-quota issue on the acceptance test suite — see test plan below).
- New unit test `getSession_withAnsweredQuestions_populatesAnsweredQuestionContents` exercising the mapping end-to-end with Mockito.

## Frontend follow-up
A separate PR in `passtheo-ui` will consume the new field so the "Continue Practicing" card resumes with the correct progress, navigator grid, and back-navigation into previously answered questions.

## Test plan
- [x] `./gradlew test` — all unit tests pass (incl. new mapping test).
- [x] Docker image builds and service starts cleanly on port 8087.
- [x] `/actuator/health/readiness` returns `UP`.
- [ ] Karate acceptance suite has pre-existing failures on `develop` (daily-question-limit quota state bleeds across scenarios). The new resume scenario hits the same pre-existing issue. Out of scope for this PR — tracked separately.