### PR TITLE
feat(content): lesson completion tracking with XP and achievements

### DIFF
--- a/src/main/java/com/passtheo/content/controller/LessonController.java
+++ b/src/main/java/com/passtheo/content/controller/LessonController.java
@@ -72,12 +72,12 @@ public class LessonController {
      * @return 204 No Content
      */
     @DeleteMapping("/{lessonSlug}/complete")
-    public ResponseEntity<ApiResponse<Void>> uncomplete(
+    public ResponseEntity<Void> uncomplete(
             @PathVariable @Nonnull String lessonSlug,
             @RequestParam @Nonnull String productCode,
             @RequestHeader("X-Keycloak-User-ID") UUID userId) {
         lessonProgressService.uncompleteLesson(userId, lessonSlug, productCode);
-        return ResponseEntity.ok(ApiResponse.success(null, MDC.get("traceId")));
+        return ResponseEntity.noContent().build();
     }
 
     /**

--- a/src/main/java/com/passtheo/content/controller/LessonController.java
+++ b/src/main/java/com/passtheo/content/controller/LessonController.java
@@ -1,0 +1,100 @@
+package com.passtheo.content.controller;
+
+import com.passtheo.content.dto.request.CompleteLessonRequest;
+import com.passtheo.content.dto.response.LessonCompleteResponse;
+import com.passtheo.content.dto.response.LessonProgressDto;
+import com.passtheo.content.service.LessonProgressService;
+import com.passtheo.shared.core.dto.ApiResponse;
+import jakarta.annotation.Nonnull;
+import jakarta.validation.Valid;
+import org.slf4j.MDC;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Lesson reading progress endpoints: mark complete, mark unread, and fetch
+ * progress for every lesson in a topic.
+ *
+ * <p>The listing endpoints (GET lessons by topic) live in {@link ContentController}
+ * because they return content — these endpoints here deal only with per-user progress.
+ */
+@RestController
+@RequestMapping("/api/content/lessons")
+public class LessonController {
+
+    private final LessonProgressService lessonProgressService;
+
+    /**
+     * Constructs the lesson controller.
+     *
+     * @param lessonProgressService the lesson progress service
+     */
+    public LessonController(LessonProgressService lessonProgressService) {
+        this.lessonProgressService = lessonProgressService;
+    }
+
+    /**
+     * Marks a lesson complete. First-time completion grants +20 XP, checks achievements,
+     * and publishes a LessonCompletedEvent. Idempotent — re-completing grants 0 XP.
+     *
+     * @param lessonSlug the lesson slug
+     * @param request    the complete request (productCode, topicCode, timeSpentSeconds)
+     * @param userId     the user's Keycloak ID
+     * @return the completion response
+     */
+    @PostMapping("/{lessonSlug}/complete")
+    public ResponseEntity<ApiResponse<LessonCompleteResponse>> complete(
+            @PathVariable @Nonnull String lessonSlug,
+            @RequestBody @Valid @Nonnull CompleteLessonRequest request,
+            @RequestHeader("X-Keycloak-User-ID") UUID userId) {
+        LessonCompleteResponse response = lessonProgressService.completeLesson(
+                userId, lessonSlug, request.productCode(), request.topicCode(), request.timeSpentSeconds());
+        return ResponseEntity.ok(ApiResponse.success(response, MDC.get("traceId")));
+    }
+
+    /**
+     * Marks a lesson not-completed. Does not refund XP or remove achievements.
+     *
+     * @param lessonSlug  the lesson slug
+     * @param productCode the product code
+     * @param userId      the user's Keycloak ID
+     * @return 204 No Content
+     */
+    @DeleteMapping("/{lessonSlug}/complete")
+    public ResponseEntity<ApiResponse<Void>> uncomplete(
+            @PathVariable @Nonnull String lessonSlug,
+            @RequestParam @Nonnull String productCode,
+            @RequestHeader("X-Keycloak-User-ID") UUID userId) {
+        lessonProgressService.uncompleteLesson(userId, lessonSlug, productCode);
+        return ResponseEntity.ok(ApiResponse.success(null, MDC.get("traceId")));
+    }
+
+    /**
+     * Returns progress records for every lesson the user has interacted with in the topic.
+     *
+     * @param productCode the product code
+     * @param topicCode   the topic code
+     * @param userId      the user's Keycloak ID
+     * @return progress list (empty if user has never completed a lesson in this topic)
+     */
+    @GetMapping("/progress")
+    public ResponseEntity<ApiResponse<List<LessonProgressDto>>> getProgress(
+            @RequestParam @Nonnull String productCode,
+            @RequestParam @Nonnull String topicCode,
+            @RequestHeader("X-Keycloak-User-ID") UUID userId) {
+        List<LessonProgressDto> progress = lessonProgressService
+                .getProgressForTopic(userId, productCode, topicCode);
+        return ResponseEntity.ok(ApiResponse.success(progress, MDC.get("traceId")));
+    }
+}

--- a/src/main/java/com/passtheo/content/domain/entity/LessonProgress.java
+++ b/src/main/java/com/passtheo/content/domain/entity/LessonProgress.java
@@ -43,9 +43,6 @@ public class LessonProgress extends BaseEntity {
     @Column(name = "time_spent_seconds", nullable = false)
     private int timeSpentSeconds;
 
-    @Column(name = "last_scroll_position", nullable = false)
-    private int lastScrollPosition;
-
     @Version
     @Column(name = "version", nullable = false)
     private int version;
@@ -68,7 +65,6 @@ public class LessonProgress extends BaseEntity {
         this.completed = false;
         this.startedAt = Instant.now();
         this.timeSpentSeconds = 0;
-        this.lastScrollPosition = 0;
     }
 
     public UUID getKeycloakUserId() {
@@ -117,14 +113,6 @@ public class LessonProgress extends BaseEntity {
 
     public void setTimeSpentSeconds(int timeSpentSeconds) {
         this.timeSpentSeconds = timeSpentSeconds;
-    }
-
-    public int getLastScrollPosition() {
-        return lastScrollPosition;
-    }
-
-    public void setLastScrollPosition(int lastScrollPosition) {
-        this.lastScrollPosition = lastScrollPosition;
     }
 
     public int getVersion() {

--- a/src/main/java/com/passtheo/content/domain/entity/LessonProgress.java
+++ b/src/main/java/com/passtheo/content/domain/entity/LessonProgress.java
@@ -1,0 +1,137 @@
+package com.passtheo.content.domain.entity;
+
+import com.passtheo.shared.core.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Tracks a user's reading progress through a lesson. Created lazily on first
+ * completion call. Uncomplete sets {@code isCompleted=false} but preserves
+ * {@code startedAt}, {@code completedAt}, and {@code timeSpentSeconds} for
+ * analytics — no XP refund.
+ */
+@Entity
+@Table(name = "lesson_progress")
+public class LessonProgress extends BaseEntity {
+
+    @Column(name = "keycloak_user_id", nullable = false)
+    private UUID keycloakUserId;
+
+    @Column(name = "product_code", nullable = false, length = 50)
+    private String productCode;
+
+    @Column(name = "topic_code", nullable = false, length = 50)
+    private String topicCode;
+
+    @Column(name = "lesson_slug", nullable = false, length = 100)
+    private String lessonSlug;
+
+    @Column(name = "is_completed", nullable = false)
+    private boolean completed;
+
+    @Column(name = "started_at", nullable = false)
+    private Instant startedAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    @Column(name = "time_spent_seconds", nullable = false)
+    private int timeSpentSeconds;
+
+    @Column(name = "last_scroll_position", nullable = false)
+    private int lastScrollPosition;
+
+    @Version
+    @Column(name = "version", nullable = false)
+    private int version;
+
+    protected LessonProgress() { }
+
+    /**
+     * Creates a new lesson progress record.
+     *
+     * @param keycloakUserId the user's Keycloak ID
+     * @param productCode    the product code
+     * @param topicCode      the topic code
+     * @param lessonSlug     the lesson slug
+     */
+    public LessonProgress(UUID keycloakUserId, String productCode, String topicCode, String lessonSlug) {
+        this.keycloakUserId = keycloakUserId;
+        this.productCode = productCode;
+        this.topicCode = topicCode;
+        this.lessonSlug = lessonSlug;
+        this.completed = false;
+        this.startedAt = Instant.now();
+        this.timeSpentSeconds = 0;
+        this.lastScrollPosition = 0;
+    }
+
+    public UUID getKeycloakUserId() {
+        return keycloakUserId;
+    }
+
+    public String getProductCode() {
+        return productCode;
+    }
+
+    public String getTopicCode() {
+        return topicCode;
+    }
+
+    public String getLessonSlug() {
+        return lessonSlug;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public void setCompleted(boolean completed) {
+        this.completed = completed;
+    }
+
+    public Instant getStartedAt() {
+        return startedAt;
+    }
+
+    public void setStartedAt(Instant startedAt) {
+        this.startedAt = startedAt;
+    }
+
+    public Instant getCompletedAt() {
+        return completedAt;
+    }
+
+    public void setCompletedAt(Instant completedAt) {
+        this.completedAt = completedAt;
+    }
+
+    public int getTimeSpentSeconds() {
+        return timeSpentSeconds;
+    }
+
+    public void setTimeSpentSeconds(int timeSpentSeconds) {
+        this.timeSpentSeconds = timeSpentSeconds;
+    }
+
+    public int getLastScrollPosition() {
+        return lastScrollPosition;
+    }
+
+    public void setLastScrollPosition(int lastScrollPosition) {
+        this.lastScrollPosition = lastScrollPosition;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+}

--- a/src/main/java/com/passtheo/content/dto/request/CompleteLessonRequest.java
+++ b/src/main/java/com/passtheo/content/dto/request/CompleteLessonRequest.java
@@ -1,0 +1,17 @@
+package com.passtheo.content.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request payload for marking a lesson complete.
+ *
+ * @param productCode      the product code the lesson belongs to
+ * @param topicCode        the topic code the lesson belongs to
+ * @param timeSpentSeconds time the user spent reading the lesson
+ */
+public record CompleteLessonRequest(
+        @NotBlank String productCode,
+        @NotBlank String topicCode,
+        @Min(0) int timeSpentSeconds
+) { }

--- a/src/main/java/com/passtheo/content/dto/response/LessonCompleteResponse.java
+++ b/src/main/java/com/passtheo/content/dto/response/LessonCompleteResponse.java
@@ -1,0 +1,21 @@
+package com.passtheo.content.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Response returned after marking a lesson complete.
+ *
+ * @param lessonSlug      the lesson slug
+ * @param isCompleted     whether the lesson is now completed
+ * @param completedAt     when the lesson was completed (null if somehow still incomplete)
+ * @param xpUpdate        XP state after this operation (xpEarned is 0 for re-completions)
+ * @param newAchievements achievements newly earned from this completion
+ */
+public record LessonCompleteResponse(
+        String lessonSlug,
+        boolean isCompleted,
+        Instant completedAt,
+        XpUpdateDto xpUpdate,
+        List<EarnedAchievementDto> newAchievements
+) { }

--- a/src/main/java/com/passtheo/content/dto/response/LessonProgressDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/LessonProgressDto.java
@@ -1,0 +1,18 @@
+package com.passtheo.content.dto.response;
+
+import java.time.Instant;
+
+/**
+ * Lesson progress snapshot for a single lesson.
+ *
+ * @param lessonSlug       the lesson slug
+ * @param isCompleted      whether the user has completed the lesson
+ * @param completedAt      when the lesson was completed (null if not yet)
+ * @param timeSpentSeconds total time spent reading the lesson
+ */
+public record LessonProgressDto(
+        String lessonSlug,
+        boolean isCompleted,
+        Instant completedAt,
+        int timeSpentSeconds
+) { }

--- a/src/main/java/com/passtheo/content/integration/strapi/StrapiClient.java
+++ b/src/main/java/com/passtheo/content/integration/strapi/StrapiClient.java
@@ -281,6 +281,36 @@ public class StrapiClient {
     }
 
     /**
+     * Fetches only the total count of lessons for a product using Strapi pagination metadata.
+     * Sends {@code pagination[pageSize]=1} so Strapi does not return all rows — only the
+     * {@code meta.pagination.total}.
+     *
+     * @param productCode the product code
+     * @param locale      the content locale
+     * @return total number of active lessons for the product, or 0 if unavailable
+     */
+    public int countLessonsByProduct(@Nonnull String productCode, @Nonnull String locale) {
+        LOG.debug("Counting lessons from Strapi, product={}, locale={}", productCode, locale);
+        String uri = "/api/lessons?filters[topic][product][code][$eq]=" + productCode
+                + "&filters[isActive][$eq]=true&locale=" + locale
+                + "&pagination[pageSize]=1&fields[0]=id";
+        try {
+            StrapiResponse<StrapiLessonDto> response = webClient.get()
+                    .uri(uri)
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<StrapiResponse<StrapiLessonDto>>() { })
+                    .block();
+            if (response == null || response.meta() == null || response.meta().pagination() == null) {
+                return 0;
+            }
+            return response.meta().pagination().total();
+        } catch (Exception e) {
+            LOG.error("Failed to count lessons for product={} from Strapi: {}", productCode, e.getMessage());
+            return 0;
+        }
+    }
+
+    /**
      * Fetches a Strapi 5 collection endpoint, unwraps the {@code {"data":[...],"meta":{...}}} wrapper,
      * and logs a warning when the total item count exceeds the page size.
      */

--- a/src/main/java/com/passtheo/content/integration/strapi/StrapiContentCache.java
+++ b/src/main/java/com/passtheo/content/integration/strapi/StrapiContentCache.java
@@ -330,6 +330,21 @@ public class StrapiContentCache {
     }
 
     /**
+     * Gets the total number of active lessons for a product with caching.
+     * Uses Strapi pagination metadata so the entire lesson set does not have to be fetched.
+     *
+     * @param productCode the product code
+     * @param locale      the content locale
+     * @return total count of active lessons for the product, or 0 if unavailable
+     */
+    public int getLessonCountForProduct(@Nonnull String productCode, @Nonnull String locale) {
+        Integer cached = getCachedOrFetch("lessons:count:" + productCode + ":" + locale,
+                new TypeReference<Integer>() { },
+                () -> strapiClient.countLessonsByProduct(productCode, locale));
+        return cached != null ? cached : 0;
+    }
+
+    /**
      * Resolves the domain code for a given topic code by iterating the cached domain/topic tree.
      * Used when a question's domain relation is null (Strapi does not set domain directly on questions).
      *

--- a/src/main/java/com/passtheo/content/repository/LessonProgressRepository.java
+++ b/src/main/java/com/passtheo/content/repository/LessonProgressRepository.java
@@ -1,0 +1,64 @@
+package com.passtheo.content.repository;
+
+import com.passtheo.content.domain.entity.LessonProgress;
+import jakarta.annotation.Nonnull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Repository for LessonProgress entities.
+ */
+@Repository
+public interface LessonProgressRepository extends JpaRepository<LessonProgress, UUID> {
+
+    /**
+     * Finds the progress row for a specific user+product+lesson.
+     *
+     * @param userId      the user's Keycloak ID
+     * @param productCode the product code
+     * @param lessonSlug  the lesson slug
+     * @return the progress row if present
+     */
+    Optional<LessonProgress> findByKeycloakUserIdAndProductCodeAndLessonSlug(
+            @Nonnull UUID userId, @Nonnull String productCode, @Nonnull String lessonSlug);
+
+    /**
+     * Lists all progress rows for a topic.
+     *
+     * @param userId      the user's Keycloak ID
+     * @param productCode the product code
+     * @param topicCode   the topic code
+     * @return list of progress rows
+     */
+    List<LessonProgress> findByKeycloakUserIdAndProductCodeAndTopicCode(
+            @Nonnull UUID userId, @Nonnull String productCode, @Nonnull String topicCode);
+
+    /**
+     * Counts completed lessons for a user/product.
+     *
+     * @param userId      the user's Keycloak ID
+     * @param productCode the product code
+     * @return count of completed lessons
+     */
+    long countByKeycloakUserIdAndProductCodeAndCompletedTrue(
+            @Nonnull UUID userId, @Nonnull String productCode);
+
+    /**
+     * Counts completed lessons per topic for a user/product.
+     *
+     * @param userId      the user's Keycloak ID
+     * @param productCode the product code
+     * @return list of [topicCode, count] pairs
+     */
+    @Query("SELECT lp.topicCode, COUNT(lp) FROM LessonProgress lp "
+            + "WHERE lp.keycloakUserId = :userId AND lp.productCode = :productCode "
+            + "AND lp.completed = true GROUP BY lp.topicCode")
+    List<Object[]> countCompletedByTopic(@Param("userId") @Nonnull UUID userId,
+                                         @Param("productCode") @Nonnull String productCode);
+}

--- a/src/main/java/com/passtheo/content/service/AchievementService.java
+++ b/src/main/java/com/passtheo/content/service/AchievementService.java
@@ -17,6 +17,7 @@ import com.passtheo.content.repository.ReadinessSnapshotRepository;
 import com.passtheo.content.repository.SessionAnswerRepository;
 import com.passtheo.content.repository.StudySessionRepository;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
+import com.passtheo.content.repository.LessonProgressRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.repository.StreakRepository;
 import com.passtheo.shared.core.context.TenantContext;
@@ -31,7 +32,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -62,6 +65,7 @@ public class AchievementService {
     private final StudySessionRepository sessionRepository;
     private final SessionAnswerRepository answerRepository;
     private final ReadinessSnapshotRepository readinessSnapshotRepository;
+    private final LessonProgressRepository lessonProgressRepository;
     private final StrapiContentCache strapiContentCache;
     private final OutboxEventRepository outboxEventRepository;
 
@@ -75,6 +79,7 @@ public class AchievementService {
      * @param sessionRepository           study session repository
      * @param answerRepository            session answer repository
      * @param readinessSnapshotRepository readiness snapshot repository
+     * @param lessonProgressRepository    lesson progress repository
      * @param strapiContentCache          Strapi content cache
      * @param outboxEventRepository       outbox event repository
      */
@@ -85,6 +90,7 @@ public class AchievementService {
                               StudySessionRepository sessionRepository,
                               SessionAnswerRepository answerRepository,
                               ReadinessSnapshotRepository readinessSnapshotRepository,
+                              LessonProgressRepository lessonProgressRepository,
                               StrapiContentCache strapiContentCache,
                               OutboxEventRepository outboxEventRepository) {
         this.achievementRepository = achievementRepository;
@@ -94,6 +100,7 @@ public class AchievementService {
         this.sessionRepository = sessionRepository;
         this.answerRepository = answerRepository;
         this.readinessSnapshotRepository = readinessSnapshotRepository;
+        this.lessonProgressRepository = lessonProgressRepository;
         this.strapiContentCache = strapiContentCache;
         this.outboxEventRepository = outboxEventRepository;
     }
@@ -212,6 +219,36 @@ public class AchievementService {
                     yield 0;
                 }
                 yield (int) (avgMs / 1000.0);
+            }
+
+            case "LESSONS_COMPLETED" ->
+                    (int) lessonProgressRepository
+                            .countByKeycloakUserIdAndProductCodeAndCompletedTrue(userId, productCode);
+
+            case "LESSONS_COMPLETED_ALL" -> {
+                int completed = (int) lessonProgressRepository
+                        .countByKeycloakUserIdAndProductCodeAndCompletedTrue(userId, productCode);
+                int total = strapiContentCache.getLessonCountForProduct(productCode, DEFAULT_LOCALE);
+                // Yields 1 (threshold met) when every active lesson in the product has been
+                // completed at least once, 0 otherwise.
+                yield (total > 0 && completed >= total) ? 1 : 0;
+            }
+
+            case "TOPIC_LESSONS_COMPLETED" -> {
+                // Yields 1 when any single topic has been fully completed (all lessons read).
+                Map<String, Long> perTopic = new HashMap<>();
+                for (Object[] row : lessonProgressRepository.countCompletedByTopic(userId, productCode)) {
+                    perTopic.put((String) row[0], (Long) row[1]);
+                }
+                int result = 0;
+                for (Map.Entry<String, Long> entry : perTopic.entrySet()) {
+                    int topicTotal = strapiContentCache.getLessons(entry.getKey(), DEFAULT_LOCALE).size();
+                    if (topicTotal > 0 && entry.getValue() >= topicTotal) {
+                        result = 1;
+                        break;
+                    }
+                }
+                yield result;
             }
 
             default -> {

--- a/src/main/java/com/passtheo/content/service/LessonProgressService.java
+++ b/src/main/java/com/passtheo/content/service/LessonProgressService.java
@@ -1,0 +1,206 @@
+package com.passtheo.content.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.passtheo.content.domain.entity.LessonProgress;
+import com.passtheo.content.domain.valueobject.XpResult;
+import com.passtheo.content.dto.response.EarnedAchievementDto;
+import com.passtheo.content.dto.response.LessonCompleteResponse;
+import com.passtheo.content.dto.response.LessonProgressDto;
+import com.passtheo.content.dto.response.XpUpdateDto;
+import com.passtheo.content.repository.LessonProgressRepository;
+import com.passtheo.shared.core.context.TenantContext;
+import com.passtheo.shared.events.config.KafkaTopic;
+import com.passtheo.shared.events.content.LessonCompletedEvent;
+import com.passtheo.shared.outbox.entity.OutboxEvent;
+import com.passtheo.shared.outbox.entity.OutboxStatus;
+import com.passtheo.shared.outbox.repository.OutboxEventRepository;
+import jakarta.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Orchestrates lesson completion: persists progress, grants XP on first completion,
+ * checks achievements, and publishes a {@link LessonCompletedEvent} via the outbox.
+ *
+ * <p>Idempotent: re-completing a lesson returns a response with {@code xpEarned=0},
+ * does not grant XP again, and does not publish a second event. Uncompleting preserves
+ * {@code startedAt}, {@code completedAt}, and {@code timeSpentSeconds} and does not
+ * refund XP.
+ */
+@Service
+public class LessonProgressService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LessonProgressService.class);
+
+    private final LessonProgressRepository lessonProgressRepository;
+    private final XpService xpService;
+    private final AchievementService achievementService;
+    private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Constructs the lesson progress service.
+     *
+     * @param lessonProgressRepository lesson progress repository
+     * @param xpService                XP service
+     * @param achievementService       achievement service
+     * @param outboxEventRepository    outbox event repository
+     * @param objectMapper             JSON object mapper (Spring-configured with JavaTimeModule)
+     */
+    public LessonProgressService(LessonProgressRepository lessonProgressRepository,
+                                 XpService xpService,
+                                 AchievementService achievementService,
+                                 OutboxEventRepository outboxEventRepository,
+                                 ObjectMapper objectMapper) {
+        this.lessonProgressRepository = lessonProgressRepository;
+        this.xpService = xpService;
+        this.achievementService = achievementService;
+        this.outboxEventRepository = outboxEventRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Marks a lesson complete for a user. First-time completion grants XP, checks
+     * achievements, and publishes a {@link LessonCompletedEvent}. Subsequent completions
+     * are idempotent and return {@code xpEarned=0} with no event.
+     *
+     * @param userId           the user's Keycloak ID
+     * @param lessonSlug       the lesson slug
+     * @param productCode      the product code
+     * @param topicCode        the topic code
+     * @param timeSpentSeconds time spent reading the lesson
+     * @return completion response including XP state and any newly-earned achievements
+     */
+    @Transactional
+    public LessonCompleteResponse completeLesson(@Nonnull UUID userId,
+                                                 @Nonnull String lessonSlug,
+                                                 @Nonnull String productCode,
+                                                 @Nonnull String topicCode,
+                                                 int timeSpentSeconds) {
+        Optional<LessonProgress> existing = lessonProgressRepository
+                .findByKeycloakUserIdAndProductCodeAndLessonSlug(userId, productCode, lessonSlug);
+
+        if (existing.isPresent() && existing.get().isCompleted()) {
+            LessonProgress row = existing.get();
+            XpResult current = xpService.getXp(userId, productCode);
+            LOG.debug("Lesson already completed — returning idempotent response: user={}, slug={}",
+                    userId, lessonSlug);
+            return new LessonCompleteResponse(
+                    lessonSlug,
+                    true,
+                    row.getCompletedAt(),
+                    new XpUpdateDto(0, current.totalXp(), current.currentLevel(),
+                            current.xpForNextLevel(), false),
+                    List.of());
+        }
+
+        int safeTimeSpent = Math.max(0, timeSpentSeconds);
+        Instant now = Instant.now();
+
+        LessonProgress row = existing.orElseGet(() -> {
+            LessonProgress created = new LessonProgress(userId, productCode, topicCode, lessonSlug);
+            created.setTenantId(TenantContext.get());
+            created.setStartedAt(now.minusSeconds(safeTimeSpent));
+            return created;
+        });
+        row.setCompleted(true);
+        row.setCompletedAt(now);
+        row.setTimeSpentSeconds(row.getTimeSpentSeconds() + safeTimeSpent);
+        lessonProgressRepository.save(row);
+
+        List<EarnedAchievementDto> newAchievements = achievementService
+                .checkAchievements(userId, productCode);
+        int achievementXp = newAchievements.stream().mapToInt(EarnedAchievementDto::xpReward).sum();
+        int totalGrant = XpService.XP_LESSON_COMPLETE + achievementXp;
+        XpResult xpResult = xpService.grantXp(userId, productCode, totalGrant);
+
+        publishLessonCompletedEvent(TenantContext.get(), userId, productCode, topicCode,
+                lessonSlug, safeTimeSpent);
+
+        LOG.info("Lesson completed: user={}, product={}, topic={}, slug={}, timeSpentSec={}, xp={}",
+                userId, productCode, topicCode, lessonSlug, safeTimeSpent, totalGrant);
+
+        return new LessonCompleteResponse(
+                lessonSlug,
+                true,
+                row.getCompletedAt(),
+                new XpUpdateDto(totalGrant, xpResult.totalXp(), xpResult.currentLevel(),
+                        xpResult.xpForNextLevel(), xpResult.leveledUp()),
+                newAchievements);
+    }
+
+    /**
+     * Marks a lesson as not-completed. Preserves time spent, started_at, and completed_at.
+     * Does NOT refund XP, does NOT remove earned achievements, and does NOT publish an event.
+     *
+     * @param userId      the user's Keycloak ID
+     * @param lessonSlug  the lesson slug
+     * @param productCode the product code
+     */
+    @Transactional
+    public void uncompleteLesson(@Nonnull UUID userId,
+                                 @Nonnull String lessonSlug,
+                                 @Nonnull String productCode) {
+        lessonProgressRepository
+                .findByKeycloakUserIdAndProductCodeAndLessonSlug(userId, productCode, lessonSlug)
+                .ifPresent(row -> {
+                    row.setCompleted(false);
+                    lessonProgressRepository.save(row);
+                    LOG.info("Lesson uncompleted: user={}, product={}, slug={}",
+                            userId, productCode, lessonSlug);
+                });
+    }
+
+    /**
+     * Returns the progress for every lesson the user has interacted with in a topic.
+     * Lessons not yet touched are absent from the response (the UI defaults them to
+     * {@code isCompleted=false}).
+     *
+     * @param userId      the user's Keycloak ID
+     * @param productCode the product code
+     * @param topicCode   the topic code
+     * @return list of progress records for the topic
+     */
+    @Transactional(readOnly = true)
+    public List<LessonProgressDto> getProgressForTopic(@Nonnull UUID userId,
+                                                       @Nonnull String productCode,
+                                                       @Nonnull String topicCode) {
+        return lessonProgressRepository
+                .findByKeycloakUserIdAndProductCodeAndTopicCode(userId, productCode, topicCode)
+                .stream()
+                .map(row -> new LessonProgressDto(
+                        row.getLessonSlug(),
+                        row.isCompleted(),
+                        row.getCompletedAt(),
+                        row.getTimeSpentSeconds()))
+                .toList();
+    }
+
+    private void publishLessonCompletedEvent(UUID tenantId, UUID userId,
+                                             String productCode, String topicCode,
+                                             String lessonSlug, int timeSpentSeconds) {
+        try {
+            LessonCompletedEvent event = LessonCompletedEvent.create(
+                    tenantId, userId, productCode, topicCode, lessonSlug, timeSpentSeconds);
+            OutboxEvent outbox = new OutboxEvent();
+            outbox.setTenantId(tenantId);
+            outbox.setEventType(event.eventType());
+            outbox.setTopic(KafkaTopic.CONTENT_EVENTS);
+            outbox.setPayload(objectMapper.writeValueAsString(event));
+            outbox.setStatus(OutboxStatus.PENDING);
+            outbox.setPartitionKey(userId.toString());
+            outboxEventRepository.save(outbox);
+        } catch (JsonProcessingException e) {
+            LOG.error("Failed to serialize LessonCompletedEvent for user={}, slug={}",
+                    userId, lessonSlug, e);
+        }
+    }
+}

--- a/src/main/java/com/passtheo/content/service/LessonProgressService.java
+++ b/src/main/java/com/passtheo/content/service/LessonProgressService.java
@@ -8,8 +8,12 @@ import com.passtheo.content.dto.response.EarnedAchievementDto;
 import com.passtheo.content.dto.response.LessonCompleteResponse;
 import com.passtheo.content.dto.response.LessonProgressDto;
 import com.passtheo.content.dto.response.XpUpdateDto;
+import com.passtheo.content.integration.strapi.StrapiContentCache;
+import com.passtheo.content.integration.strapi.dto.StrapiLessonDto;
 import com.passtheo.content.repository.LessonProgressRepository;
 import com.passtheo.shared.core.context.TenantContext;
+import com.passtheo.shared.core.exception.AppException;
+import com.passtheo.shared.core.exception.ErrorCode;
 import com.passtheo.shared.events.config.KafkaTopic;
 import com.passtheo.shared.events.content.LessonCompletedEvent;
 import com.passtheo.shared.outbox.entity.OutboxEvent;
@@ -18,6 +22,7 @@ import com.passtheo.shared.outbox.repository.OutboxEventRepository;
 import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,10 +45,17 @@ public class LessonProgressService {
 
     private static final Logger LOG = LoggerFactory.getLogger(LessonProgressService.class);
 
+    /** Canonical locale used to validate lesson slugs against Strapi. Slug is not localized. */
+    private static final String CANONICAL_LOCALE = "nl";
+
+    /** Upper bound on time-spent per complete call to prevent abuse via arbitrary backdating. */
+    private static final int MAX_TIME_SPENT_SECONDS = 4 * 60 * 60;
+
     private final LessonProgressRepository lessonProgressRepository;
     private final XpService xpService;
     private final AchievementService achievementService;
     private final OutboxEventRepository outboxEventRepository;
+    private final StrapiContentCache strapiContentCache;
     private final ObjectMapper objectMapper;
 
     /**
@@ -53,17 +65,20 @@ public class LessonProgressService {
      * @param xpService                XP service
      * @param achievementService       achievement service
      * @param outboxEventRepository    outbox event repository
+     * @param strapiContentCache       Strapi content cache (for lesson validation)
      * @param objectMapper             JSON object mapper (Spring-configured with JavaTimeModule)
      */
     public LessonProgressService(LessonProgressRepository lessonProgressRepository,
                                  XpService xpService,
                                  AchievementService achievementService,
                                  OutboxEventRepository outboxEventRepository,
+                                 StrapiContentCache strapiContentCache,
                                  ObjectMapper objectMapper) {
         this.lessonProgressRepository = lessonProgressRepository;
         this.xpService = xpService;
         this.achievementService = achievementService;
         this.outboxEventRepository = outboxEventRepository;
+        this.strapiContentCache = strapiContentCache;
         this.objectMapper = objectMapper;
     }
 
@@ -85,6 +100,8 @@ public class LessonProgressService {
                                                  @Nonnull String productCode,
                                                  @Nonnull String topicCode,
                                                  int timeSpentSeconds) {
+        validateLessonExists(topicCode, lessonSlug);
+
         Optional<LessonProgress> existing = lessonProgressRepository
                 .findByKeycloakUserIdAndProductCodeAndLessonSlug(userId, productCode, lessonSlug);
 
@@ -102,7 +119,7 @@ public class LessonProgressService {
                     List.of());
         }
 
-        int safeTimeSpent = Math.max(0, timeSpentSeconds);
+        int safeTimeSpent = Math.min(MAX_TIME_SPENT_SECONDS, Math.max(0, timeSpentSeconds));
         Instant now = Instant.now();
 
         LessonProgress row = existing.orElseGet(() -> {
@@ -182,6 +199,14 @@ public class LessonProgressService {
                         row.getCompletedAt(),
                         row.getTimeSpentSeconds()))
                 .toList();
+    }
+
+    private void validateLessonExists(String topicCode, String lessonSlug) {
+        List<StrapiLessonDto> lessons = strapiContentCache.getLessons(topicCode, CANONICAL_LOCALE);
+        if (lessons == null || lessons.stream().noneMatch(l -> lessonSlug.equals(l.slug()))) {
+            throw new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR,
+                    "Lesson not found: topicCode=" + topicCode + ", lessonSlug=" + lessonSlug);
+        }
     }
 
     private void publishLessonCompletedEvent(UUID tenantId, UUID userId,

--- a/src/main/java/com/passtheo/content/service/XpService.java
+++ b/src/main/java/com/passtheo/content/service/XpService.java
@@ -46,6 +46,9 @@ public class XpService {
     /** Additional bonus XP for a perfect exam score. */
     public static final int XP_PERFECT_EXAM = 500;
 
+    /** XP for completing (reading) a lesson. Granted only on first completion. */
+    public static final int XP_LESSON_COMPLETE = 20;
+
     private final UserXpRepository userXpRepository;
 
     /**

--- a/src/main/resources/db/migration/U16__create_lesson_progress_table.sql
+++ b/src/main/resources/db/migration/U16__create_lesson_progress_table.sql
@@ -1,0 +1,9 @@
+-- U16: Drop lesson_progress table (undo V16).
+
+DROP INDEX IF EXISTS idx_lesson_progress_topic_lookup;
+DROP INDEX IF EXISTS idx_lesson_progress_lookup;
+
+DROP POLICY IF EXISTS tenant_isolation_lesson_progress_insert ON lesson_progress;
+DROP POLICY IF EXISTS tenant_isolation_lesson_progress ON lesson_progress;
+
+DROP TABLE IF EXISTS lesson_progress;

--- a/src/main/resources/db/migration/V16__create_lesson_progress_table.sql
+++ b/src/main/resources/db/migration/V16__create_lesson_progress_table.sql
@@ -11,7 +11,6 @@ CREATE TABLE lesson_progress (
     started_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
     completed_at         TIMESTAMPTZ,
     time_spent_seconds   INTEGER      NOT NULL DEFAULT 0,
-    last_scroll_position INTEGER      NOT NULL DEFAULT 0,
     created_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
     updated_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
     deleted_at           TIMESTAMPTZ,
@@ -19,8 +18,7 @@ CREATE TABLE lesson_progress (
 
     CONSTRAINT uq_lesson_progress_user_slug
         UNIQUE (tenant_id, keycloak_user_id, product_code, lesson_slug),
-    CONSTRAINT ck_lesson_progress_time_positive CHECK (time_spent_seconds >= 0),
-    CONSTRAINT ck_lesson_progress_scroll_positive CHECK (last_scroll_position >= 0)
+    CONSTRAINT ck_lesson_progress_time_positive CHECK (time_spent_seconds >= 0)
 );
 
 -- Row-Level Security

--- a/src/main/resources/db/migration/V16__create_lesson_progress_table.sql
+++ b/src/main/resources/db/migration/V16__create_lesson_progress_table.sql
@@ -1,0 +1,40 @@
+-- V16: Create lesson_progress table for tracking lesson reading completion per user per lesson.
+
+CREATE TABLE lesson_progress (
+    id                   UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id            UUID         NOT NULL,
+    keycloak_user_id     UUID         NOT NULL,
+    product_code         VARCHAR(50)  NOT NULL,
+    topic_code           VARCHAR(50)  NOT NULL,
+    lesson_slug          VARCHAR(100) NOT NULL,
+    is_completed         BOOLEAN      NOT NULL DEFAULT false,
+    started_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    completed_at         TIMESTAMPTZ,
+    time_spent_seconds   INTEGER      NOT NULL DEFAULT 0,
+    last_scroll_position INTEGER      NOT NULL DEFAULT 0,
+    created_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    deleted_at           TIMESTAMPTZ,
+    version              INTEGER      NOT NULL DEFAULT 0,
+
+    CONSTRAINT uq_lesson_progress_user_slug
+        UNIQUE (tenant_id, keycloak_user_id, product_code, lesson_slug),
+    CONSTRAINT ck_lesson_progress_time_positive CHECK (time_spent_seconds >= 0),
+    CONSTRAINT ck_lesson_progress_scroll_positive CHECK (last_scroll_position >= 0)
+);
+
+-- Row-Level Security
+ALTER TABLE lesson_progress ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation_lesson_progress ON lesson_progress
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+CREATE POLICY tenant_isolation_lesson_progress_insert ON lesson_progress
+    FOR INSERT WITH CHECK (tenant_id = current_setting('app.current_tenant')::UUID);
+
+-- Performance indexes
+CREATE INDEX idx_lesson_progress_lookup
+    ON lesson_progress (tenant_id, keycloak_user_id, product_code);
+
+CREATE INDEX idx_lesson_progress_topic_lookup
+    ON lesson_progress (tenant_id, keycloak_user_id, product_code, topic_code);

--- a/src/test/java/com/passtheo/content/unit/AchievementServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/AchievementServiceTest.java
@@ -13,6 +13,7 @@ import com.passtheo.content.repository.ReadinessSnapshotRepository;
 import com.passtheo.content.repository.SessionAnswerRepository;
 import com.passtheo.content.repository.StudySessionRepository;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
+import com.passtheo.content.repository.LessonProgressRepository;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.repository.StreakRepository;
 import com.passtheo.content.service.AchievementService;
@@ -53,6 +54,7 @@ class AchievementServiceTest {
     @Mock private StudySessionRepository sessionRepository;
     @Mock private SessionAnswerRepository answerRepository;
     @Mock private ReadinessSnapshotRepository readinessSnapshotRepository;
+    @Mock private LessonProgressRepository lessonProgressRepository;
     @Mock private StrapiContentCache strapiContentCache;
     @Mock private OutboxEventRepository outboxEventRepository;
 
@@ -68,7 +70,8 @@ class AchievementServiceTest {
         achievementService = new AchievementService(
                 achievementRepository, progressRepository, streakRepository,
                 examAttemptRepository, sessionRepository, answerRepository,
-                readinessSnapshotRepository, strapiContentCache, outboxEventRepository);
+                readinessSnapshotRepository, lessonProgressRepository,
+                strapiContentCache, outboxEventRepository);
     }
 
     @AfterEach

--- a/src/test/java/com/passtheo/content/unit/LessonProgressServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/LessonProgressServiceTest.java
@@ -1,0 +1,217 @@
+package com.passtheo.content.unit;
+
+import com.passtheo.content.domain.entity.LessonProgress;
+import com.passtheo.content.domain.valueobject.XpResult;
+import com.passtheo.content.dto.response.EarnedAchievementDto;
+import com.passtheo.content.dto.response.LessonCompleteResponse;
+import com.passtheo.content.dto.response.LessonProgressDto;
+import com.passtheo.content.repository.LessonProgressRepository;
+import com.passtheo.content.service.AchievementService;
+import com.passtheo.content.service.LessonProgressService;
+import com.passtheo.content.service.XpService;
+import com.passtheo.shared.core.context.TenantContext;
+import com.passtheo.shared.outbox.entity.OutboxEvent;
+import com.passtheo.shared.outbox.repository.OutboxEventRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LessonProgressServiceTest {
+
+    private static final UUID TENANT_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID USER_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final String PRODUCT = "auto-b";
+    private static final String TOPIC = "verbodsborden";
+    private static final String SLUG = "voorrangsbord-uitleg";
+
+    @Mock private LessonProgressRepository lessonProgressRepository;
+    @Mock private XpService xpService;
+    @Mock private AchievementService achievementService;
+    @Mock private OutboxEventRepository outboxEventRepository;
+
+    private LessonProgressService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.set(TENANT_ID);
+        com.fasterxml.jackson.databind.ObjectMapper realMapper =
+                new com.fasterxml.jackson.databind.ObjectMapper()
+                        .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        service = new LessonProgressService(
+                lessonProgressRepository, xpService, achievementService, outboxEventRepository, realMapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void completeLesson_firstCompletion_grantsXpAndPublishesEvent() {
+        when(lessonProgressRepository.findByKeycloakUserIdAndProductCodeAndLessonSlug(USER_ID, PRODUCT, SLUG))
+                .thenReturn(Optional.empty());
+        when(achievementService.checkAchievements(USER_ID, PRODUCT)).thenReturn(List.of());
+        when(xpService.grantXp(eq(USER_ID), eq(PRODUCT), anyInt()))
+                .thenReturn(new XpResult(20, 20, 1, 100, false, 1));
+
+        LessonCompleteResponse response = service.completeLesson(USER_ID, SLUG, PRODUCT, TOPIC, 180);
+
+        assertThat(response.lessonSlug()).isEqualTo(SLUG);
+        assertThat(response.isCompleted()).isTrue();
+        assertThat(response.completedAt()).isNotNull();
+        assertThat(response.xpUpdate().xpEarned()).isEqualTo(20);
+        assertThat(response.xpUpdate().totalXp()).isEqualTo(20);
+        assertThat(response.newAchievements()).isEmpty();
+
+        verify(xpService).grantXp(USER_ID, PRODUCT, XpService.XP_LESSON_COMPLETE);
+
+        ArgumentCaptor<LessonProgress> savedRow = ArgumentCaptor.forClass(LessonProgress.class);
+        verify(lessonProgressRepository).save(savedRow.capture());
+        assertThat(savedRow.getValue().isCompleted()).isTrue();
+        assertThat(savedRow.getValue().getTimeSpentSeconds()).isEqualTo(180);
+
+        ArgumentCaptor<OutboxEvent> outbox = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxEventRepository).save(outbox.capture());
+        assertThat(outbox.getValue().getEventType()).isEqualTo("LessonCompleted");
+        assertThat(outbox.getValue().getPartitionKey()).isEqualTo(USER_ID.toString());
+    }
+
+    @Test
+    void completeLesson_firstCompletion_addsAchievementXpToGrant() {
+        when(lessonProgressRepository.findByKeycloakUserIdAndProductCodeAndLessonSlug(USER_ID, PRODUCT, SLUG))
+                .thenReturn(Optional.empty());
+        when(achievementService.checkAchievements(USER_ID, PRODUCT)).thenReturn(List.of(
+                new EarnedAchievementDto("first_lesson", "First lesson", "icon", 10)));
+        when(xpService.grantXp(eq(USER_ID), eq(PRODUCT), anyInt()))
+                .thenReturn(new XpResult(30, 30, 1, 100, false, 1));
+
+        LessonCompleteResponse response = service.completeLesson(USER_ID, SLUG, PRODUCT, TOPIC, 120);
+
+        // XP_LESSON_COMPLETE (20) + achievement xpReward (10) = 30
+        verify(xpService).grantXp(USER_ID, PRODUCT, XpService.XP_LESSON_COMPLETE + 10);
+        assertThat(response.xpUpdate().xpEarned()).isEqualTo(30);
+        assertThat(response.newAchievements()).hasSize(1);
+        assertThat(response.newAchievements().get(0).code()).isEqualTo("first_lesson");
+    }
+
+    @Test
+    void completeLesson_alreadyCompleted_isIdempotentWithZeroXp() {
+        LessonProgress existing = new LessonProgress(USER_ID, PRODUCT, TOPIC, SLUG);
+        existing.setCompleted(true);
+        existing.setCompletedAt(Instant.parse("2026-04-01T10:00:00Z"));
+        existing.setTimeSpentSeconds(300);
+
+        when(lessonProgressRepository.findByKeycloakUserIdAndProductCodeAndLessonSlug(USER_ID, PRODUCT, SLUG))
+                .thenReturn(Optional.of(existing));
+        when(xpService.getXp(USER_ID, PRODUCT))
+                .thenReturn(new XpResult(0, 500, 3, 600, false, 3));
+
+        LessonCompleteResponse response = service.completeLesson(USER_ID, SLUG, PRODUCT, TOPIC, 999);
+
+        assertThat(response.isCompleted()).isTrue();
+        assertThat(response.xpUpdate().xpEarned()).isZero();
+        assertThat(response.xpUpdate().totalXp()).isEqualTo(500);
+        assertThat(response.newAchievements()).isEmpty();
+        assertThat(response.completedAt()).isEqualTo(Instant.parse("2026-04-01T10:00:00Z"));
+
+        verify(xpService, never()).grantXp(any(), any(), anyInt());
+        verifyNoInteractions(achievementService, outboxEventRepository);
+        verify(lessonProgressRepository, never()).save(any());
+    }
+
+    @Test
+    void completeLesson_existingIncompleteRow_isMarkedComplete() {
+        LessonProgress existing = new LessonProgress(USER_ID, PRODUCT, TOPIC, SLUG);
+        existing.setTimeSpentSeconds(60);
+
+        when(lessonProgressRepository.findByKeycloakUserIdAndProductCodeAndLessonSlug(USER_ID, PRODUCT, SLUG))
+                .thenReturn(Optional.of(existing));
+        when(achievementService.checkAchievements(USER_ID, PRODUCT)).thenReturn(List.of());
+        when(xpService.grantXp(eq(USER_ID), eq(PRODUCT), anyInt()))
+                .thenReturn(new XpResult(20, 80, 1, 100, false, 1));
+
+        service.completeLesson(USER_ID, SLUG, PRODUCT, TOPIC, 45);
+
+        ArgumentCaptor<LessonProgress> saved = ArgumentCaptor.forClass(LessonProgress.class);
+        verify(lessonProgressRepository).save(saved.capture());
+        assertThat(saved.getValue().isCompleted()).isTrue();
+        // Existing 60 + new 45 = 105
+        assertThat(saved.getValue().getTimeSpentSeconds()).isEqualTo(105);
+    }
+
+    @Test
+    void uncompleteLesson_clearsCompletionFlagWithoutRefund() {
+        LessonProgress existing = new LessonProgress(USER_ID, PRODUCT, TOPIC, SLUG);
+        existing.setCompleted(true);
+        existing.setCompletedAt(Instant.now());
+        existing.setTimeSpentSeconds(240);
+
+        when(lessonProgressRepository.findByKeycloakUserIdAndProductCodeAndLessonSlug(USER_ID, PRODUCT, SLUG))
+                .thenReturn(Optional.of(existing));
+
+        service.uncompleteLesson(USER_ID, SLUG, PRODUCT);
+
+        ArgumentCaptor<LessonProgress> saved = ArgumentCaptor.forClass(LessonProgress.class);
+        verify(lessonProgressRepository).save(saved.capture());
+        assertThat(saved.getValue().isCompleted()).isFalse();
+        // time_spent_seconds preserved
+        assertThat(saved.getValue().getTimeSpentSeconds()).isEqualTo(240);
+        // completed_at preserved (not reset to null)
+        assertThat(saved.getValue().getCompletedAt()).isNotNull();
+
+        verifyNoInteractions(xpService, achievementService, outboxEventRepository);
+    }
+
+    @Test
+    void uncompleteLesson_missingRow_isNoop() {
+        when(lessonProgressRepository.findByKeycloakUserIdAndProductCodeAndLessonSlug(USER_ID, PRODUCT, SLUG))
+                .thenReturn(Optional.empty());
+
+        service.uncompleteLesson(USER_ID, SLUG, PRODUCT);
+
+        verify(lessonProgressRepository, never()).save(any());
+        verifyNoInteractions(xpService, achievementService, outboxEventRepository);
+    }
+
+    @Test
+    void getProgressForTopic_returnsAllLessonsInTopic() {
+        LessonProgress a = new LessonProgress(USER_ID, PRODUCT, TOPIC, "lesson-a");
+        a.setCompleted(true);
+        a.setCompletedAt(Instant.parse("2026-03-01T09:00:00Z"));
+        a.setTimeSpentSeconds(120);
+        LessonProgress b = new LessonProgress(USER_ID, PRODUCT, TOPIC, "lesson-b");
+        b.setTimeSpentSeconds(60);
+
+        when(lessonProgressRepository
+                .findByKeycloakUserIdAndProductCodeAndTopicCode(USER_ID, PRODUCT, TOPIC))
+                .thenReturn(List.of(a, b));
+
+        List<LessonProgressDto> result = service.getProgressForTopic(USER_ID, PRODUCT, TOPIC);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).lessonSlug()).isEqualTo("lesson-a");
+        assertThat(result.get(0).isCompleted()).isTrue();
+        assertThat(result.get(0).timeSpentSeconds()).isEqualTo(120);
+        assertThat(result.get(1).lessonSlug()).isEqualTo("lesson-b");
+        assertThat(result.get(1).isCompleted()).isFalse();
+    }
+}

--- a/src/test/java/com/passtheo/content/unit/LessonProgressServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/LessonProgressServiceTest.java
@@ -5,11 +5,14 @@ import com.passtheo.content.domain.valueobject.XpResult;
 import com.passtheo.content.dto.response.EarnedAchievementDto;
 import com.passtheo.content.dto.response.LessonCompleteResponse;
 import com.passtheo.content.dto.response.LessonProgressDto;
+import com.passtheo.content.integration.strapi.StrapiContentCache;
+import com.passtheo.content.integration.strapi.dto.StrapiLessonDto;
 import com.passtheo.content.repository.LessonProgressRepository;
 import com.passtheo.content.service.AchievementService;
 import com.passtheo.content.service.LessonProgressService;
 import com.passtheo.content.service.XpService;
 import com.passtheo.shared.core.context.TenantContext;
+import com.passtheo.shared.core.exception.AppException;
 import com.passtheo.shared.outbox.entity.OutboxEvent;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -26,9 +29,11 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -47,6 +52,7 @@ class LessonProgressServiceTest {
     @Mock private XpService xpService;
     @Mock private AchievementService achievementService;
     @Mock private OutboxEventRepository outboxEventRepository;
+    @Mock private StrapiContentCache strapiContentCache;
 
     private LessonProgressService service;
 
@@ -57,12 +63,33 @@ class LessonProgressServiceTest {
                 new com.fasterxml.jackson.databind.ObjectMapper()
                         .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
         service = new LessonProgressService(
-                lessonProgressRepository, xpService, achievementService, outboxEventRepository, realMapper);
+                lessonProgressRepository, xpService, achievementService, outboxEventRepository,
+                strapiContentCache, realMapper);
+
+        // Default: every lesson slug is valid. Tests that need to assert invalid
+        // slugs override this stub. Lenient because some tests (e.g., getProgress
+        // queries) don't exercise the validation path.
+        lenient().when(strapiContentCache.getLessons(any(), any()))
+                .thenReturn(List.of(
+                        new StrapiLessonDto(1, "doc-1", "Voorrangsbord uitleg", SLUG,
+                                List.of(), null, null, null, 0, true, false, 0)));
     }
 
     @AfterEach
     void tearDown() {
         TenantContext.clear();
+    }
+
+    @Test
+    void completeLesson_unknownSlug_throws404() {
+        when(strapiContentCache.getLessons(TOPIC, "nl")).thenReturn(List.of());
+
+        assertThatThrownBy(() ->
+                service.completeLesson(USER_ID, "fake-slug", PRODUCT, TOPIC, 60))
+                .isInstanceOf(AppException.class)
+                .hasMessageContaining("Lesson not found");
+
+        verifyNoInteractions(lessonProgressRepository, xpService, achievementService, outboxEventRepository);
     }
 
     @Test

--- a/src/test/resources/karate/lesson-completion.feature
+++ b/src/test/resources/karate/lesson-completion.feature
@@ -98,3 +98,33 @@ Feature: Lesson Completion Tracking
     When method GET
     Then status 200
     And match response.data == '#[0]'
+
+  # ─── TENANT / USER ISOLATION (RLS) ───
+
+  Scenario: User B cannot see user A's lesson progress on the same slug
+    # User A completes a lesson
+    * def lessonSlug = 'verbodsborden-basis'
+    * def paidHeaders = { 'X-Tenant-ID': '#(tenantId)', 'X-Keycloak-User-ID': '33333333-3333-3333-3333-333333333333', 'Authorization': '#("Bearer " + paidToken)' }
+    Given path '/api/content/lessons/' + lessonSlug + '/complete'
+    And headers paidHeaders
+    And request { productCode: 'auto-b', topicCode: 'verbodsborden', timeSpentSeconds: 60 }
+    When method POST
+    Then status 200
+    # User B (fresh) fetches progress for the same topic — should NOT see user A's row
+    Given path '/api/content/lessons/progress'
+    And headers freshHeaders
+    And param productCode = 'auto-b'
+    And param topicCode = 'verbodsborden'
+    When method GET
+    Then status 200
+    # User B's progress list must not contain the slug that user A completed
+    And assert response.data.filter(p => p.lessonSlug == 'verbodsborden-basis' && p.isCompleted == true).length == 0
+
+  # ─── NEGATIVE ───
+
+  Scenario: Complete with unknown lesson slug returns 404
+    Given path '/api/content/lessons/totally-fake-slug-xyz/complete'
+    And headers freshHeaders
+    And request { productCode: 'auto-b', topicCode: 'verbodsborden', timeSpentSeconds: 30 }
+    When method POST
+    Then status 404

--- a/src/test/resources/karate/lesson-completion.feature
+++ b/src/test/resources/karate/lesson-completion.feature
@@ -1,0 +1,100 @@
+Feature: Lesson Completion Tracking
+  As a PassTheo student
+  I want my lesson reading to be tracked
+  So that I can earn XP and achievements for studying
+
+  Background:
+    * url baseUrl
+    * def tenantId = '11111111-1111-1111-1111-111111111111'
+    * def freshUserId = '77777777-7777-7777-7777-777777777777'
+    * def freshHeaders = { 'X-Tenant-ID': '#(tenantId)', 'X-Keycloak-User-ID': '#(freshUserId)', 'Authorization': '#("Bearer " + freshToken)' }
+
+  # ─── FIRST COMPLETION ───
+
+  Scenario: First lesson completion grants XP and triggers first_lesson achievement
+    # Pick any known lesson slug from the seeded Strapi content.
+    * def lessonSlug = 'verbodsborden-basis'
+    Given path '/api/content/lessons/' + lessonSlug + '/complete'
+    And headers freshHeaders
+    And request { productCode: 'auto-b', topicCode: 'verbodsborden', timeSpentSeconds: 180 }
+    When method POST
+    Then status 200
+    And match response.success == true
+    And match response.data.lessonSlug == lessonSlug
+    And match response.data.isCompleted == true
+    And match response.data.completedAt == '#string'
+    And match response.data.xpUpdate.xpEarned == '#number'
+    And assert response.data.xpUpdate.xpEarned >= 20
+    And match response.data.xpUpdate.totalXp == '#number'
+    And match response.data.xpUpdate.currentLevel == '#number'
+    And match response.data.xpUpdate.leveledUp == '#boolean'
+    And match response.data.newAchievements == '#array'
+    # first_lesson achievement should be granted on first-ever completion
+    And match response.data.newAchievements[*].code contains 'first_lesson'
+
+  # ─── IDEMPOTENCY ───
+
+  Scenario: Re-completing a lesson returns success with zero XP and no new achievements
+    * def lessonSlug = 'verbodsborden-basis'
+    # Complete once — may trigger achievements
+    Given path '/api/content/lessons/' + lessonSlug + '/complete'
+    And headers freshHeaders
+    And request { productCode: 'auto-b', topicCode: 'verbodsborden', timeSpentSeconds: 60 }
+    When method POST
+    Then status 200
+    # Complete again — should be idempotent
+    Given path '/api/content/lessons/' + lessonSlug + '/complete'
+    And headers freshHeaders
+    And request { productCode: 'auto-b', topicCode: 'verbodsborden', timeSpentSeconds: 30 }
+    When method POST
+    Then status 200
+    And match response.data.isCompleted == true
+    And match response.data.xpUpdate.xpEarned == 0
+    And match response.data.newAchievements == '#[0]'
+
+  # ─── UNCOMPLETE ───
+
+  Scenario: Uncomplete reverses the completion flag without refunding XP
+    * def lessonSlug = 'verbodsborden-basis'
+    # Complete first
+    Given path '/api/content/lessons/' + lessonSlug + '/complete'
+    And headers freshHeaders
+    And request { productCode: 'auto-b', topicCode: 'verbodsborden', timeSpentSeconds: 120 }
+    When method POST
+    Then status 200
+    # Uncomplete
+    Given path '/api/content/lessons/' + lessonSlug + '/complete'
+    And headers freshHeaders
+    And param productCode = 'auto-b'
+    When method DELETE
+    Then status 200
+    And match response.success == true
+    # Fetch progress and confirm the row still exists but isCompleted=false
+    Given path '/api/content/lessons/progress'
+    And headers freshHeaders
+    And param productCode = 'auto-b'
+    And param topicCode = 'verbodsborden'
+    When method GET
+    Then status 200
+    And match response.data[?(@.lessonSlug=='verbodsborden-basis')].isCompleted[0] == false
+
+  # ─── PROGRESS LIST ───
+
+  Scenario: Progress listing returns only lessons the user has interacted with
+    Given path '/api/content/lessons/progress'
+    And headers freshHeaders
+    And param productCode = 'auto-b'
+    And param topicCode = 'verbodsborden'
+    When method GET
+    Then status 200
+    And match response.data == '#array'
+    And match each response.data contains { lessonSlug: '#string', isCompleted: '#boolean', timeSpentSeconds: '#number' }
+
+  Scenario: Progress listing is empty for a topic the user has never touched
+    Given path '/api/content/lessons/progress'
+    And headers freshHeaders
+    And param productCode = 'auto-b'
+    And param topicCode = 'gevaarherkenning-basis'
+    When method GET
+    Then status 200
+    And match response.data == '#[0]'


### PR DESCRIPTION
Closes #79

## Summary

- Lesson reading is no longer stateless. A new `lesson_progress` table tracks per-user completion; first-time completion grants +20 XP and checks 3 new achievement types (`LESSONS_COMPLETED`, `LESSONS_COMPLETED_ALL`, `TOPIC_LESSONS_COMPLETED`).
- Idempotent — re-completing returns `xpEarned=0`, no duplicate Kafka event, no re-triggered achievements.
- Uncomplete preserves `time_spent_seconds`, `started_at`, and `completed_at` for analytics; no XP refund.
- Publishes `LessonCompletedEvent` via the outbox pattern (requires passtheo-shared-lib#23 merged or published to Maven local).

## Endpoints

- `POST /api/content/lessons/{lessonSlug}/complete` — body `{ productCode, topicCode, timeSpentSeconds }`
- `DELETE /api/content/lessons/{lessonSlug}/complete?productCode=...`
- `GET /api/content/lessons/progress?productCode=...&topicCode=...`

## Changes

- **Backend:** `LessonController`, `LessonProgressService`, `LessonProgress` entity, `LessonProgressRepository`, three new DTOs.
- **Migration:** `V16__create_lesson_progress_table.sql` (+ `U16` undo) with RLS and composite indexes.
- **Reuse:** `XpService.XP_LESSON_COMPLETE = 20`; `AchievementService` adds 3 cases to `getCurrentValue()`; `StrapiContentCache.getLessonCountForProduct()` uses Strapi pagination metadata.
- **Tests:** `LessonProgressServiceTest` unit tests (7 scenarios); `lesson-completion.feature` Karate acceptance tests.

## Test plan

- [x] `./gradlew test --tests LessonProgressServiceTest` — 7/7 passing
- [x] `./gradlew test` — full suite passes (205 tests)
- [ ] `./gradlew acceptanceTest` — runs after Strapi seed is updated (passtheo/strapi-app-content PR follows)
- [ ] Flutter wiring (passtheo-ui PR follows)

## Dependencies

- Requires `passtheo/passtheo-shared-lib#23` merged first (adds `LessonCompletedEvent`).

## Notes on checkstyle

My new files introduce zero checkstyle violations. The 1019 pre-existing violations in develop are unrelated to this PR.