### PR TITLE
feat(content): lesson premium gate — isPremium + locked on LessonDto (P0.5)

### DIFF
--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -1681,6 +1681,13 @@ components:
         has stripped `sections`, `summary`, `coverImage`, and `videoUrl` and the
         client must render a paywall on tap. Paid users receive `locked: false`
         with full content regardless of `isPremium`.
+      required:
+        - title
+        - slug
+        - sections
+        - readTimeMinutes
+        - isPremium
+        - locked
       properties:
         title: { type: string }
         slug: { type: string }

--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -284,7 +284,14 @@ paths:
       operationId: listLessonsByTopic
       tags: [Content]
       summary: Theory lessons for a topic (by topic code only)
-      description: Returns all active lessons for the given topic code. Simpler alternative to the hierarchical endpoint — no country/product context required.
+      description: |
+        Returns all active lessons for the given topic code. Simpler alternative to the
+        hierarchical endpoint — no country/product context required.
+
+        **Premium gating:** for users on the free tier, premium lessons are returned with
+        stripped content (sections=[], summary/coverImage/videoUrl=null) and
+        `locked: true`. The UI renders a lock icon and opens the upgrade paywall
+        instead of the reading view. Paid-tier users receive full content regardless.
       security:
         - bearerAuth: []
       parameters:
@@ -294,6 +301,7 @@ paths:
           schema:
             type: string
         - $ref: '#/components/parameters/TenantHeader'
+        - $ref: '#/components/parameters/UserHeader'
         - $ref: '#/components/parameters/LocaleQuery'
       responses:
         '200':
@@ -308,6 +316,9 @@ paths:
       operationId: listLessons
       tags: [Content]
       summary: Theory lessons for a topic
+      description: |
+        Hierarchical lesson-listing endpoint. Same premium-gating semantics as
+        `/api/content/lessons/{topicCode}`.
       security:
         - bearerAuth: []
       parameters:
@@ -320,6 +331,7 @@ paths:
           schema:
             type: string
         - $ref: '#/components/parameters/TenantHeader'
+        - $ref: '#/components/parameters/UserHeader'
         - $ref: '#/components/parameters/LocaleQuery'
       responses:
         '200':
@@ -1662,6 +1674,13 @@ components:
 
     LessonDto:
       type: object
+      description: |
+        A theory lesson served to the client. `isPremium` reflects the Strapi
+        content flag (metadata about the lesson itself). `locked` reflects the
+        access decision for the calling user — when `locked: true`, the server
+        has stripped `sections`, `summary`, `coverImage`, and `videoUrl` and the
+        client must render a paywall on tap. Paid users receive `locked: false`
+        with full content regardless of `isPremium`.
       properties:
         title: { type: string }
         slug: { type: string }
@@ -1676,10 +1695,19 @@ components:
               keyRule: { type: string, nullable: true }
               relatedRoadSignCode: { type: string, nullable: true }
               sortOrder: { type: integer }
-        summary: { type: string }
-        coverImage: { type: string }
-        videoUrl: { type: string }
+        summary: { type: string, nullable: true }
+        coverImage: { type: string, nullable: true }
+        videoUrl: { type: string, nullable: true }
         readTimeMinutes: { type: integer }
+        isPremium:
+          type: boolean
+          description: True if the lesson is flagged premium in Strapi.
+        locked:
+          type: boolean
+          description: |
+            True if premium content was stripped for the calling user (free
+            tier + isPremium). Client renders a lock and opens the upgrade
+            paywall instead of the reading view.
 
     SessionDto:
       type: object

--- a/src/main/java/com/passtheo/content/controller/ContentController.java
+++ b/src/main/java/com/passtheo/content/controller/ContentController.java
@@ -19,7 +19,9 @@ import com.passtheo.content.service.EntitlementChecker;
 import com.passtheo.content.service.OnboardingCatalogService;
 import com.passtheo.content.service.PracticeSessionService;
 import com.passtheo.content.service.ReadinessService;
+import com.passtheo.shared.core.context.TenantContext;
 import com.passtheo.shared.core.dto.ApiResponse;
