### PR TITLE
feat(content): UserProductChanged handler, study plan preview, products catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,7 +111,7 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform {
-        excludeTags("acceptance")
+        excludeTags("acceptance", "contract")
     }
     finalizedBy(tasks.jacocoTestReport)
 }
@@ -145,6 +145,10 @@ val karateContractTest by tasks.registering(Test::class) {
     }
     systemProperty("spring.profiles.active", "acceptance")
     dependsOn(copyContracts)
+    // Both runners boot against the same content_service schema and call
+    // flyway.clean() in @BeforeAll — serialize them so a parallel Gradle
+    // invocation can't race on the schema.
+    mustRunAfter(acceptanceTest)
 }
 
 tasks.withType<JavaCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,6 +135,18 @@ val acceptanceTest by tasks.registering(Test::class) {
     dependsOn(copyContracts)
 }
 
+val karateContractTest by tasks.registering(Test::class) {
+    description = "Runs Karate contract verification tests — verifies this provider satisfies all consumer contracts"
+    group = "verification"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    useJUnitPlatform {
+        includeTags("contract")
+    }
+    systemProperty("spring.profiles.active", "acceptance")
+    dependsOn(copyContracts)
+}
+
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
     options.compilerArgs.add("-parameters")

--- a/src/main/java/com/passtheo/content/controller/InternalProductController.java
+++ b/src/main/java/com/passtheo/content/controller/InternalProductController.java
@@ -1,0 +1,76 @@
+package com.passtheo.content.controller;
+
+import com.passtheo.content.dto.response.ProductCatalogEntryDto;
+import com.passtheo.content.integration.strapi.StrapiContentCache;
+import com.passtheo.content.integration.strapi.dto.StrapiCountryDto;
+import com.passtheo.content.integration.strapi.dto.StrapiProductDto;
+import com.passtheo.content.integration.strapi.dto.StrapiProductTypeDto;
+import com.passtheo.shared.core.dto.ApiResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Internal service-to-service endpoint that exposes the product catalog in a
+ * flat form so services that need to validate a productCode (e.g. user-service)
+ * can do so without talking to Strapi directly.
+ *
+ * <p>Sourced from {@link StrapiContentCache}, so results honour the Redis TTL
+ * and circuit-breaker protections already in place for Strapi calls.
+ */
+@RestController
+@RequestMapping("/internal/products")
+public class InternalProductController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InternalProductController.class);
+
+    private final StrapiContentCache strapiContentCache;
+
+    /**
+     * Constructs the internal product controller.
+     *
+     * @param strapiContentCache the Strapi content cache
+     */
+    public InternalProductController(StrapiContentCache strapiContentCache) {
+        this.strapiContentCache = strapiContentCache;
+    }
+
+    /**
+     * Returns every product across every country + product-type in a single flat list.
+     *
+     * @param locale the content locale (default "nl")
+     * @return 200 OK with a list of {@link ProductCatalogEntryDto}
+     */
+    @GetMapping("/catalog")
+    public ResponseEntity<ApiResponse<List<ProductCatalogEntryDto>>> getCatalog(
+            @RequestParam(defaultValue = "nl") String locale) {
+        List<ProductCatalogEntryDto> catalog = new ArrayList<>();
+        List<StrapiCountryDto> countries = strapiContentCache.getCountries(locale);
+        for (StrapiCountryDto country : countries) {
+            List<StrapiProductTypeDto> productTypes =
+                    strapiContentCache.getProductTypes(country.code(), locale);
+            for (StrapiProductTypeDto productType : productTypes) {
+                List<StrapiProductDto> products =
+                        strapiContentCache.getProducts(productType.code(), locale);
+                for (StrapiProductDto product : products) {
+                    catalog.add(new ProductCatalogEntryDto(
+                            product.code(),
+                            product.name(),
+                            productType.code(),
+                            country.code(),
+                            product.isActive()));
+                }
+            }
+        }
+        LOG.debug("Product catalog assembled: {} entries ({} countries)", catalog.size(), countries.size());
+        return ResponseEntity.ok(ApiResponse.success(catalog, MDC.get("traceId")));
+    }
+}

--- a/src/main/java/com/passtheo/content/controller/StudyPlanController.java
+++ b/src/main/java/com/passtheo/content/controller/StudyPlanController.java
@@ -90,4 +90,26 @@ public class StudyPlanController {
         StudyPlanDayDto today = studyPlanService.getTodaysTasks(userId, productCode);
         return ResponseEntity.ok(ApiResponse.success(today, MDC.get("traceId")));
     }
+
+    /**
+     * Previews what a new study plan would look like for the given inputs,
+     * without persisting anything or touching the user's existing active plan.
+     * Returns a {@link StudyPlanDto} with {@code planId=null} and
+     * {@code status="PREVIEW"} so callers can distinguish preview from real.
+     *
+     * @param userId  user ID from header — used to pull the caller's mastery
+     *                count for an accurate daily-goal preview
+     * @param request the plan-generation inputs (productCode, examDate, optional dailyQuestionTarget)
+     * @param locale  content locale
+     * @return a preview of the plan
+     */
+    @PostMapping("/preview")
+    public ResponseEntity<ApiResponse<StudyPlanDto>> previewStudyPlan(
+            @RequestHeader("X-Keycloak-User-ID") UUID userId,
+            @RequestBody @Valid @Nonnull GenerateStudyPlanRequest request,
+            @RequestParam(defaultValue = "nl") String locale) {
+
+        StudyPlanDto preview = studyPlanService.previewPlan(userId, request, locale);
+        return ResponseEntity.ok(ApiResponse.success(preview, MDC.get("traceId")));
+    }
 }

--- a/src/main/java/com/passtheo/content/dto/response/ProductCatalogEntryDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/ProductCatalogEntryDto.java
@@ -1,0 +1,20 @@
+package com.passtheo.content.dto.response;
+
+/**
+ * Flat entry in the product catalog, returned by the internal
+ * {@code GET /internal/products/catalog} endpoint. Callers such as user-service
+ * use {@code code} to validate user-supplied productCode values.
+ *
+ * @param code             the product code (e.g. "auto-b")
+ * @param name             the product's display name
+ * @param productTypeCode  the parent product-type code (e.g. "cbr-auto")
+ * @param countryCode      the country the product belongs to (e.g. "NL")
+ * @param active           whether the product is currently available for new learners
+ */
+public record ProductCatalogEntryDto(
+        String code,
+        String name,
+        String productTypeCode,
+        String countryCode,
+        boolean active
+) {}

