### PR TITLE
fix(content): prevent lesson XP farming via mark-unread cycle

### DIFF
--- a/src/main/java/com/passtheo/content/service/LessonProgressService.java
+++ b/src/main/java/com/passtheo/content/service/LessonProgressService.java
@@ -83,9 +83,11 @@ public class LessonProgressService {
     }
 
     /**
-     * Marks a lesson complete for a user. First-time completion grants XP, checks
-     * achievements, and publishes a {@link LessonCompletedEvent}. Subsequent completions
-     * are idempotent and return {@code xpEarned=0} with no event.
+     * Marks a lesson complete for a user. XP, achievement checks, and the Kafka event
+     * fire only on the first-ever completion of this lesson (tracked via
+     * {@code completed_at}). Re-completing a lesson that has been marked unread and
+     * marked read again returns {@code xpEarned=0} with no new event — this prevents
+     * XP farming via mark-unread / mark-read cycling.
      *
      * @param userId           the user's Keycloak ID
      * @param lessonSlug       the lesson slug
@@ -105,10 +107,18 @@ public class LessonProgressService {
         Optional<LessonProgress> existing = lessonProgressRepository
                 .findByKeycloakUserIdAndProductCodeAndLessonSlug(userId, productCode, lessonSlug);
 
-        if (existing.isPresent() && existing.get().isCompleted()) {
+        // Sticky guard: completed_at is set once on first completion and never cleared
+        // by uncompleteLesson. Using it (instead of is_completed) prevents XP farming
+        // when a user cycles mark-unread / mark-read.
+        if (existing.isPresent() && existing.get().getCompletedAt() != null) {
             LessonProgress row = existing.get();
+            // User may have toggled to "unread" and back — flip is_completed=true if needed.
+            if (!row.isCompleted()) {
+                row.setCompleted(true);
+                lessonProgressRepository.save(row);
+            }
             XpResult current = xpService.getXp(userId, productCode);
-            LOG.debug("Lesson already completed — returning idempotent response: user={}, slug={}",
+            LOG.debug("Lesson already rewarded — returning idempotent response: user={}, slug={}",
                     userId, lessonSlug);
             return new LessonCompleteResponse(
                     lessonSlug,

--- a/src/test/java/com/passtheo/content/unit/LessonProgressServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/LessonProgressServiceTest.java
@@ -186,6 +186,43 @@ class LessonProgressServiceTest {
     }
 
     @Test
+    void completeLesson_afterUncomplete_doesNotGrantXpAgain() {
+        // Row where completed_at is already set (user previously completed this lesson)
+        // but is_completed is false (user has since marked it unread).
+        LessonProgress previouslyCompleted = new LessonProgress(USER_ID, PRODUCT, TOPIC, SLUG);
+        previouslyCompleted.setCompleted(false);
+        previouslyCompleted.setCompletedAt(Instant.parse("2026-04-01T10:00:00Z"));
+        previouslyCompleted.setTimeSpentSeconds(300);
+
+        when(lessonProgressRepository.findByKeycloakUserIdAndProductCodeAndLessonSlug(USER_ID, PRODUCT, SLUG))
+                .thenReturn(Optional.of(previouslyCompleted));
+        when(xpService.getXp(USER_ID, PRODUCT))
+                .thenReturn(new XpResult(0, 500, 3, 600, false, 3));
+
+        LessonCompleteResponse response = service.completeLesson(USER_ID, SLUG, PRODUCT, TOPIC, 999);
+
+        // No XP granted — completed_at was already set.
+        assertThat(response.xpUpdate().xpEarned()).isZero();
+        assertThat(response.xpUpdate().totalXp()).isEqualTo(500);
+        assertThat(response.newAchievements()).isEmpty();
+        assertThat(response.isCompleted()).isTrue();
+        // Original completedAt timestamp is preserved — this is the true first-completion.
+        assertThat(response.completedAt()).isEqualTo(Instant.parse("2026-04-01T10:00:00Z"));
+
+        // is_completed flipped back to true and row saved.
+        ArgumentCaptor<LessonProgress> saved = ArgumentCaptor.forClass(LessonProgress.class);
+        verify(lessonProgressRepository).save(saved.capture());
+        assertThat(saved.getValue().isCompleted()).isTrue();
+        assertThat(saved.getValue().getCompletedAt()).isEqualTo(Instant.parse("2026-04-01T10:00:00Z"));
+        // time_spent_seconds frozen at 300 (no further accumulation after rewards locked).
+        assertThat(saved.getValue().getTimeSpentSeconds()).isEqualTo(300);
+
+        // Zero interactions with reward subsystems.
+        verify(xpService, never()).grantXp(any(), any(), anyInt());
+        verifyNoInteractions(achievementService, outboxEventRepository);
+    }
+
+    @Test
     void uncompleteLesson_clearsCompletionFlagWithoutRefund() {
         LessonProgress existing = new LessonProgress(USER_ID, PRODUCT, TOPIC, SLUG);
         existing.setCompleted(true);


### PR DESCRIPTION
Closes #81

## Summary

Closes an XP-farming exploit: looping `POST /complete` → `DELETE /complete` → `POST /complete` previously granted +20 XP on every second POST indefinitely. The guard now uses `completed_at` (sticky, never cleared by uncomplete) instead of `is_completed`.

## Changes

- `LessonProgressService.completeLesson` — idempotency guard changed from `existing.isCompleted()` to `existing.getCompletedAt() != null`. Re-complete path flips `is_completed=true` for UI reactivity but skips XP / achievement / outbox.
- `LessonProgressServiceTest.completeLesson_afterUncomplete_doesNotGrantXpAgain` — new scenario verifying the regression.

## Test plan

- [x] `./gradlew test --tests "LessonProgressServiceTest"` — 9/9
- [x] `./gradlew test` — 207/207
- [ ] Manual against local stack: POST → DELETE → POST returns `xpEarned=0` on the second POST