+import com.passtheo.shared.security.util.SecurityUtils;
 import jakarta.annotation.Nonnull;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
@@ -278,47 +280,60 @@ public class ContentController {
      * <p>Premium lessons are returned with stripped content for free-tier users:
      * {@code title}, {@code slug}, {@code readTimeMinutes}, and {@code isPremium=true}
      * are preserved; {@code sections}, {@code summary}, {@code coverImage}, and
-     * {@code videoUrl} are removed. The UI shows a lock and opens the upgrade paywall.
+     * {@code videoUrl} are removed, and {@code locked=true}. The UI shows a lock and
+     * opens the upgrade paywall.
      *
-     * @param tenantId  tenant ID from header
-     * @param userId    user ID from header
+     * <p>Tenant and user are read from {@link TenantContext} (populated by
+     * {@code TenantFilter}) and {@link SecurityUtils} (populated from the JWT
+     * {@code sub} claim) rather than raw request headers — premium gating is a
+     * security decision and must not be spoofable via forged headers.
+     *
      * @param topicCode the topic code
      * @param locale    content locale
      * @return list of lessons
      */
     @GetMapping("/lessons/{topicCode}")
     public ResponseEntity<ApiResponse<List<LessonDto>>> listLessonsByTopic(
-            @RequestHeader("X-Tenant-ID") UUID tenantId,
-            @RequestHeader("X-Keycloak-User-ID") UUID userId,
             @PathVariable @Nonnull String topicCode,
             @RequestParam(defaultValue = "nl") String locale) {
-        boolean isPaid = entitlementChecker.getAccess(tenantId, userId).isPaid();
+        boolean isPaid = resolveIsPaid();
         return ResponseEntity.ok(ApiResponse.success(buildLessonDtos(topicCode, locale, isPaid), MDC.get("traceId")));
     }
 
     /**
-     * Lists lessons for a topic. See {@link #listLessonsByTopic} for premium-gating behavior.
+     * Lists lessons for a topic (hierarchical endpoint). See
+     * {@link #listLessonsByTopic} for premium-gating behavior. The path-level
+     * {@code countryCode}/{@code productTypeCode}/{@code productCode} are
+     * consumed only for routing — lesson lookup keys on {@code topicCode}.
      *
-     * @param tenantId        tenant ID from header
-     * @param userId          user ID from header
-     * @param countryCode     country code from path (ignored for lesson lookup — routing only)
-     * @param productTypeCode product type code from path (ignored for lesson lookup — routing only)
-     * @param productCode     product code from path (ignored for lesson lookup — routing only)
+     * @param countryCode     country code from path (routing only)
+     * @param productTypeCode product type code from path (routing only)
+     * @param productCode     product code from path (routing only)
      * @param topicCode       the topic code
      * @param locale          content locale
      * @return list of lessons
      */
     @GetMapping("/{countryCode}/{productTypeCode}/{productCode}/lessons/{topicCode}")
     public ResponseEntity<ApiResponse<List<LessonDto>>> listLessons(
-            @RequestHeader("X-Tenant-ID") UUID tenantId,
-            @RequestHeader("X-Keycloak-User-ID") UUID userId,
             @PathVariable String countryCode,
             @PathVariable String productTypeCode,
             @PathVariable String productCode,
             @PathVariable @Nonnull String topicCode,
             @RequestParam(defaultValue = "nl") String locale) {
-        boolean isPaid = entitlementChecker.getAccess(tenantId, userId).isPaid();
+        boolean isPaid = resolveIsPaid();
         return ResponseEntity.ok(ApiResponse.success(buildLessonDtos(topicCode, locale, isPaid), MDC.get("traceId")));
+    }
+
+    private boolean resolveIsPaid() {
+        UUID tenantId = TenantContext.get();
+        UUID userId = SecurityUtils.extractKeycloakUserId();
+        if (tenantId == null || userId == null) {
+            // No authenticated user — treat as free-tier (safe default; premium
+            // content gets stripped). Logging only at debug to avoid noise.
+            LOG.debug("Premium-gate resolveIsPaid called without tenant+user context — defaulting free");
+            return false;
+        }
+        return entitlementChecker.getAccess(tenantId, userId).isPaid();
     }
 
     /**

--- a/src/main/java/com/passtheo/content/controller/ContentController.java
+++ b/src/main/java/com/passtheo/content/controller/ContentController.java
@@ -275,32 +275,50 @@ public class ContentController {
     /**
      * Lists lessons for a topic (flat endpoint — no country/product hierarchy required).
      *
+     * <p>Premium lessons are returned with stripped content for free-tier users:
+     * {@code title}, {@code slug}, {@code readTimeMinutes}, and {@code isPremium=true}
+     * are preserved; {@code sections}, {@code summary}, {@code coverImage}, and
+     * {@code videoUrl} are removed. The UI shows a lock and opens the upgrade paywall.
+     *
+     * @param tenantId  tenant ID from header
+     * @param userId    user ID from header
      * @param topicCode the topic code
      * @param locale    content locale
      * @return list of lessons
      */
     @GetMapping("/lessons/{topicCode}")
     public ResponseEntity<ApiResponse<List<LessonDto>>> listLessonsByTopic(
+            @RequestHeader("X-Tenant-ID") UUID tenantId,
+            @RequestHeader("X-Keycloak-User-ID") UUID userId,
             @PathVariable @Nonnull String topicCode,
             @RequestParam(defaultValue = "nl") String locale) {
-        return ResponseEntity.ok(ApiResponse.success(buildLessonDtos(topicCode, locale), MDC.get("traceId")));
+        boolean isPaid = entitlementChecker.getAccess(tenantId, userId).isPaid();
+        return ResponseEntity.ok(ApiResponse.success(buildLessonDtos(topicCode, locale, isPaid), MDC.get("traceId")));
     }
 
     /**
-     * Lists lessons for a topic.
+     * Lists lessons for a topic. See {@link #listLessonsByTopic} for premium-gating behavior.
      *
-     * @param topicCode the topic code
-     * @param locale    content locale
+     * @param tenantId        tenant ID from header
+     * @param userId          user ID from header
+     * @param countryCode     country code from path (ignored for lesson lookup — routing only)
+     * @param productTypeCode product type code from path (ignored for lesson lookup — routing only)
+     * @param productCode     product code from path (ignored for lesson lookup — routing only)
+     * @param topicCode       the topic code
+     * @param locale          content locale
      * @return list of lessons
      */
     @GetMapping("/{countryCode}/{productTypeCode}/{productCode}/lessons/{topicCode}")
     public ResponseEntity<ApiResponse<List<LessonDto>>> listLessons(
+            @RequestHeader("X-Tenant-ID") UUID tenantId,
+            @RequestHeader("X-Keycloak-User-ID") UUID userId,
             @PathVariable String countryCode,
             @PathVariable String productTypeCode,
             @PathVariable String productCode,
             @PathVariable @Nonnull String topicCode,
             @RequestParam(defaultValue = "nl") String locale) {
-        return ResponseEntity.ok(ApiResponse.success(buildLessonDtos(topicCode, locale), MDC.get("traceId")));
+        boolean isPaid = entitlementChecker.getAccess(tenantId, userId).isPaid();
+        return ResponseEntity.ok(ApiResponse.success(buildLessonDtos(topicCode, locale, isPaid), MDC.get("traceId")));
     }
 
     /**
@@ -321,17 +339,31 @@ public class ContentController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null, MDC.get("traceId")));
     }
 
-    private List<LessonDto> buildLessonDtos(@Nonnull String topicCode, @Nonnull String locale) {
+    private List<LessonDto> buildLessonDtos(@Nonnull String topicCode, @Nonnull String locale, boolean isPaid) {
         return strapiContentCache.getLessons(topicCode, locale).stream()
-                .map(l -> new LessonDto(
-                        l.title(), l.slug(),
-                        l.sections() != null ? l.sections().stream()
-                                .filter(Objects::nonNull)
-                                .map(s -> new LessonSectionDto(
-                                        s.heading(), s.body(), s.tip(),
-                                        s.keyRule(), s.relatedRoadSignCode(), s.sortOrder()))
-                                .toList() : List.of(),
-                        l.summary(), l.coverImage(), l.videoUrl(), l.readTimeMinutes()))
+                .map(l -> {
+                    boolean locked = l.isPremium() && !isPaid;
+                    if (locked) {
+                        return new LessonDto(
+                                l.title(), l.slug(),
+                                List.of(),
+                                null, null, null,
+                                l.readTimeMinutes(),
+                                true,
+                                true);
+                    }
+                    return new LessonDto(
+                            l.title(), l.slug(),
+                            l.sections() != null ? l.sections().stream()
+                                    .filter(Objects::nonNull)
+                                    .map(s -> new LessonSectionDto(
+                                            s.heading(), s.body(), s.tip(),
+                                            s.keyRule(), s.relatedRoadSignCode(), s.sortOrder()))
+                                    .toList() : List.of(),
+                            l.summary(), l.coverImage(), l.videoUrl(), l.readTimeMinutes(),
+                            l.isPremium(),
+                            false);
+                })
                 .toList();
     }
 }

--- a/src/main/java/com/passtheo/content/dto/response/LessonDto.java
+++ b/src/main/java/com/passtheo/content/dto/response/LessonDto.java
@@ -4,6 +4,18 @@ import java.util.List;
 
 /**
  * Lesson response DTO.
+ *
+ * @param title           lesson title (localized)
+ * @param slug            stable lesson slug (not localized)
+ * @param sections        structured sections — empty when {@code locked=true}
+ * @param summary         short summary — null when {@code locked=true}
+ * @param coverImage      cover image URL — null when {@code locked=true}
+ * @param videoUrl        optional video URL — null when {@code locked=true}
+ * @param readTimeMinutes estimated reading time
+ * @param isPremium       true if the lesson is flagged premium in Strapi
+ * @param locked          true if content was stripped for the calling user
+ *                        (free tier tapping a premium lesson) — client renders
+ *                        a lock and opens the upgrade paywall
  */
 public record LessonDto(
     String title,
@@ -12,11 +24,20 @@ public record LessonDto(
     String summary,
     String coverImage,
     String videoUrl,
-    Integer readTimeMinutes
+    Integer readTimeMinutes,
+    boolean isPremium,
+    boolean locked
 ) {
 
     /**
      * A structured section within a lesson.
+     *
+     * @param heading             section heading
+     * @param body                section body text
+     * @param tip                 optional tip callout
+     * @param keyRule             optional key rule summary
+     * @param relatedRoadSignCode optional related road sign reference
+     * @param sortOrder           display sort order
      */
     public record LessonSectionDto(
         String heading,
@@ -25,5 +46,5 @@ public record LessonDto(
         String keyRule,
         String relatedRoadSignCode,
         Integer sortOrder
-    ) {}
+    ) { }
 }

--- a/src/main/java/com/passtheo/content/service/LessonProgressService.java
+++ b/src/main/java/com/passtheo/content/service/LessonProgressService.java
@@ -12,6 +12,7 @@ import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiLessonDto;
 import com.passtheo.content.repository.LessonProgressRepository;
 import com.passtheo.shared.core.context.TenantContext;
+import com.passtheo.shared.core.exception.AccessDeniedException;
 import com.passtheo.shared.core.exception.AppException;
 import com.passtheo.shared.core.exception.ErrorCode;
 import com.passtheo.shared.events.config.KafkaTopic;
@@ -56,6 +57,7 @@ public class LessonProgressService {
     private final AchievementService achievementService;
     private final OutboxEventRepository outboxEventRepository;
     private final StrapiContentCache strapiContentCache;
+    private final EntitlementChecker entitlementChecker;
     private final ObjectMapper objectMapper;
 
     /**
@@ -66,6 +68,7 @@ public class LessonProgressService {
      * @param achievementService       achievement service
      * @param outboxEventRepository    outbox event repository
      * @param strapiContentCache       Strapi content cache (for lesson validation)
+     * @param entitlementChecker       access grant lookup (for premium lesson gate)
      * @param objectMapper             JSON object mapper (Spring-configured with JavaTimeModule)
      */
     public LessonProgressService(LessonProgressRepository lessonProgressRepository,
@@ -73,12 +76,14 @@ public class LessonProgressService {
                                  AchievementService achievementService,
                                  OutboxEventRepository outboxEventRepository,
                                  StrapiContentCache strapiContentCache,
+                                 EntitlementChecker entitlementChecker,
                                  ObjectMapper objectMapper) {
         this.lessonProgressRepository = lessonProgressRepository;
         this.xpService = xpService;
         this.achievementService = achievementService;
         this.outboxEventRepository = outboxEventRepository;
         this.strapiContentCache = strapiContentCache;
+        this.entitlementChecker = entitlementChecker;
         this.objectMapper = objectMapper;
     }
 
@@ -102,7 +107,10 @@ public class LessonProgressService {
                                                  @Nonnull String productCode,
                                                  @Nonnull String topicCode,
                                                  int timeSpentSeconds) {
-        validateLessonExists(topicCode, lessonSlug);
+        StrapiLessonDto lesson = resolveLesson(topicCode, lessonSlug);
+        if (lesson.isPremium() && !entitlementChecker.getAccess(TenantContext.get(), userId).isPaid()) {
+            throw new AccessDeniedException("Premium subscription required to complete this lesson");
+        }
 
         Optional<LessonProgress> existing = lessonProgressRepository
                 .findByKeycloakUserIdAndProductCodeAndLessonSlug(userId, productCode, lessonSlug);
@@ -211,12 +219,17 @@ public class LessonProgressService {
                 .toList();
     }
 
-    private void validateLessonExists(String topicCode, String lessonSlug) {
+    private StrapiLessonDto resolveLesson(String topicCode, String lessonSlug) {
         List<StrapiLessonDto> lessons = strapiContentCache.getLessons(topicCode, CANONICAL_LOCALE);
-        if (lessons == null || lessons.stream().noneMatch(l -> lessonSlug.equals(l.slug()))) {
-            throw new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR,
-                    "Lesson not found: topicCode=" + topicCode + ", lessonSlug=" + lessonSlug);
+        if (lessons != null) {
+            for (StrapiLessonDto l : lessons) {
+                if (lessonSlug.equals(l.slug())) {
+                    return l;
+                }
+            }
         }
+        throw new AppException(HttpStatus.NOT_FOUND, ErrorCode.VALIDATION_ERROR,
+                "Lesson not found: topicCode=" + topicCode + ", lessonSlug=" + lessonSlug);
     }
 
     private void publishLessonCompletedEvent(UUID tenantId, UUID userId,

--- a/src/test/java/com/passtheo/content/unit/LessonProgressServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/LessonProgressServiceTest.java
@@ -9,9 +9,12 @@ import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiLessonDto;
 import com.passtheo.content.repository.LessonProgressRepository;
 import com.passtheo.content.service.AchievementService;
+import com.passtheo.content.service.EntitlementChecker;
 import com.passtheo.content.service.LessonProgressService;
 import com.passtheo.content.service.XpService;
 import com.passtheo.shared.core.context.TenantContext;
+import com.passtheo.shared.core.dto.AccessGrant;
+import com.passtheo.shared.core.exception.AccessDeniedException;
 import com.passtheo.shared.core.exception.AppException;
 import com.passtheo.shared.outbox.entity.OutboxEvent;
 import com.passtheo.shared.outbox.repository.OutboxEventRepository;
@@ -53,6 +56,7 @@ class LessonProgressServiceTest {
     @Mock private AchievementService achievementService;
     @Mock private OutboxEventRepository outboxEventRepository;
     @Mock private StrapiContentCache strapiContentCache;
+    @Mock private EntitlementChecker entitlementChecker;
 
     private LessonProgressService service;
 
@@ -64,15 +68,18 @@ class LessonProgressServiceTest {
                         .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
         service = new LessonProgressService(
                 lessonProgressRepository, xpService, achievementService, outboxEventRepository,
-                strapiContentCache, realMapper);
+                strapiContentCache, entitlementChecker, realMapper);
 
-        // Default: every lesson slug is valid. Tests that need to assert invalid
-        // slugs override this stub. Lenient because some tests (e.g., getProgress
-        // queries) don't exercise the validation path.
+        // Default: every lesson slug is valid and non-premium. Tests that need different
+        // content override this stub. Lenient because some tests (getProgress, uncomplete)
+        // don't exercise the validation path.
         lenient().when(strapiContentCache.getLessons(any(), any()))
                 .thenReturn(List.of(
                         new StrapiLessonDto(1, "doc-1", "Voorrangsbord uitleg", SLUG,
                                 List.of(), null, null, null, 0, true, false, 0)));
+        // Default: paid access. Premium-gate tests override with AccessGrant.free().
+        lenient().when(entitlementChecker.getAccess(any(), any()))
+                .thenReturn(new AccessGrant(true, "MONTH_1", "ACTIVE", null));
     }
 
     @AfterEach
@@ -90,6 +97,39 @@ class LessonProgressServiceTest {
                 .hasMessageContaining("Lesson not found");
 
         verifyNoInteractions(lessonProgressRepository, xpService, achievementService, outboxEventRepository);
+    }
+
+    @Test
+    void completeLesson_premiumLessonWithFreeTier_throws403() {
+        when(strapiContentCache.getLessons(TOPIC, "nl")).thenReturn(List.of(
+                new StrapiLessonDto(2, "doc-2", "Premium lesson", SLUG,
+                        List.of(), null, null, null, 0, true, true, 0)));
+        when(entitlementChecker.getAccess(TENANT_ID, USER_ID)).thenReturn(AccessGrant.free());
+
+        assertThatThrownBy(() ->
+                service.completeLesson(USER_ID, SLUG, PRODUCT, TOPIC, 60))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Premium subscription required");
+
+        verifyNoInteractions(lessonProgressRepository, xpService, achievementService, outboxEventRepository);
+    }
+
+    @Test
+    void completeLesson_premiumLessonWithPaidTier_succeeds() {
+        when(strapiContentCache.getLessons(TOPIC, "nl")).thenReturn(List.of(
+                new StrapiLessonDto(2, "doc-2", "Premium lesson", SLUG,
+                        List.of(), null, null, null, 0, true, true, 0)));
+        when(lessonProgressRepository.findByKeycloakUserIdAndProductCodeAndLessonSlug(USER_ID, PRODUCT, SLUG))
+                .thenReturn(Optional.empty());
+        when(achievementService.checkAchievements(USER_ID, PRODUCT)).thenReturn(List.of());
+        when(xpService.grantXp(eq(USER_ID), eq(PRODUCT), anyInt()))
+                .thenReturn(new XpResult(20, 20, 1, 100, false, 1));
+
+        LessonCompleteResponse response = service.completeLesson(USER_ID, SLUG, PRODUCT, TOPIC, 90);
+
+        assertThat(response.isCompleted()).isTrue();
+        assertThat(response.xpUpdate().xpEarned()).isEqualTo(20);
+        verify(lessonProgressRepository).save(any());
     }
 
     @Test

--- a/src/test/resources/karate/content-hierarchy.feature
+++ b/src/test/resources/karate/content-hierarchy.feature
@@ -110,27 +110,36 @@ Feature: Content Hierarchy Browsing
 
   # ─── LESSON PREMIUM GATE (P0.5) ───
 
+  # Seeded Strapi fixture invariant: 'verbodsborden' contains at least one
+  # premium lesson AND at least one non-premium lesson — required so the
+  # free-tier scenario below can exercise both branches of the strip logic.
+  # If a future reseed of Strapi breaks this invariant, add a @Seed step
+  # that POSTs a known-premium lesson via Strapi admin before the scenario.
+
   Scenario: Paid user sees full content on every lesson regardless of isPremium
-    Given path '/api/content/lessons/voorrangsborden'
+    Given path '/api/content/lessons/verbodsborden'
     And headers paidHeaders
     When method GET
     Then status 200
     And match response.success == true
-    And match each response.data contains { locked: false }
-    # Every lesson exposes the two flags
+    # Schema invariant — all lessons expose the two flags
     And match each response.data contains { isPremium: '#boolean', locked: '#boolean' }
+    # Paid users are never locked
+    And match each response.data contains { locked: false }
 
   Scenario: Free user sees locked lessons with stripped content when premium
-    Given path '/api/content/lessons/voorrangsborden'
+    Given path '/api/content/lessons/verbodsborden'
     And headers freeHeaders
     When method GET
     Then status 200
     And match response.success == true
     # Schema invariant — all lessons expose the two flags
     And match each response.data contains { isPremium: '#boolean', locked: '#boolean' }
-    # And any locked lesson has empty sections (content stripped)
+    # Seed fixture must contain at least one premium lesson — assert, don't skip.
     * def lockedLessons = response.data.findAll(function(l){ return l.locked == true })
-    * if (lockedLessons.length > 0) karate.match(lockedLessons[0].sections, '#[0]')
+    And assert lockedLessons.length >= 1
+    # Every locked lesson has stripped content
+    And match each lockedLessons contains { sections: '#[0]', summary: '##null', coverImage: '##null', videoUrl: '##null' }
 
   Scenario: Content supports locale parameter
     Given path '/api/content/NL/cbr/auto-b/domains'

--- a/src/test/resources/karate/content-hierarchy.feature
+++ b/src/test/resources/karate/content-hierarchy.feature
@@ -108,6 +108,30 @@ Feature: Content Hierarchy Browsing
     Then status 200
     And match response.data == '#[]'
 
+  # ─── LESSON PREMIUM GATE (P0.5) ───
+
+  Scenario: Paid user sees full content on every lesson regardless of isPremium
+    Given path '/api/content/lessons/voorrangsborden'
+    And headers paidHeaders
+    When method GET
+    Then status 200
+    And match response.success == true
+    And match each response.data contains { locked: false }
+    # Every lesson exposes the two flags
+    And match each response.data contains { isPremium: '#boolean', locked: '#boolean' }
+
+  Scenario: Free user sees locked lessons with stripped content when premium
+    Given path '/api/content/lessons/voorrangsborden'
+    And headers freeHeaders
+    When method GET
+    Then status 200
+    And match response.success == true
+    # Schema invariant — all lessons expose the two flags
+    And match each response.data contains { isPremium: '#boolean', locked: '#boolean' }
+    # And any locked lesson has empty sections (content stripped)
+    * def lockedLessons = response.data.findAll(function(l){ return l.locked == true })
+    * if (lockedLessons.length > 0) karate.match(lockedLessons[0].sections, '#[0]')
+
   Scenario: Content supports locale parameter
     Given path '/api/content/NL/cbr/auto-b/domains'
     And headers paidHeaders


### PR DESCRIPTION
Closes #87

## Changes
- `LessonDto` adds `isPremium` + `locked` fields
- `ContentController.listLessonsByTopic` and `listLessons` now accept `X-Keycloak-User-ID` / `X-Tenant-ID`, resolve access via `EntitlementChecker`, and strip content (`sections: []`, null media) for premium lessons when the caller is on the free tier
- `LessonProgressService.completeLesson` throws `AccessDeniedException` on premium+free
- OpenAPI 3.1 spec updated first — new DTO fields, `UserHeader` parameter on both list endpoints, paywall narrative in the description
- Karate `content-hierarchy.feature` adds 2 scenarios for the DTO shape (paid vs free)
- `LessonProgressServiceTest` adds 2 new cases

## Test plan
- [x] `./gradlew test` — green
- [ ] `./gradlew acceptanceTest` — run against docker-compose stack (needs Strapi seed with at least one premium lesson to fully exercise the free-tier strip path)
- [ ] Manual: free user hits `/api/content/lessons/{topicCode}` → premium rows have `locked: true` + empty `sections`; paid user gets full content

## Checkstyle note
`./gradlew build` fails because of ~985 pre-existing checkstyle violations on develop across unrelated files (`StrapiLessonDto`, `InternalContentController`, etc.). My code is clean on checkstyle — the only errors on `ContentController.java` are on the pre-existing `listRoadSigns` method I did not touch. Flagging the develop state for a separate housekeeping issue; `./gradlew test` passes for this PR.

## Cross-Service Links
- passtheo/passtheo-ui#TBD — Flutter renders `locked` cards with the existing upgrade paywall