### PR TITLE
chore(content): log study plan inputs for observability

### DIFF
--- a/src/main/java/com/passtheo/content/service/StudyPlanService.java
+++ b/src/main/java/com/passtheo/content/service/StudyPlanService.java
@@ -216,6 +216,8 @@ public class StudyPlanService {
                 long remaining = Math.max(totalQuestions - clampedMastered, 0);
                 resolvedDailyTarget = (int) Math.min(50, Math.max(5,
                         (long) Math.ceil((double) remaining / daysUntilExam)));
+                LOG.info("Study plan inputs: totalQuestions={}, mastered={}, remaining={}, daysUntilExam={}, dailyQuestionTarget={}",
+                        totalQuestions, mastered, remaining, daysUntilExam, resolvedDailyTarget);
             } else {
                 resolvedDailyTarget = 20;
             }


### PR DESCRIPTION
Closes #85

## Summary
- Adds one `LOG.info(...)` line in `StudyPlanService.computePlan()` (line 219) emitting the inputs to the daily-target formula: `totalQuestions`, `mastered`, `remaining`, `daysUntilExam`, and the computed `dailyQuestionTarget`.
- Fires only on the auto-calculated branch (when the exam date is set and `daysUntilExam > 0`).
- No change to formula, clamping (`Math.min(50, Math.max(5, …))`), or control flow.

## Context
A recent bug report ("daily goal is always 5 regardless of exam date") could not be explained from service logs. Static analysis showed the formula is working as written — the observed behaviour is driven by a small seeded question pool (~68 in Strapi) combined with the intentional floor of 5. Growing the question pool is the real fix and is tracked separately. This PR just makes future investigations on this code path possible from log output.

## Test plan
- [x] `./gradlew test --tests 'com.passtheo.content.unit.StudyPlanServiceTest'` passes (all 9 existing scenarios).
- [x] `./gradlew test` (full suite) passes.
- [x] `./gradlew assemble` succeeds.
- [ ] After merge + deploy, hit `POST /api/study-plan` for a user with an exam date set and confirm the new log line appears in service output.