--- a/src/main/java/com/passtheo/content/kafka/consumer/UserEventConsumer.java
+++ b/src/main/java/com/passtheo/content/kafka/consumer/UserEventConsumer.java
@@ -138,8 +138,6 @@ public class UserEventConsumer {
                 ? payload.get("tenantId").asText(null) : null;
         String productCode = payload.has("productCode")
                 ? payload.get("productCode").asText(null) : null;
-        String examDateStr = payload.has("examDate") && !payload.get("examDate").isNull()
-                ? payload.get("examDate").asText(null) : null;
 
         if (keycloakUserIdStr == null || tenantIdStr == null
                 || productCode == null || productCode.isBlank()) {
@@ -149,7 +147,7 @@ public class UserEventConsumer {
 
         UUID keycloakUserId = UUID.fromString(keycloakUserIdStr);
         UUID tenantId = UUID.fromString(tenantIdStr);
-        LocalDate examDate = examDateStr != null ? LocalDate.parse(examDateStr) : null;
+        LocalDate examDate = parseLocalDateNode(payload.get("examDate"));
 
         boolean hasActivePlan = planRepository.findByKeycloakUserIdAndProductCodeAndStatus(
                 keycloakUserId, productCode, PlanStatus.ACTIVE).isPresent();
@@ -177,8 +175,6 @@ public class UserEventConsumer {
                 ? payload.get("tenantId").asText(null) : null;
         String productCode = payload.has("productCode")
                 ? payload.get("productCode").asText(null) : null;
-        String examDateStr = payload.has("examDate") && !payload.get("examDate").isNull()
-                ? payload.get("examDate").asText(null) : null;
 
         if (keycloakUserIdStr == null || tenantIdStr == null
                 || productCode == null || productCode.isBlank()) {
@@ -188,7 +184,7 @@ public class UserEventConsumer {
 
         UUID keycloakUserId = UUID.fromString(keycloakUserIdStr);
         UUID tenantId = UUID.fromString(tenantIdStr);
-        LocalDate examDate = examDateStr != null ? LocalDate.parse(examDateStr) : null;
+        LocalDate examDate = parseLocalDateNode(payload.get("examDate"));
 
         LOG.info("Regenerating study plan for exam date change: userId={}, productCode={}, examDate={}",
                 keycloakUserId, productCode, examDate);
@@ -237,9 +233,6 @@ public class UserEventConsumer {
                 ? payload.get("oldProductCode").asText(null) : null;
         String newProductCode = payload.has("newProductCode")
                 ? payload.get("newProductCode").asText(null) : null;
-        String examDateStr = payload.has("examDate") && !payload.get("examDate").isNull()
-                ? payload.get("examDate").asText(null) : null;
-
         if (keycloakUserIdStr == null || tenantIdStr == null
                 || oldProductCode == null || oldProductCode.isBlank()
                 || newProductCode == null || newProductCode.isBlank()) {
@@ -249,7 +242,7 @@ public class UserEventConsumer {
 
         UUID keycloakUserId = UUID.fromString(keycloakUserIdStr);
         UUID tenantId = UUID.fromString(tenantIdStr);
-        LocalDate examDate = examDateStr != null ? LocalDate.parse(examDateStr) : null;
+        LocalDate examDate = parseLocalDateNode(payload.get("examDate"));
 
         LOG.info("Product changed: userId={}, old={}, new={}, examDate={}",
                 keycloakUserId, oldProductCode, newProductCode, examDate);
@@ -267,6 +260,28 @@ public class UserEventConsumer {
         } finally {
             TenantContext.clear();
         }
+    }
+
+    /**
+     * Parses a LocalDate from a JSON node, tolerating both the ISO string format
+     * (e.g. {@code "2026-05-01"}) and the legacy Jackson timestamp-array format
+     * (e.g. {@code [2026, 5, 1]}) that older OutboxEventPublisher versions
+     * emitted before {@code WRITE_DATES_AS_TIMESTAMPS=false} was applied. Any
+     * pending outbox rows written under the old format must still deserialize
+     * correctly when the poller replays them.
+     *
+     * @param node the JSON node (may be null or a null node)
+     * @return the parsed LocalDate, or null if the node is absent / null / empty
+     */
+    private static LocalDate parseLocalDateNode(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isArray() && node.size() == 3) {
+            return LocalDate.of(node.get(0).asInt(), node.get(1).asInt(), node.get(2).asInt());
+        }
+        String text = node.asText(null);
+        return (text == null || text.isEmpty()) ? null : LocalDate.parse(text);
     }
 
     private void deleteAllUserData(UUID userId) {

--- a/src/main/java/com/passtheo/content/kafka/consumer/UserEventConsumer.java
+++ b/src/main/java/com/passtheo/content/kafka/consumer/UserEventConsumer.java
@@ -120,6 +120,9 @@ public class UserEventConsumer {
 
             } else if ("UserExamDateCleared".equals(eventType)) {
                 handleExamDateCleared(payload, record);
+
+            } else if ("UserProductChanged".equals(eventType)) {
+                handleProductChanged(payload, record);
             }
 
             ack.acknowledge();
@@ -220,6 +223,47 @@ public class UserEventConsumer {
         TenantContext.set(tenantId);
         try {
             studyPlanService.abandonActivePlan(keycloakUserId, productCode);
+        } finally {
+            TenantContext.clear();
+        }
+    }
+
+    private void handleProductChanged(JsonNode payload, ConsumerRecord<String, String> record) {
+        String keycloakUserIdStr = payload.has("keycloakUserId")
+                ? payload.get("keycloakUserId").asText(null) : null;
+        String tenantIdStr = payload.has("tenantId")
+                ? payload.get("tenantId").asText(null) : null;
+        String oldProductCode = payload.has("oldProductCode")
+                ? payload.get("oldProductCode").asText(null) : null;
+        String newProductCode = payload.has("newProductCode")
+                ? payload.get("newProductCode").asText(null) : null;
+        String examDateStr = payload.has("examDate") && !payload.get("examDate").isNull()
+                ? payload.get("examDate").asText(null) : null;
+
+        if (keycloakUserIdStr == null || tenantIdStr == null
+                || oldProductCode == null || oldProductCode.isBlank()
+                || newProductCode == null || newProductCode.isBlank()) {
+            LOG.warn("Ignoring incomplete UserProductChanged event: offset={}", record.offset());
+            return;
+        }
+
+        UUID keycloakUserId = UUID.fromString(keycloakUserIdStr);
+        UUID tenantId = UUID.fromString(tenantIdStr);
+        LocalDate examDate = examDateStr != null ? LocalDate.parse(examDateStr) : null;
+
+        LOG.info("Product changed: userId={}, old={}, new={}, examDate={}",
+                keycloakUserId, oldProductCode, newProductCode, examDate);
+
+        TenantContext.set(tenantId);
+        try {
+            studyPlanService.abandonActivePlan(keycloakUserId, oldProductCode);
+            if (examDate != null) {
+                studyPlanService.generatePlan(keycloakUserId,
+                        new GenerateStudyPlanRequest(newProductCode, examDate, null), DEFAULT_LOCALE);
+            } else {
+                LOG.info("No exam date on new product — plan will be generated when user sets one: "
+                        + "userId={}, newProductCode={}", keycloakUserId, newProductCode);
+            }
         } finally {
             TenantContext.clear();
         }

--- a/src/main/java/com/passtheo/content/service/StudyPlanService.java
+++ b/src/main/java/com/passtheo/content/service/StudyPlanService.java
@@ -114,6 +114,73 @@ public class StudyPlanService {
                     planRepository.saveAndFlush(existing);
                 });
 
+        ComputedPlan computed = computePlan(userId, request, locale);
+
+        StudyPlan plan = new StudyPlan();
+        plan.setTenantId(TenantContext.get());
+        plan.setKeycloakUserId(userId);
+        plan.setProductCode(request.productCode());
+        plan.setExamDate(computed.examDate());
+        plan.setTotalDays(computed.days().size());
+        plan.setStatus(PlanStatus.ACTIVE);
+        plan.setDailyQuestionTarget(computed.dailyQuestionTarget());
+        plan.setFocusDomains(serializeJson(computed.focusDomains()));
+        plan.setUpdatedAt(Instant.now());
+        plan = planRepository.save(plan);
+
+        for (StudyPlanDay day : computed.days()) {
+            day.setPlanId(plan.getId());
+        }
+        planDayRepository.saveAll(computed.days());
+
+        LOG.info("Study plan generated: id={}, user={}, product={}, days={}, focusDomains={}",
+                plan.getId(), userId, request.productCode(), computed.days().size(), computed.focusDomains());
+
+        return toPlanDto(plan, computed.days(), 1);
+    }
+
+    /**
+     * Computes what a new study plan would look like for the given inputs,
+     * <em>without</em> persisting anything or touching the user's existing
+     * active plan. Returns a {@link StudyPlanDto} shaped identically to the one
+     * {@link #generatePlan} returns, but with {@code planId=null} and
+     * {@code status="PREVIEW"} so callers can distinguish preview from real.
+     *
+     * <p>Use case: Flutter shows a confirmation dialog with the new daily goal
+     * and total days before the user commits to changing their exam date or
+     * product.
+     *
+     * @param userId  the user's Keycloak ID
+     * @param request the plan generation request
+     * @param locale  content locale
+     * @return a preview of the plan
+     */
+    @Transactional(readOnly = true)
+    public StudyPlanDto previewPlan(@Nonnull UUID userId, @Nonnull GenerateStudyPlanRequest request,
+                                    @Nonnull String locale) {
+        ComputedPlan computed = computePlan(userId, request, locale);
+
+        List<StudyPlanDayDto> dayDtos = computed.days().stream()
+                .map(d -> new StudyPlanDayDto(
+                        d.getDayNumber(), d.getPlanDate(),
+                        d.getDomainCode(), d.getDomainCode(),
+                        d.getQuestionTarget(), d.getQuestionsCompleted(),
+                        d.isIncludeExam(), d.getStatus().name(), null))
+                .toList();
+
+        return new StudyPlanDto(
+                null,
+                request.productCode(),
+                computed.examDate(),
+                computed.days().size(),
+                0,
+                computed.dailyQuestionTarget(),
+                "PREVIEW",
+                computed.focusDomains(),
+                dayDtos);
+    }
+
+    private ComputedPlan computePlan(UUID userId, GenerateStudyPlanRequest request, String locale) {
         ReadinessScore readiness = readinessService.calculate(userId, request.productCode(), locale);
 
         LocalDate startDate = LocalDate.now(ZoneOffset.UTC);
@@ -136,7 +203,6 @@ public class StudyPlanService {
             totalDays = DEFAULT_PLAN_DAYS;
         }
 
-        // Resolve dailyQuestionTarget: auto-calculate when not provided
         int resolvedDailyTarget;
         if (request.dailyQuestionTarget() != null) {
             resolvedDailyTarget = request.dailyQuestionTarget();
@@ -146,7 +212,6 @@ public class StudyPlanService {
                 long totalQuestions = strapiContentCache.getQuestionCount(request.productCode(), locale);
                 long mastered = progressRepository.countByKeycloakUserIdAndProductCodeAndMasteryLevel(
                         userId, request.productCode(), MasteryLevel.MASTERED);
-                // Clamp mastered to active total — progress records may reference deactivated questions
                 long clampedMastered = Math.min(mastered, totalQuestions);
                 long remaining = Math.max(totalQuestions - clampedMastered, 0);
                 resolvedDailyTarget = (int) Math.min(50, Math.max(5,
@@ -158,7 +223,6 @@ public class StudyPlanService {
             resolvedDailyTarget = 20;
         }
 
-        // Sort domains by weakness; fall back to all Strapi domains if no progress exists
         List<ReadinessScore.DomainStrengthValue> domains = new ArrayList<>(readiness.domainStrengths());
         if (domains.isEmpty()) {
             domains = strapiContentCache.getDomains(request.productCode(), locale).stream()
@@ -170,7 +234,6 @@ public class StudyPlanService {
 
         Map<String, Integer> allocation = allocateDays(domains, totalDays);
 
-        // Generate daily tasks
         List<StudyPlanDay> days = new ArrayList<>();
         int dayNumber = 1;
         LocalDate planDate = startDate;
@@ -192,7 +255,6 @@ public class StudyPlanService {
             }
         }
 
-        // Last 3 days: mixed review + daily mock exams
         for (int i = 0; i < MIXED_REVIEW_DAYS && dayNumber <= totalDays; i++) {
             StudyPlanDay day = new StudyPlanDay();
             day.setTenantId(TenantContext.get());
@@ -208,36 +270,25 @@ public class StudyPlanService {
             planDate = planDate.plusDays(1);
         }
 
-        // Focus domains
         List<String> focusDomains = domains.stream()
                 .filter(d -> "WEAK".equals(d.strength()) || "MODERATE".equals(d.strength()))
                 .map(ReadinessScore.DomainStrengthValue::domainCode)
                 .toList();
 
-        // Save plan
-        StudyPlan plan = new StudyPlan();
-        plan.setTenantId(TenantContext.get());
-        plan.setKeycloakUserId(userId);
-        plan.setProductCode(request.productCode());
-        plan.setExamDate(resolvedExamDate);
-        plan.setTotalDays(days.size());
-        plan.setStatus(PlanStatus.ACTIVE);
-        plan.setDailyQuestionTarget(resolvedDailyTarget);
-        plan.setFocusDomains(serializeJson(focusDomains));
-        plan.setUpdatedAt(Instant.now());
-        plan = planRepository.save(plan);
-
-        // Save plan days
-        for (StudyPlanDay day : days) {
-            day.setPlanId(plan.getId());
-        }
-        planDayRepository.saveAll(days);
-
-        LOG.info("Study plan generated: id={}, user={}, product={}, days={}, focusDomains={}",
-                plan.getId(), userId, request.productCode(), days.size(), focusDomains);
-
-        return toPlanDto(plan, days, 1);
+        return new ComputedPlan(resolvedExamDate, resolvedDailyTarget, focusDomains, days);
     }
+
+    /**
+     * Pure-compute result shared by {@link #generatePlan} and {@link #previewPlan}.
+     * The {@code days} list is unpersisted; {@code generatePlan} assigns
+     * {@code planId} and saves them; {@code previewPlan} converts them to DTOs.
+     */
+    private record ComputedPlan(
+            LocalDate examDate,
+            int dailyQuestionTarget,
+            List<String> focusDomains,
+            List<StudyPlanDay> days
+    ) {}
 
     /**
      * Abandons the active study plan for a user/product, if one exists.

--- a/src/test/java/com/passtheo/content/KarateContractRunner.java
+++ b/src/test/java/com/passtheo/content/KarateContractRunner.java
@@ -1,0 +1,86 @@
+package com.passtheo.content;
+
+import com.intuit.karate.junit5.Karate;
+import com.passtheo.content.config.TestSchedulingConfig;
+import com.passtheo.content.integration.strapi.StrapiClient;
+import com.passtheo.content.integration.strapi.dto.StrapiCountryDto;
+import com.passtheo.content.integration.strapi.dto.StrapiProductDto;
+import com.passtheo.content.integration.strapi.dto.StrapiProductTypeDto;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Karate contract verification runner for passtheo-content-service.
+ * Verifies the provider's real implementation matches the contracts
+ * in {@code ../contracts/passtheo-content-service/mappings/}.
+ *
+ * <p>StrapiClient is mocked with a fixed fixture so {@code /internal/products/catalog}
+ * returns a deterministic shape. The feature under
+ * {@code src/test/resources/karate/contract/} asserts the response shape matches
+ * the stubs consumers rely on.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("acceptance")
+@Import({TestSchedulingConfig.class})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag("contract")
+class KarateContractRunner {
+
+    @LocalServerPort
+    private int port;
+
+    @MockitoBean
+    private StrapiClient strapiClient;
+
+    @Autowired
+    @Qualifier("actualDataSource")
+    private DataSource rawDataSource;
+
+    @BeforeAll
+    void setupAll() {
+        runFlywayMigrations();
+        configureStrapiMocks();
+    }
+
+    private void runFlywayMigrations() {
+        Flyway flyway = Flyway.configure()
+                .dataSource(rawDataSource)
+                .schemas("content_service")
+                .locations("classpath:db/migration")
+                .cleanDisabled(false)
+                .load();
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    private void configureStrapiMocks() {
+        when(strapiClient.getCountries(anyString())).thenReturn(List.of(
+                new StrapiCountryDto(1, null, "Nederland", "NL", null, "nl", List.of("nl"), true, 1)));
+        when(strapiClient.getProductTypes(anyString(), anyString())).thenReturn(List.of(
+                new StrapiProductTypeDto(1, null, "CBR", "cbr", null, null, null, null, null, true, 1, 2)));
+        when(strapiClient.getProducts(anyString(), anyString())).thenReturn(List.of(
+                new StrapiProductDto(1, null, "Auto B", "auto-b", "B", null, null, null, true, false, 1, null, 0, 0),
+                new StrapiProductDto(2, null, "Motor A", "motor-a", "A", null, null, null, true, false, 2, null, 0, 0)));
+    }
+
+    @Karate.Test
+    Karate verifyContracts() {
+        System.setProperty("karate.baseUrl", "http://localhost:" + port);
+        return Karate.run("classpath:karate/contract").relativeTo(getClass());
+    }
+}

--- a/src/test/java/com/passtheo/content/unit/InternalProductControllerTest.java
+++ b/src/test/java/com/passtheo/content/unit/InternalProductControllerTest.java
@@ -1,0 +1,97 @@
+package com.passtheo.content.unit;
+
+import com.passtheo.content.controller.InternalProductController;
+import com.passtheo.content.dto.response.ProductCatalogEntryDto;
+import com.passtheo.content.integration.strapi.StrapiContentCache;
+import com.passtheo.content.integration.strapi.dto.StrapiCountryDto;
+import com.passtheo.content.integration.strapi.dto.StrapiProductDto;
+import com.passtheo.content.integration.strapi.dto.StrapiProductTypeDto;
+import com.passtheo.shared.core.dto.ApiResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for InternalProductController. Mocks StrapiContentCache to drive
+ * the iteration over countries -> product types -> products.
+ */
+@ExtendWith(MockitoExtension.class)
+class InternalProductControllerTest {
+
+    @Mock private StrapiContentCache cache;
+
+    private InternalProductController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new InternalProductController(cache);
+    }
+
+    @Test
+    void getCatalog_returnsProductsAcrossAllCountriesAndTypes() {
+        StrapiCountryDto nl = country("NL", "Netherlands");
+        StrapiCountryDto de = country("DE", "Germany");
+        when(cache.getCountries("nl")).thenReturn(List.of(nl, de));
+
+        StrapiProductTypeDto cbrAuto = productType("cbr-auto", "CBR Auto");
+        StrapiProductTypeDto cbrMotor = productType("cbr-motor", "CBR Motor");
+        StrapiProductTypeDto deAuto = productType("de-auto", "DE Auto");
+        when(cache.getProductTypes("NL", "nl")).thenReturn(List.of(cbrAuto, cbrMotor));
+        when(cache.getProductTypes("DE", "nl")).thenReturn(List.of(deAuto));
+
+        when(cache.getProducts("cbr-auto", "nl")).thenReturn(List.of(
+                product("auto-b", "Auto B", true),
+                product("auto-be", "Auto B+E", false)));
+        when(cache.getProducts("cbr-motor", "nl")).thenReturn(List.of(
+                product("motor-a", "Motor A", true)));
+        when(cache.getProducts("de-auto", "nl")).thenReturn(List.of(
+                product("de-b", "DE B", true)));
+
+        ResponseEntity<ApiResponse<List<ProductCatalogEntryDto>>> response =
+                controller.getCatalog("nl");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        List<ProductCatalogEntryDto> entries = response.getBody().getData();
+        assertThat(entries).hasSize(4)
+                .extracting(ProductCatalogEntryDto::code, ProductCatalogEntryDto::productTypeCode,
+                        ProductCatalogEntryDto::countryCode, ProductCatalogEntryDto::active)
+                .containsExactly(
+                        tuple("auto-b", "cbr-auto", "NL", true),
+                        tuple("auto-be", "cbr-auto", "NL", false),
+                        tuple("motor-a", "cbr-motor", "NL", true),
+                        tuple("de-b", "de-auto", "DE", true));
+    }
+
+    @Test
+    void getCatalog_noCountries_returnsEmptyList() {
+        when(cache.getCountries("nl")).thenReturn(List.of());
+
+        ResponseEntity<ApiResponse<List<ProductCatalogEntryDto>>> response =
+                controller.getCatalog("nl");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getData()).isEmpty();
+    }
+
+    private static StrapiCountryDto country(String code, String name) {
+        return new StrapiCountryDto(0, null, name, code, null, "nl", List.of("nl", "en"), true, 0);
+    }
+
+    private static StrapiProductTypeDto productType(String code, String name) {
+        return new StrapiProductTypeDto(0, null, name, code, null, null, null, null, null, true, 0, 0);
+    }
+
+    private static StrapiProductDto product(String code, String name, boolean active) {
+        return new StrapiProductDto(0, null, name, code, null, null, null, null, active, false, 0, null, 0, 0);
+    }
+}

--- a/src/test/java/com/passtheo/content/unit/StudyPlanControllerTest.java
+++ b/src/test/java/com/passtheo/content/unit/StudyPlanControllerTest.java
@@ -1,0 +1,84 @@
+package com.passtheo.content.unit;
+
+import com.passtheo.content.controller.StudyPlanController;
+import com.passtheo.content.dto.request.GenerateStudyPlanRequest;
+import com.passtheo.content.dto.response.StudyPlanDto;
+import com.passtheo.content.service.StudyPlanService;
+import com.passtheo.shared.core.dto.ApiResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for StudyPlanController — focus on the preview endpoint and its
+ * contract that a preview response carries {@code planId=null} +
+ * {@code status="PREVIEW"}.
+ */
+@ExtendWith(MockitoExtension.class)
+class StudyPlanControllerTest {
+
+    private static final UUID USER_ID = UUID.randomUUID();
+
+    @Mock private StudyPlanService studyPlanService;
+
+    private StudyPlanController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new StudyPlanController(studyPlanService);
+    }
+
+    @Test
+    void previewStudyPlan_returns200WithPreviewDto() {
+        GenerateStudyPlanRequest request = new GenerateStudyPlanRequest(
+                "motor-a", LocalDate.of(2026, 9, 1), null);
+        StudyPlanDto preview = new StudyPlanDto(
+                null,
+                "motor-a",
+                LocalDate.of(2026, 9, 1),
+                60, 0, 12,
+                "PREVIEW",
+                List.of("signs", "priority"),
+                List.of());
+        when(studyPlanService.previewPlan(USER_ID, request, "nl")).thenReturn(preview);
+
+        ResponseEntity<ApiResponse<StudyPlanDto>> response =
+                controller.previewStudyPlan(USER_ID, request, "nl");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        StudyPlanDto data = response.getBody().getData();
+        assertThat(data.planId()).isNull();
+        assertThat(data.status()).isEqualTo("PREVIEW");
+        assertThat(data.productCode()).isEqualTo("motor-a");
+        assertThat(data.totalDays()).isEqualTo(60);
+        assertThat(data.dailyQuestionTarget()).isEqualTo(12);
+        verify(studyPlanService).previewPlan(USER_ID, request, "nl");
+    }
+
+    @Test
+    void previewStudyPlan_passesLocaleThrough() {
+        GenerateStudyPlanRequest request = new GenerateStudyPlanRequest(
+                "auto-b", LocalDate.of(2026, 7, 1), null);
+        StudyPlanDto preview = new StudyPlanDto(
+                null, "auto-b", LocalDate.of(2026, 7, 1),
+                60, 0, 10, "PREVIEW", List.of(), List.of());
+        when(studyPlanService.previewPlan(USER_ID, request, "en")).thenReturn(preview);
+
+        controller.previewStudyPlan(USER_ID, request, "en");
+
+        verify(studyPlanService).previewPlan(USER_ID, request, "en");
+    }
+}

--- a/src/test/java/com/passtheo/content/unit/StudyPlanServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/StudyPlanServiceTest.java
@@ -1,0 +1,215 @@
+package com.passtheo.content.unit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.passtheo.content.domain.enums.ConfidenceLabel;
+import com.passtheo.content.domain.enums.MasteryLevel;
+import com.passtheo.content.domain.enums.ReadinessLabel;
+import com.passtheo.content.domain.enums.RecommendationKey;
+import com.passtheo.content.domain.valueobject.ExamConfidence;
+import com.passtheo.content.domain.valueobject.ReadinessScore;
+import com.passtheo.content.domain.valueobject.ReadinessScore.DomainStrengthValue;
+import com.passtheo.content.dto.request.GenerateStudyPlanRequest;
+import com.passtheo.content.dto.response.StudyPlanDto;
+import com.passtheo.content.integration.strapi.StrapiContentCache;
+import com.passtheo.content.repository.QuestionProgressRepository;
+import com.passtheo.content.repository.StudyPlanDayRepository;
+import com.passtheo.content.repository.StudyPlanRepository;
+import com.passtheo.content.service.ReadinessService;
+import com.passtheo.content.service.StudyPlanService;
+import com.passtheo.shared.core.client.UserServiceInternalClient;
+import com.passtheo.shared.core.context.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for StudyPlanService — focus on the new {@code previewPlan}
+ * method and its behavioural equivalence with {@code generatePlan}.
+ */
+@ExtendWith(MockitoExtension.class)
+class StudyPlanServiceTest {
+
+    private static final UUID TENANT_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final String PRODUCT = "auto-b";
+    private static final String LOCALE = "nl";
+
+    @Mock private StudyPlanRepository planRepository;
+    @Mock private StudyPlanDayRepository planDayRepository;
+    @Mock private ReadinessService readinessService;
+    @Mock private StrapiContentCache strapiContentCache;
+    @Mock private UserServiceInternalClient userServiceClient;
+    @Mock private QuestionProgressRepository progressRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private StudyPlanService service;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.set(TENANT_ID);
+        service = new StudyPlanService(
+                planRepository, planDayRepository, readinessService,
+                strapiContentCache, objectMapper, userServiceClient, progressRepository);
+
+        ExamConfidence.Breakdown breakdown = new ExamConfidence.Breakdown(
+                0, 0, 0, 0, 0, false, false, 0, List.of());
+        ExamConfidence examConfidence = new ExamConfidence(
+                0, ConfidenceLabel.NOT_READY, RecommendationKey.KEEP_PRACTICING, breakdown);
+        ReadinessScore readiness = new ReadinessScore(
+                0.0, 0.0, 0.0, 0.0, ReadinessLabel.NOT_READY, 0, 500, null, 44,
+                List.of(
+                        new DomainStrengthValue("verkeersborden", "Verkeersborden", 0.0, 0.0, "WEAK"),
+                        new DomainStrengthValue("snelheid", "Snelheid", 0.0, 0.0, "MODERATE")),
+                null, null, examConfidence);
+        lenient().when(readinessService.calculate(eq(USER_ID), eq(PRODUCT), anyString()))
+                .thenReturn(readiness);
+        lenient().when(strapiContentCache.getQuestionCount(eq(PRODUCT), anyString())).thenReturn(500);
+        lenient().when(progressRepository.countByKeycloakUserIdAndProductCodeAndMasteryLevel(
+                eq(USER_ID), eq(PRODUCT), eq(MasteryLevel.MASTERED))).thenReturn(0L);
+        lenient().when(userServiceClient.getProfile(eq(USER_ID), any())).thenReturn(Optional.empty());
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void previewPlan_doesNotPersist() {
+        GenerateStudyPlanRequest request = new GenerateStudyPlanRequest(
+                PRODUCT, LocalDate.now(ZoneOffset.UTC).plusDays(60), null);
+
+        StudyPlanDto preview = service.previewPlan(USER_ID, request, LOCALE);
+
+        assertThat(preview).isNotNull();
+        assertThat(preview.planId()).isNull();
+        assertThat(preview.status()).isEqualTo("PREVIEW");
+        verify(planRepository, never()).save(any());
+        verify(planRepository, never()).saveAndFlush(any());
+        verify(planDayRepository, never()).saveAll(any());
+    }
+
+    @Test
+    void previewPlan_returnsSameShapeAsGenerate() {
+        LocalDate examDate = LocalDate.now(ZoneOffset.UTC).plusDays(60);
+        GenerateStudyPlanRequest request = new GenerateStudyPlanRequest(PRODUCT, examDate, null);
+
+        when(planRepository.findByKeycloakUserIdAndProductCodeAndStatus(any(), any(), any()))
+                .thenReturn(Optional.empty());
+        when(planRepository.save(any())).thenAnswer(i -> {
+            var plan = (com.passtheo.content.domain.entity.StudyPlan) i.getArgument(0);
+            plan.setId(UUID.randomUUID());
+            return plan;
+        });
+
+        StudyPlanDto preview = service.previewPlan(USER_ID, request, LOCALE);
+        StudyPlanDto generated = service.generatePlan(USER_ID, request, LOCALE);
+
+        assertThat(preview.totalDays()).isEqualTo(generated.totalDays());
+        assertThat(preview.dailyQuestionTarget()).isEqualTo(generated.dailyQuestionTarget());
+        assertThat(preview.focusDomains()).containsExactlyElementsOf(generated.focusDomains());
+        assertThat(preview.days()).hasSameSizeAs(generated.days());
+    }
+
+    @Test
+    void previewPlan_usesMasteryCountForDailyGoal() {
+        // 500 total questions, 50 mastered, 50 days until exam => ceil(450/50) = 9
+        LocalDate examDate = LocalDate.now(ZoneOffset.UTC).plusDays(50);
+        GenerateStudyPlanRequest request = new GenerateStudyPlanRequest(PRODUCT, examDate, null);
+        when(progressRepository.countByKeycloakUserIdAndProductCodeAndMasteryLevel(
+                eq(USER_ID), eq(PRODUCT), eq(MasteryLevel.MASTERED))).thenReturn(50L);
+
+        StudyPlanDto preview = service.previewPlan(USER_ID, request, LOCALE);
+
+        assertThat(preview.dailyQuestionTarget()).isEqualTo(9);
+    }
+
+    @Test
+    void previewPlan_dailyTargetFloor() {
+        // 50 remaining / 60 days => ceil = 1, clamped to floor of 5.
+        LocalDate examDate = LocalDate.now(ZoneOffset.UTC).plusDays(60);
+        when(strapiContentCache.getQuestionCount(eq(PRODUCT), anyString())).thenReturn(50);
+        when(progressRepository.countByKeycloakUserIdAndProductCodeAndMasteryLevel(
+                eq(USER_ID), eq(PRODUCT), eq(MasteryLevel.MASTERED))).thenReturn(0L);
+        GenerateStudyPlanRequest request = new GenerateStudyPlanRequest(PRODUCT, examDate, null);
+
+        StudyPlanDto preview = service.previewPlan(USER_ID, request, LOCALE);
+
+        assertThat(preview.dailyQuestionTarget()).isEqualTo(5);
+    }
+
+    @Test
+    void previewPlan_dailyTargetCeiling() {
+        // 5000 remaining / 30 days => ceil = 167, clamped to ceiling of 50.
+        LocalDate examDate = LocalDate.now(ZoneOffset.UTC).plusDays(30);
+        when(strapiContentCache.getQuestionCount(eq(PRODUCT), anyString())).thenReturn(5000);
+        when(progressRepository.countByKeycloakUserIdAndProductCodeAndMasteryLevel(
+                eq(USER_ID), eq(PRODUCT), eq(MasteryLevel.MASTERED))).thenReturn(0L);
+        GenerateStudyPlanRequest request = new GenerateStudyPlanRequest(PRODUCT, examDate, null);
+
+        StudyPlanDto preview = service.previewPlan(USER_ID, request, LOCALE);
+
+        assertThat(preview.dailyQuestionTarget()).isEqualTo(50);
+    }
+
+    @Test
+    void previewPlan_totalDaysClampedToMaxPlanDays() {
+        // 365 days until exam should clamp to MAX_PLAN_DAYS = 90.
+        LocalDate examDate = LocalDate.now(ZoneOffset.UTC).plusDays(365);
+        GenerateStudyPlanRequest request = new GenerateStudyPlanRequest(PRODUCT, examDate, null);
+
+        StudyPlanDto preview = service.previewPlan(USER_ID, request, LOCALE);
+
+        assertThat(preview.totalDays()).isEqualTo(90);
+    }
+
+    @Test
+    void previewPlan_totalDaysClampedToMinPlanDays() {
+        // 2 days until exam should clamp to MIN_PLAN_DAYS = 7.
+        LocalDate examDate = LocalDate.now(ZoneOffset.UTC).plusDays(2);
+        GenerateStudyPlanRequest request = new GenerateStudyPlanRequest(PRODUCT, examDate, null);
+
+        StudyPlanDto preview = service.previewPlan(USER_ID, request, LOCALE);
+
+        assertThat(preview.totalDays()).isEqualTo(7);
+    }
+
+    @Test
+    void previewPlan_explicitDailyTargetOverridesAutoCalc() {
+        LocalDate examDate = LocalDate.now(ZoneOffset.UTC).plusDays(60);
+        GenerateStudyPlanRequest request = new GenerateStudyPlanRequest(PRODUCT, examDate, 42);
+
+        StudyPlanDto preview = service.previewPlan(USER_ID, request, LOCALE);
+
+        assertThat(preview.dailyQuestionTarget()).isEqualTo(42);
+    }
+
+    @Test
+    void previewPlan_noExamDate_usesDefault30Days() {
+        GenerateStudyPlanRequest request = new GenerateStudyPlanRequest(PRODUCT, null, null);
+
+        StudyPlanDto preview = service.previewPlan(USER_ID, request, LOCALE);
+
+        assertThat(preview.totalDays()).isEqualTo(30);
+        assertThat(preview.dailyQuestionTarget()).isEqualTo(20);
+    }
+}

--- a/src/test/java/com/passtheo/content/unit/UserEventConsumerTest.java
+++ b/src/test/java/com/passtheo/content/unit/UserEventConsumerTest.java
@@ -132,6 +132,32 @@ class UserEventConsumerTest {
     }
 
     @Test
+    void onUserProductChanged_examDateInLegacyArrayFormat_isParsedCorrectly() {
+        // Verifies backward compat with outbox rows written before
+        // WRITE_DATES_AS_TIMESTAMPS=false was applied to OutboxEventPublisher.
+        String payload = """
+                {
+                  "eventType": "UserProductChanged",
+                  "tenantId": "%s",
+                  "keycloakUserId": "%s",
+                  "oldProductCode": "auto-b",
+                  "newProductCode": "motor-a",
+                  "examDate": [2026, 9, 1]
+                }
+                """.formatted(TENANT_ID, USER_ID);
+        ConsumerRecord<String, String> record = kafkaRecord(payload);
+
+        consumer.onUserEvent(record, ack);
+
+        verify(studyPlanService).abandonActivePlan(USER_ID, "auto-b");
+        ArgumentCaptor<GenerateStudyPlanRequest> requestCaptor =
+                ArgumentCaptor.forClass(GenerateStudyPlanRequest.class);
+        verify(studyPlanService).generatePlan(eq(USER_ID), requestCaptor.capture(), eq("nl"));
+        assertThat(requestCaptor.getValue().examDate()).isEqualTo(LocalDate.of(2026, 9, 1));
+        verify(ack).acknowledge();
+    }
+
+    @Test
     void onUserProductChanged_exceptionInService_isSwallowed() {
         String payload = """
                 {

--- a/src/test/java/com/passtheo/content/unit/UserEventConsumerTest.java
+++ b/src/test/java/com/passtheo/content/unit/UserEventConsumerTest.java
@@ -1,0 +1,159 @@
+package com.passtheo.content.unit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.passtheo.content.dto.request.GenerateStudyPlanRequest;
+import com.passtheo.content.kafka.consumer.UserEventConsumer;
+import com.passtheo.content.repository.DomainProgressRepository;
+import com.passtheo.content.repository.EarnedAchievementRepository;
+import com.passtheo.content.repository.ExamAttemptRepository;
+import com.passtheo.content.repository.QuestionProgressRepository;
+import com.passtheo.content.repository.ReadinessSnapshotRepository;
+import com.passtheo.content.repository.StreakRepository;
+import com.passtheo.content.repository.StudyPlanRepository;
+import com.passtheo.content.repository.TopicProgressRepository;
+import com.passtheo.content.service.StudyPlanService;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for UserEventConsumer — focuses on the UserProductChanged branch.
+ */
+@ExtendWith(MockitoExtension.class)
+class UserEventConsumerTest {
+
+    private static final UUID TENANT_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock private QuestionProgressRepository progressRepository;
+    @Mock private TopicProgressRepository topicProgressRepository;
+    @Mock private DomainProgressRepository domainProgressRepository;
+    @Mock private StreakRepository streakRepository;
+    @Mock private EarnedAchievementRepository achievementRepository;
+    @Mock private ExamAttemptRepository examAttemptRepository;
+    @Mock private ReadinessSnapshotRepository snapshotRepository;
+    @Mock private StudyPlanRepository planRepository;
+    @Mock private StudyPlanService studyPlanService;
+    @Mock private Acknowledgment ack;
+
+    private UserEventConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        consumer = new UserEventConsumer(objectMapper,
+                progressRepository, topicProgressRepository, domainProgressRepository,
+                streakRepository, achievementRepository, examAttemptRepository,
+                snapshotRepository, planRepository, studyPlanService);
+    }
+
+    @Test
+    void onUserProductChanged_abandonsOldAndRegeneratesWhenExamDatePresent() {
+        String payload = """
+                {
+                  "eventType": "UserProductChanged",
+                  "tenantId": "%s",
+                  "keycloakUserId": "%s",
+                  "oldProductCode": "auto-b",
+                  "newProductCode": "motor-a",
+                  "examDate": "2026-09-01"
+                }
+                """.formatted(TENANT_ID, USER_ID);
+        ConsumerRecord<String, String> record = kafkaRecord(payload);
+
+        consumer.onUserEvent(record, ack);
+
+        verify(studyPlanService).abandonActivePlan(USER_ID, "auto-b");
+
+        ArgumentCaptor<GenerateStudyPlanRequest> requestCaptor =
+                ArgumentCaptor.forClass(GenerateStudyPlanRequest.class);
+        verify(studyPlanService).generatePlan(eq(USER_ID), requestCaptor.capture(), eq("nl"));
+        GenerateStudyPlanRequest captured = requestCaptor.getValue();
+        assertThat(captured.productCode()).isEqualTo("motor-a");
+        assertThat(captured.examDate()).isEqualTo(LocalDate.of(2026, 9, 1));
+
+        verify(ack).acknowledge();
+    }
+
+    @Test
+    void onUserProductChanged_abandonsButSkipsRegenWhenExamDateNull() {
+        String payload = """
+                {
+                  "eventType": "UserProductChanged",
+                  "tenantId": "%s",
+                  "keycloakUserId": "%s",
+                  "oldProductCode": "auto-b",
+                  "newProductCode": "motor-a",
+                  "examDate": null
+                }
+                """.formatted(TENANT_ID, USER_ID);
+        ConsumerRecord<String, String> record = kafkaRecord(payload);
+
+        consumer.onUserEvent(record, ack);
+
+        verify(studyPlanService).abandonActivePlan(USER_ID, "auto-b");
+        verify(studyPlanService, never()).generatePlan(any(), any(), any());
+        verify(ack).acknowledge();
+    }
+
+    @Test
+    void onUserProductChanged_missingOldProductCode_isIgnoredButAcked() {
+        String payload = """
+                {
+                  "eventType": "UserProductChanged",
+                  "tenantId": "%s",
+                  "keycloakUserId": "%s",
+                  "newProductCode": "motor-a",
+                  "examDate": "2026-09-01"
+                }
+                """.formatted(TENANT_ID, USER_ID);
+        ConsumerRecord<String, String> record = kafkaRecord(payload);
+
+        consumer.onUserEvent(record, ack);
+
+        verify(studyPlanService, never()).abandonActivePlan(any(), any());
+        verify(studyPlanService, never()).generatePlan(any(), any(), any());
+        verify(ack).acknowledge();
+    }
+
+    @Test
+    void onUserProductChanged_exceptionInService_isSwallowed() {
+        String payload = """
+                {
+                  "eventType": "UserProductChanged",
+                  "tenantId": "%s",
+                  "keycloakUserId": "%s",
+                  "oldProductCode": "auto-b",
+                  "newProductCode": "motor-a",
+                  "examDate": "2026-09-01"
+                }
+                """.formatted(TENANT_ID, USER_ID);
+        ConsumerRecord<String, String> record = kafkaRecord(payload);
+        org.mockito.Mockito.doThrow(new RuntimeException("db down"))
+                .when(studyPlanService).abandonActivePlan(any(), any());
+
+        // Should not throw — the consumer catches and logs.
+        consumer.onUserEvent(record, ack);
+
+        verify(ack, never()).acknowledge();
+    }
+
+    private static ConsumerRecord<String, String> kafkaRecord(String value) {
+        return new ConsumerRecord<>("passtheo.user.events", 0, 0L, "key", value);
+    }
+}

--- a/src/test/resources/karate-config.js
+++ b/src/test/resources/karate-config.js
@@ -4,6 +4,9 @@ function fn() {
   var now = new Date();
   now.setDate(now.getDate() + 30);
   var futureDate = now.toISOString().split('T')[0];
+  var far = new Date();
+  far.setDate(far.getDate() + 60);
+  var farFutureDate = far.toISOString().split('T')[0];
 
   var config = {
     baseUrl: baseUrl,
@@ -12,6 +15,7 @@ function fn() {
     userWithoutExamDate: '22222222-2222-2222-2222-222222222222',
     learnerRole: 'LEARNER',
     futureDate: futureDate,
+    farFutureDate: farFutureDate,
     freeToken: 'test-bearer-free-user',
     paidToken: 'test-bearer-paid-user',
     freshToken: 'test-bearer-fresh-user'

--- a/src/test/resources/karate/contract/verify-contracts.feature
+++ b/src/test/resources/karate/contract/verify-contracts.feature
@@ -1,0 +1,28 @@
+@contract
+Feature: Contract verification — passtheo-content-service provider
+
+  Background:
+    * url baseUrl
+
+  # ─── GET /internal/products/catalog — 200 with products ─────────────────────
+
+  Scenario: GET /internal/products/catalog returns a flat product list
+    Given path '/internal/products/catalog'
+    And param locale = 'nl'
+    When method GET
+    Then status 200
+    # Contract: { success: true, data: [{ code, name, productTypeCode, countryCode, active }] }
+    And match response.success == true
+    And match response.data == '#array'
+    And match each response.data == { code: '#string', name: '#string', productTypeCode: '#string', countryCode: '#string', active: '#boolean' }
+    # At least one product expected from the StrapiClient mock in KarateContractRunner.
+    And match response.data[0].code == '#notnull'
+
+  # ─── GET /internal/products/catalog — default locale ────────────────────────
+
+  Scenario: GET /internal/products/catalog defaults locale to 'nl'
+    Given path '/internal/products/catalog'
+    When method GET
+    Then status 200
+    And match response.success == true
+    And match response.data == '#array'

--- a/src/test/resources/karate/study-plan.feature
+++ b/src/test/resources/karate/study-plan.feature
@@ -36,3 +36,41 @@ Feature: Study plan generation with exam date fallback
     Then status 200
     And match response.success == true
     And match response.data.days == '#array'
+
+  Scenario: POST /preview returns a PREVIEW plan without persisting
+    * header X-Tenant-ID = tenantId
+    * header X-Keycloak-User-ID = userId
+    * header X-User-Roles = learnerRole
+    Given path '/api/study-plan/preview'
+    And request { productCode: 'auto-b', examDate: '#(futureDate)' }
+    When method post
+    Then status 200
+    And match response.success == true
+    And match response.data.planId == '#null'
+    And match response.data.status == 'PREVIEW'
+    And match response.data.totalDays == '#number'
+    And match response.data.dailyQuestionTarget == '#number'
+    And match response.data.days == '#array'
+
+  Scenario: POST /preview does not modify the active plan
+    * header X-Tenant-ID = tenantId
+    * header X-Keycloak-User-ID = userId
+    * header X-User-Roles = learnerRole
+    # Capture the currently active plan (or 404 if none)
+    Given path '/api/study-plan'
+    And param productCode = 'auto-b'
+    When method get
+    * def beforeStatus = responseStatus
+    * def beforePlanId = beforeStatus == 200 ? response.data.planId : null
+    # Call preview with a different exam date
+    Given path '/api/study-plan/preview'
+    And request { productCode: 'auto-b', examDate: '#(farFutureDate)' }
+    When method post
+    Then status 200
+    And match response.data.status == 'PREVIEW'
+    # The active plan should be unchanged
+    Given path '/api/study-plan'
+    And param productCode = 'auto-b'
+    When method get
+    Then status == beforeStatus
+    * if (beforeStatus == 200) karate.match(response.data.planId, beforePlanId)

--- a/src/test/resources/karate/study-plan.feature
+++ b/src/test/resources/karate/study-plan.feature
@@ -56,21 +56,25 @@ Feature: Study plan generation with exam date fallback
     * header X-Tenant-ID = tenantId
     * header X-Keycloak-User-ID = userId
     * header X-User-Roles = learnerRole
-    # Capture the currently active plan (or 404 if none)
+    # Establish a baseline plan so we can prove the preview call leaves it untouched.
     Given path '/api/study-plan'
-    And param productCode = 'auto-b'
-    When method get
-    * def beforeStatus = responseStatus
-    * def beforePlanId = beforeStatus == 200 ? response.data.planId : null
+    And request { productCode: 'auto-b', examDate: '#(futureDate)', dailyQuestionTarget: 20 }
+    When method post
+    Then status 200
+    * def baselinePlanId = response.data.planId
+    * def baselineExamDate = response.data.examDate
     # Call preview with a different exam date
     Given path '/api/study-plan/preview'
     And request { productCode: 'auto-b', examDate: '#(farFutureDate)' }
     When method post
     Then status 200
     And match response.data.status == 'PREVIEW'
-    # The active plan should be unchanged
+    And match response.data.planId == '#null'
+    # The active plan must be unchanged
     Given path '/api/study-plan'
     And param productCode = 'auto-b'
     When method get
-    Then status == beforeStatus
-    * if (beforeStatus == 200) karate.match(response.data.planId, beforePlanId)
+    Then status 200
+    And match response.data.planId == baselinePlanId
+    And match response.data.examDate == baselineExamDate
+    And match response.data.status == 'ACTIVE'


### PR DESCRIPTION
Closes #83

## Summary

Three related additions so profile changes that touch productCode or examDate can be handled correctly and previewed by the UI:

- **UserEventConsumer** now handles the new \`UserProductChanged\` event — abandons the old product's active plan, then generates a new plan for the new product when \`examDate\` is present.
- **StudyPlanService** splits into a pure-compute path (\`previewPlan\`) and a persist path (\`generatePlan\`). New endpoint \`POST /api/study-plan/preview\` returns a \`StudyPlanDto\` with \`planId=null\`, \`status=\"PREVIEW\"\`, and the full day list — without persisting.
- **InternalProductController** exposes \`GET /internal/products/catalog\` so user-service can validate user-supplied productCodes without talking to Strapi directly. New \`KarateContractRunner\` + \`karateContractTest\` Gradle task verify the response shape matches the stubs in the contracts repo.

Depends on: passtheo/contracts PR #1 (new stubs for \`/internal/products/catalog\`).
Pairs with: passtheo/user-service PR (issue #29) — user-service consumes this catalog to validate productCode.

## Test plan

- [x] Unit tests pass: \`./gradlew test\`
- [ ] Acceptance tests pass: \`./gradlew acceptanceTest\` (requires Docker infra)
- [ ] Contract verification passes: \`./gradlew karateContractTest\` (requires Docker infra)
- [ ] Manual smoke test: register test user, patch productCode, observe active plan abandoned and new plan generated
- [ ] Manual smoke test: POST /api/study-plan/preview returns PREVIEW DTO, GET /api/study-plan confirms no persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)