### PR TITLE
fix(content): reconcile study-plan examDate on read against user-service profile

### DIFF
--- a/open-api/passtheo-content-service-openapi.yaml
+++ b/open-api/passtheo-content-service-openapi.yaml
@@ -1122,6 +1122,14 @@ paths:
       operationId: getActiveStudyPlan
       tags: [StudyPlan]
       summary: Get current active study plan
+      description: |
+        Returns the user's active study plan. The service self-heals if the
+        stored plan's `examDate` has drifted from the authoritative
+        `UserProfile.examDate` in user-service (e.g., a `UserExamDateSet`
+        event was lost): it transparently regenerates the plan and returns
+        the fresh one. If user-service is unreachable at read time, the
+        stored plan is returned unchanged — drift detection never fails
+        the request.
       security:
         - bearerAuth: []
       parameters:
@@ -1134,7 +1142,7 @@ paths:
             type: string
       responses:
         '200':
-          description: Active study plan with today's tasks
+          description: Active study plan with today's tasks (reconciled against user-service examDate)
           content:
             application/json:
               schema:

--- a/src/main/java/com/passtheo/content/kafka/consumer/UserEventConsumer.java
+++ b/src/main/java/com/passtheo/content/kafka/consumer/UserEventConsumer.java
@@ -13,6 +13,7 @@ import com.passtheo.content.repository.StreakRepository;
 import com.passtheo.content.repository.StudyPlanRepository;
 import com.passtheo.content.repository.TopicProgressRepository;
 import com.passtheo.content.service.StudyPlanService;
+import com.passtheo.shared.core.client.UserServiceInternalClient;
 import com.passtheo.shared.core.context.TenantContext;
 import com.passtheo.shared.events.config.KafkaTopic;
 import jakarta.annotation.Nonnull;
@@ -49,6 +50,7 @@ public class UserEventConsumer {
     private final ReadinessSnapshotRepository snapshotRepository;
     private final StudyPlanRepository planRepository;
     private final StudyPlanService studyPlanService;
+    private final UserServiceInternalClient userServiceClient;
 
     /**
      * Constructs the user event consumer.
@@ -63,6 +65,7 @@ public class UserEventConsumer {
      * @param snapshotRepository       readiness snapshot repository
      * @param planRepository           study plan repository
      * @param studyPlanService         study plan service for auto-generation
+     * @param userServiceClient        user-service client (used to evict the profile cache on exam date change)
      */
     public UserEventConsumer(ObjectMapper objectMapper,
                              QuestionProgressRepository progressRepository,
@@ -73,7 +76,8 @@ public class UserEventConsumer {
                              ExamAttemptRepository examAttemptRepository,
                              ReadinessSnapshotRepository snapshotRepository,
                              StudyPlanRepository planRepository,
-                             StudyPlanService studyPlanService) {
+                             StudyPlanService studyPlanService,
+                             UserServiceInternalClient userServiceClient) {
         this.objectMapper = objectMapper;
         this.progressRepository = progressRepository;
         this.topicProgressRepository = topicProgressRepository;
@@ -84,6 +88,7 @@ public class UserEventConsumer {
         this.snapshotRepository = snapshotRepository;
         this.planRepository = planRepository;
         this.studyPlanService = studyPlanService;
+        this.userServiceClient = userServiceClient;
     }
 
     /**
@@ -188,6 +193,10 @@ public class UserEventConsumer {
 
         LOG.info("Regenerating study plan for exam date change: userId={}, productCode={}, examDate={}",
                 keycloakUserId, productCode, examDate);
+        // Drop any stale cached profile so getActivePlan's reconciliation path and
+        // generatePlan's own fallback branch both observe the freshly-changed examDate
+        // rather than a pre-change value cached up to 5 minutes in Redis.
+        userServiceClient.evictCache(keycloakUserId, tenantId);
         TenantContext.set(tenantId);
         try {
             studyPlanService.generatePlan(keycloakUserId,

--- a/src/main/java/com/passtheo/content/service/StudyPlanService.java
+++ b/src/main/java/com/passtheo/content/service/StudyPlanService.java
@@ -363,14 +363,24 @@ public class StudyPlanService {
                 .orElse(null);
 
         if (profileExamDate != null && !Objects.equals(plan.getExamDate(), profileExamDate)) {
-            LOG.warn("study plan examDate drift detected: userId={} productCode={} planExamDate={} "
+            LOG.warn("Study plan examDate drift detected: userId={} productCode={} planExamDate={} "
                             + "profileExamDate={}, regenerating",
                     userId, productCode, plan.getExamDate(), profileExamDate);
             driftCounter(productCode, TenantContext.get()).increment();
-            generatePlan(userId,
-                    new GenerateStudyPlanRequest(productCode, profileExamDate, null),
-                    RECONCILE_DEFAULT_LOCALE);
-            plan = loadActivePlan(userId, productCode);
+            // Fail-soft: if regeneration throws (Strapi unreachable, readiness transient error,
+            // DB contention), return the stored plan rather than failing the whole read. The
+            // drift is recorded in the metric; the Kafka consumer path and the next GET will
+            // retry. A stale examDate is a better user-facing outcome than a 500.
+            try {
+                generatePlan(userId,
+                        new GenerateStudyPlanRequest(productCode, profileExamDate, null),
+                        RECONCILE_DEFAULT_LOCALE);
+                plan = loadActivePlan(userId, productCode);
+            } catch (RuntimeException e) {
+                LOG.warn("Failed to reconcile stale study plan, returning stored plan unchanged: "
+                                + "userId={} productCode={} error={}",
+                        userId, productCode, e.toString());
+            }
         }
 
         return loadActivePlanWithDays(plan);

--- a/src/main/java/com/passtheo/content/service/StudyPlanService.java
+++ b/src/main/java/com/passtheo/content/service/StudyPlanService.java
@@ -13,6 +13,7 @@ import com.passtheo.content.dto.request.GenerateStudyPlanRequest;
 import com.passtheo.content.dto.response.StudyPlanDayDto;
 import com.passtheo.content.dto.response.StudyPlanDto;
 import com.passtheo.shared.core.client.UserServiceInternalClient;
+import com.passtheo.shared.core.dto.InternalUserProfileDto;
 import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.integration.strapi.dto.StrapiDomainDto;
 import com.passtheo.content.repository.QuestionProgressRepository;
@@ -21,6 +22,8 @@ import com.passtheo.content.repository.StudyPlanRepository;
 import com.passtheo.shared.core.context.TenantContext;
 import com.passtheo.shared.core.exception.AppException;
 import com.passtheo.shared.core.exception.ErrorCode;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.http.HttpStatus;
 import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -37,6 +40,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -66,6 +70,7 @@ public class StudyPlanService {
     private final ObjectMapper objectMapper;
     private final UserServiceInternalClient userServiceClient;
     private final QuestionProgressRepository progressRepository;
+    private final MeterRegistry meterRegistry;
 
     /**
      * Constructs the study plan service.
@@ -77,6 +82,7 @@ public class StudyPlanService {
      * @param objectMapper       JSON serializer
      * @param userServiceClient  user-service client for exam date fallback
      * @param progressRepository question progress repository for mastered count
+     * @param meterRegistry      Micrometer registry for drift-detection counter
      */
     public StudyPlanService(StudyPlanRepository planRepository,
                             StudyPlanDayRepository planDayRepository,
@@ -84,7 +90,8 @@ public class StudyPlanService {
                             StrapiContentCache strapiContentCache,
                             ObjectMapper objectMapper,
                             UserServiceInternalClient userServiceClient,
-                            QuestionProgressRepository progressRepository) {
+                            QuestionProgressRepository progressRepository,
+                            MeterRegistry meterRegistry) {
         this.planRepository = planRepository;
         this.planDayRepository = planDayRepository;
         this.readinessService = readinessService;
@@ -92,6 +99,7 @@ public class StudyPlanService {
         this.objectMapper = objectMapper;
         this.userServiceClient = userServiceClient;
         this.progressRepository = progressRepository;
+        this.meterRegistry = meterRegistry;
     }
 
     /**
@@ -310,28 +318,89 @@ public class StudyPlanService {
                 });
     }
 
+    /** Default locale used when reconciliation inline-regenerates via the same path as the Kafka consumer. */
+    private static final String RECONCILE_DEFAULT_LOCALE = "nl";
+
     /**
-     * Gets the active study plan for a user/product.
+     * Gets the active study plan for a user/product, self-healing on
+     * {@code examDate} drift.
+     *
+     * <p>The user-service owns the authoritative exam date via
+     * {@code UserProfile.examDate}. When that value changes, the Kafka
+     * pipeline ({@code UserExamDateSet} → {@code UserEventConsumer} →
+     * {@link #generatePlan}) is expected to regenerate the plan. If that
+     * pipeline silently fails (consumer exception without ack, Strapi/
+     * readiness unreachable, productCode mismatch, seeded fixture data),
+     * the stored plan's {@code examDate} will diverge from the profile.
+     *
+     * <p>This method reconciles on read: if the stored {@code examDate}
+     * differs from the profile's non-null {@code examDate}, it logs a
+     * WARN, increments the {@code passtheo_study_plan_drift_detected_total}
+     * counter, and regenerates the plan inline via the same
+     * {@link #generatePlan} path the Kafka consumer uses. The request
+     * then returns the freshly-regenerated plan.
+     *
+     * <p>If user-service is unreachable or returns a profile with a null
+     * examDate, the stored plan is returned unchanged — drift detection
+     * must never fail the request.
+     *
+     * <p>This method is intentionally not {@code @Transactional}: it
+     * orchestrates one read ({@link #loadActivePlan}), an HTTP call, an
+     * optional write ({@link #generatePlan}, which carries its own
+     * write transaction), and a final read ({@link #loadActivePlanWithDays}).
+     * Mixing a readOnly outer transaction with the inner write is a
+     * deliberate anti-pattern we avoid here.
      *
      * @param userId      the user's Keycloak ID
      * @param productCode the product code
-     * @return the active plan, or throws if none
+     * @return the active plan (reconciled when drift detected)
      */
-    @Transactional(readOnly = true)
     public StudyPlanDto getActivePlan(@Nonnull UUID userId, @Nonnull String productCode) {
-        StudyPlan plan = planRepository.findByKeycloakUserIdAndProductCodeAndStatus(
+        StudyPlan plan = loadActivePlan(userId, productCode);
+
+        LocalDate profileExamDate = userServiceClient.getProfile(userId, TenantContext.get())
+                .map(InternalUserProfileDto::examDate)
+                .orElse(null);
+
+        if (profileExamDate != null && !Objects.equals(plan.getExamDate(), profileExamDate)) {
+            LOG.warn("study plan examDate drift detected: userId={} productCode={} planExamDate={} "
+                            + "profileExamDate={}, regenerating",
+                    userId, productCode, plan.getExamDate(), profileExamDate);
+            driftCounter(productCode, TenantContext.get()).increment();
+            generatePlan(userId,
+                    new GenerateStudyPlanRequest(productCode, profileExamDate, null),
+                    RECONCILE_DEFAULT_LOCALE);
+            plan = loadActivePlan(userId, productCode);
+        }
+
+        return loadActivePlanWithDays(plan);
+    }
+
+    @Transactional(readOnly = true)
+    public StudyPlan loadActivePlan(@Nonnull UUID userId, @Nonnull String productCode) {
+        return planRepository.findByKeycloakUserIdAndProductCodeAndStatus(
                         userId, productCode, PlanStatus.ACTIVE)
-                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, ErrorCode.PLAN_NOT_FOUND, "No active study plan found"));
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, ErrorCode.PLAN_NOT_FOUND,
+                        "No active study plan found"));
+    }
 
+    @Transactional(readOnly = true)
+    public StudyPlanDto loadActivePlanWithDays(@Nonnull StudyPlan plan) {
         List<StudyPlanDay> days = planDayRepository.findByPlanIdOrderByDayNumberAsc(plan.getId());
-
         LocalDate today = LocalDate.now(ZoneOffset.UTC);
         int currentDay = days.stream()
                 .filter(d -> !d.getPlanDate().isAfter(today))
                 .mapToInt(StudyPlanDay::getDayNumber)
                 .max().orElse(1);
-
         return toPlanDto(plan, days, currentDay);
+    }
+
+    private Counter driftCounter(String productCode, UUID tenantId) {
+        return Counter.builder("passtheo_study_plan_drift_detected_total")
+                .description("Count of GET /api/study-plan calls that detected and auto-repaired a stale plan examDate")
+                .tag("productCode", productCode == null ? "unknown" : productCode)
+                .tag("tenantId", tenantId == null ? "unknown" : tenantId.toString())
+                .register(meterRegistry);
     }
 
     /**

--- a/src/test/java/com/passtheo/content/KarateRunner.java
+++ b/src/test/java/com/passtheo/content/KarateRunner.java
@@ -1,6 +1,7 @@
 package com.passtheo.content;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.intuit.karate.junit5.Karate;
 import com.passtheo.content.config.TestSchedulingConfig;
@@ -98,6 +99,66 @@ class KarateRunner {
         runFlywayMigrations();
         seedRedisEntitlements();
         configureStrapiMocks();
+        configureUserServiceMocks();
+    }
+
+    /**
+     * Registers priority-1 WireMock stubs per user for deterministic
+     * {@code GET /internal/users/{id}/profile} responses.
+     *
+     * <p>Why this exists: the file-based contract stubs in
+     * {@code contracts/user-service/mappings/} share a URL pattern that
+     * matches <em>any</em> UUID, so without explicit per-user priority
+     * the 200/404 stubs win non-deterministically — which quietly changes
+     * {@code computePlan}'s fallback behaviour between runs and breaks
+     * tests that assert a specific {@code totalDays} or {@code examDate}.
+     *
+     * <p>Two users get explicit behaviour:
+     * <ul>
+     *   <li>{@code 33333333-...} (paidUser) → 404: the default-30-days test
+     *       and other paid-user scenarios were written against "no profile"
+     *       fallback; pin that behaviour here.
+     *   <li>{@code 44444444-...} (drift test only) → verified profile with
+     *       {@code examDate=2026-05-15}: required by the reconcile-on-read
+     *       drift scenario.
+     * </ul>
+     */
+    private void configureUserServiceMocks() {
+        USER_SERVICE_MOCK.stubFor(WireMock.get(WireMock.urlPathEqualTo(
+                        "/internal/users/33333333-3333-3333-3333-333333333333/profile"))
+                .atPriority(1)
+                .willReturn(WireMock.aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", "application/problem+json")
+                        .withBody("""
+                                {
+                                  "type": "https://api.passtheo.nl/errors/user-not-found",
+                                  "title": "User not found",
+                                  "status": 404,
+                                  "detail": "User not found: 33333333-3333-3333-3333-333333333333"
+                                }
+                                """)));
+
+        String driftUserVerifiedBody = """
+                {
+                  "success": true,
+                  "data": {
+                    "keycloakUserId": "44444444-4444-4444-4444-444444444444",
+                    "email": "drift-test@example.com",
+                    "emailVerified": true,
+                    "emailVerifiedAt": "2026-03-01T10:00:00Z",
+                    "examDate": "2026-05-15",
+                    "tenantId": "11111111-1111-1111-1111-111111111111"
+                  }
+                }
+                """;
+        USER_SERVICE_MOCK.stubFor(WireMock.get(WireMock.urlPathEqualTo(
+                        "/internal/users/44444444-4444-4444-4444-444444444444/profile"))
+                .atPriority(1)
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(driftUserVerifiedBody)));
     }
 
     private void runFlywayMigrations() {

--- a/src/test/java/com/passtheo/content/unit/StudyPlanServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/StudyPlanServiceTest.java
@@ -14,10 +14,15 @@ import com.passtheo.content.integration.strapi.StrapiContentCache;
 import com.passtheo.content.repository.QuestionProgressRepository;
 import com.passtheo.content.repository.StudyPlanDayRepository;
 import com.passtheo.content.repository.StudyPlanRepository;
+import com.passtheo.content.domain.entity.StudyPlan;
+import com.passtheo.content.domain.enums.PlanStatus;
 import com.passtheo.content.service.ReadinessService;
 import com.passtheo.content.service.StudyPlanService;
 import com.passtheo.shared.core.client.UserServiceInternalClient;
 import com.passtheo.shared.core.context.TenantContext;
+import com.passtheo.shared.core.dto.InternalUserProfileDto;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,6 +42,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -60,15 +66,18 @@ class StudyPlanServiceTest {
     @Mock private QuestionProgressRepository progressRepository;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private MeterRegistry meterRegistry;
 
     private StudyPlanService service;
 
     @BeforeEach
     void setUp() {
         TenantContext.set(TENANT_ID);
+        meterRegistry = new SimpleMeterRegistry();
         service = new StudyPlanService(
                 planRepository, planDayRepository, readinessService,
-                strapiContentCache, objectMapper, userServiceClient, progressRepository);
+                strapiContentCache, objectMapper, userServiceClient, progressRepository,
+                meterRegistry);
 
         ExamConfidence.Breakdown breakdown = new ExamConfidence.Breakdown(
                 0, 0, 0, 0, 0, false, false, 0, List.of());
@@ -211,5 +220,153 @@ class StudyPlanServiceTest {
 
         assertThat(preview.totalDays()).isEqualTo(30);
         assertThat(preview.dailyQuestionTarget()).isEqualTo(20);
+    }
+
+    // ─── getActivePlan: reconcile-on-read against user-service examDate ───
+
+    private StudyPlan fakeActivePlan(LocalDate planExamDate) {
+        StudyPlan plan = new StudyPlan();
+        plan.setId(UUID.randomUUID());
+        plan.setTenantId(TENANT_ID);
+        plan.setKeycloakUserId(USER_ID);
+        plan.setProductCode(PRODUCT);
+        plan.setExamDate(planExamDate);
+        plan.setTotalDays(30);
+        plan.setStatus(PlanStatus.ACTIVE);
+        plan.setDailyQuestionTarget(20);
+        plan.setFocusDomains("[]");
+        return plan;
+    }
+
+    private InternalUserProfileDto fakeProfile(LocalDate examDate) {
+        return new InternalUserProfileDto(
+                USER_ID, "test@example.com", true,
+                java.time.Instant.parse("2026-01-01T00:00:00Z"),
+                examDate, TENANT_ID);
+    }
+
+    @Test
+    void getActivePlan_planExamDateMatchesProfile_returnsExistingPlanWithoutRegenerating() {
+        LocalDate examDate = LocalDate.of(2026, 6, 1);
+        StudyPlan existing = fakeActivePlan(examDate);
+        when(planRepository.findByKeycloakUserIdAndProductCodeAndStatus(
+                eq(USER_ID), eq(PRODUCT), eq(PlanStatus.ACTIVE)))
+                .thenReturn(Optional.of(existing));
+        when(userServiceClient.getProfile(eq(USER_ID), eq(TENANT_ID)))
+                .thenReturn(Optional.of(fakeProfile(examDate)));
+        when(planDayRepository.findByPlanIdOrderByDayNumberAsc(existing.getId()))
+                .thenReturn(List.of());
+
+        StudyPlanDto result = service.getActivePlan(USER_ID, PRODUCT);
+
+        assertThat(result.planId()).isEqualTo(existing.getId());
+        assertThat(result.examDate()).isEqualTo(examDate);
+        verify(planRepository, never()).save(any());
+        verify(planRepository, never()).saveAndFlush(any());
+        assertThat(meterRegistry.find("passtheo_study_plan_drift_detected_total").counter()).isNull();
+    }
+
+    @Test
+    void getActivePlan_planExamDateDiffersFromProfile_regeneratesAndReturnsRefreshedPlan() {
+        LocalDate stalePlanDate = LocalDate.of(2030, 12, 31);
+        LocalDate profileExamDate = LocalDate.of(2026, 6, 1);
+        StudyPlan stale = fakeActivePlan(stalePlanDate);
+        StudyPlan refreshed = fakeActivePlan(profileExamDate);
+
+        // First call returns stale; after regeneration the second call returns refreshed.
+        when(planRepository.findByKeycloakUserIdAndProductCodeAndStatus(
+                eq(USER_ID), eq(PRODUCT), eq(PlanStatus.ACTIVE)))
+                .thenReturn(Optional.of(stale))
+                .thenReturn(Optional.of(stale))  // generatePlan's own pre-deactivate lookup
+                .thenReturn(Optional.of(refreshed));  // post-regeneration reload
+        when(userServiceClient.getProfile(eq(USER_ID), eq(TENANT_ID)))
+                .thenReturn(Optional.of(fakeProfile(profileExamDate)));
+        when(planRepository.save(any())).thenAnswer(i -> {
+            StudyPlan p = i.getArgument(0);
+            if (p.getId() == null) p.setId(UUID.randomUUID());
+            return p;
+        });
+        when(planDayRepository.findByPlanIdOrderByDayNumberAsc(any()))
+                .thenReturn(List.of());
+
+        StudyPlanDto result = service.getActivePlan(USER_ID, PRODUCT);
+
+        // generatePlan was called: it abandons the stale via saveAndFlush and saves the new plan.
+        verify(planRepository, times(1)).saveAndFlush(any());
+        verify(planRepository, times(1)).save(any());
+        assertThat(result.examDate()).isEqualTo(profileExamDate);
+    }
+
+    @Test
+    void getActivePlan_userProfileUnavailable_returnsStoredPlanUnchanged() {
+        LocalDate planExamDate = LocalDate.of(2026, 6, 1);
+        StudyPlan existing = fakeActivePlan(planExamDate);
+        when(planRepository.findByKeycloakUserIdAndProductCodeAndStatus(
+                eq(USER_ID), eq(PRODUCT), eq(PlanStatus.ACTIVE)))
+                .thenReturn(Optional.of(existing));
+        when(userServiceClient.getProfile(eq(USER_ID), eq(TENANT_ID)))
+                .thenReturn(Optional.empty());
+        when(planDayRepository.findByPlanIdOrderByDayNumberAsc(existing.getId()))
+                .thenReturn(List.of());
+
+        StudyPlanDto result = service.getActivePlan(USER_ID, PRODUCT);
+
+        assertThat(result.planId()).isEqualTo(existing.getId());
+        assertThat(result.examDate()).isEqualTo(planExamDate);
+        verify(planRepository, never()).save(any());
+        verify(planRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void getActivePlan_profileExamDateNull_doesNotRegenerate() {
+        // User cleared their exam date in user-service but the content-service still has an active plan
+        // (e.g. UserExamDateCleared lost). Conservative behavior: do NOT regenerate to a null examDate
+        // — return the stored plan as-is. The UserExamDateCleared consumer path is the authoritative
+        // way to abandon a plan on exam-date-cleared.
+        LocalDate planExamDate = LocalDate.of(2026, 6, 1);
+        StudyPlan existing = fakeActivePlan(planExamDate);
+        when(planRepository.findByKeycloakUserIdAndProductCodeAndStatus(
+                eq(USER_ID), eq(PRODUCT), eq(PlanStatus.ACTIVE)))
+                .thenReturn(Optional.of(existing));
+        when(userServiceClient.getProfile(eq(USER_ID), eq(TENANT_ID)))
+                .thenReturn(Optional.of(fakeProfile(null)));
+        when(planDayRepository.findByPlanIdOrderByDayNumberAsc(existing.getId()))
+                .thenReturn(List.of());
+
+        StudyPlanDto result = service.getActivePlan(USER_ID, PRODUCT);
+
+        assertThat(result.planId()).isEqualTo(existing.getId());
+        verify(planRepository, never()).save(any());
+        verify(planRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void getActivePlan_driftDetected_incrementsDriftCounterExactlyOnce() {
+        LocalDate stalePlanDate = LocalDate.of(2030, 12, 31);
+        LocalDate profileExamDate = LocalDate.of(2026, 6, 1);
+        StudyPlan stale = fakeActivePlan(stalePlanDate);
+        StudyPlan refreshed = fakeActivePlan(profileExamDate);
+
+        when(planRepository.findByKeycloakUserIdAndProductCodeAndStatus(
+                eq(USER_ID), eq(PRODUCT), eq(PlanStatus.ACTIVE)))
+                .thenReturn(Optional.of(stale))
+                .thenReturn(Optional.of(stale))
+                .thenReturn(Optional.of(refreshed));
+        when(userServiceClient.getProfile(eq(USER_ID), eq(TENANT_ID)))
+                .thenReturn(Optional.of(fakeProfile(profileExamDate)));
+        when(planRepository.save(any())).thenAnswer(i -> {
+            StudyPlan p = i.getArgument(0);
+            if (p.getId() == null) p.setId(UUID.randomUUID());
+            return p;
+        });
+        when(planDayRepository.findByPlanIdOrderByDayNumberAsc(any()))
+                .thenReturn(List.of());
+
+        service.getActivePlan(USER_ID, PRODUCT);
+
+        assertThat(meterRegistry.find("passtheo_study_plan_drift_detected_total")
+                .tag("productCode", PRODUCT)
+                .tag("tenantId", TENANT_ID.toString())
+                .counter().count()).isEqualTo(1.0);
     }
 }

--- a/src/test/java/com/passtheo/content/unit/StudyPlanServiceTest.java
+++ b/src/test/java/com/passtheo/content/unit/StudyPlanServiceTest.java
@@ -341,6 +341,35 @@ class StudyPlanServiceTest {
     }
 
     @Test
+    void getActivePlan_regenerationThrows_returnsStoredPlanUnchanged() {
+        // Drift is detected and the counter is incremented, but generatePlan throws
+        // (e.g., Strapi unreachable). The orchestrator must fall back to the stored plan
+        // rather than propagating the exception and returning 500 to the caller.
+        LocalDate stalePlanDate = LocalDate.of(2030, 12, 31);
+        LocalDate profileExamDate = LocalDate.of(2026, 6, 1);
+        StudyPlan stale = fakeActivePlan(stalePlanDate);
+
+        when(planRepository.findByKeycloakUserIdAndProductCodeAndStatus(
+                eq(USER_ID), eq(PRODUCT), eq(PlanStatus.ACTIVE)))
+                .thenReturn(Optional.of(stale));
+        when(userServiceClient.getProfile(eq(USER_ID), eq(TENANT_ID)))
+                .thenReturn(Optional.of(fakeProfile(profileExamDate)));
+        // Force generatePlan to fail by making its first repository read throw.
+        when(readinessService.calculate(eq(USER_ID), eq(PRODUCT), anyString()))
+                .thenThrow(new RuntimeException("readiness service unavailable"));
+        when(planDayRepository.findByPlanIdOrderByDayNumberAsc(stale.getId()))
+                .thenReturn(List.of());
+
+        StudyPlanDto result = service.getActivePlan(USER_ID, PRODUCT);
+
+        assertThat(result.planId()).isEqualTo(stale.getId());
+        assertThat(result.examDate()).isEqualTo(stalePlanDate);
+        // Metric still fires — drift was observed even though repair failed.
+        assertThat(meterRegistry.find("passtheo_study_plan_drift_detected_total")
+                .counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
     void getActivePlan_driftDetected_incrementsDriftCounterExactlyOnce() {
         LocalDate stalePlanDate = LocalDate.of(2030, 12, 31);
         LocalDate profileExamDate = LocalDate.of(2026, 6, 1);

--- a/src/test/java/com/passtheo/content/unit/UserEventConsumerTest.java
+++ b/src/test/java/com/passtheo/content/unit/UserEventConsumerTest.java
@@ -12,6 +12,7 @@ import com.passtheo.content.repository.StreakRepository;
 import com.passtheo.content.repository.StudyPlanRepository;
 import com.passtheo.content.repository.TopicProgressRepository;
 import com.passtheo.content.service.StudyPlanService;
+import com.passtheo.shared.core.client.UserServiceInternalClient;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,7 @@ class UserEventConsumerTest {
     @Mock private ReadinessSnapshotRepository snapshotRepository;
     @Mock private StudyPlanRepository planRepository;
     @Mock private StudyPlanService studyPlanService;
+    @Mock private UserServiceInternalClient userServiceClient;
     @Mock private Acknowledgment ack;
 
     private UserEventConsumer consumer;
@@ -59,7 +61,7 @@ class UserEventConsumerTest {
         consumer = new UserEventConsumer(objectMapper,
                 progressRepository, topicProgressRepository, domainProgressRepository,
                 streakRepository, achievementRepository, examAttemptRepository,
-                snapshotRepository, planRepository, studyPlanService);
+                snapshotRepository, planRepository, studyPlanService, userServiceClient);
     }
 
     @Test
@@ -154,6 +156,29 @@ class UserEventConsumerTest {
                 ArgumentCaptor.forClass(GenerateStudyPlanRequest.class);
         verify(studyPlanService).generatePlan(eq(USER_ID), requestCaptor.capture(), eq("nl"));
         assertThat(requestCaptor.getValue().examDate()).isEqualTo(LocalDate.of(2026, 9, 1));
+        verify(ack).acknowledge();
+    }
+
+    @Test
+    void onUserExamDateSet_evictsUserProfileCacheBeforeRegenerating() {
+        String payload = """
+                {
+                  "eventType": "UserExamDateSet",
+                  "tenantId": "%s",
+                  "keycloakUserId": "%s",
+                  "productCode": "auto-b",
+                  "examDate": "2026-09-01"
+                }
+                """.formatted(TENANT_ID, USER_ID);
+        ConsumerRecord<String, String> record = kafkaRecord(payload);
+
+        consumer.onUserEvent(record, ack);
+
+        // Eviction must happen so computePlan's fallback branch inside generatePlan cannot
+        // read a stale cached profile while the Redis TTL (5 min) has not yet expired.
+        org.mockito.InOrder order = org.mockito.Mockito.inOrder(userServiceClient, studyPlanService);
+        order.verify(userServiceClient).evictCache(USER_ID, TENANT_ID);
+        order.verify(studyPlanService).generatePlan(eq(USER_ID), any(), eq("nl"));
         verify(ack).acknowledge();
     }
 

--- a/src/test/resources/karate/study-plan.feature
+++ b/src/test/resources/karate/study-plan.feature
@@ -53,9 +53,9 @@ Feature: Study plan generation with exam date fallback
     And match response.data.days == '#array'
 
   Scenario: POST /preview does not modify the active plan
-    * header X-Tenant-ID = tenantId
-    * header X-Keycloak-User-ID = userId
-    * header X-User-Roles = learnerRole
+    # `configure headers` makes the auth headers sticky for every request in this scenario.
+    # `header X-Foo` is consumed by a single request, so a multi-request scenario needs this.
+    * configure headers = { 'X-Tenant-ID': '#(tenantId)', 'X-Keycloak-User-ID': '#(userId)', 'X-User-Roles': '#(learnerRole)' }
     # Establish a baseline plan so we can prove the preview call leaves it untouched.
     Given path '/api/study-plan'
     And request { productCode: 'auto-b', examDate: '#(futureDate)', dailyQuestionTarget: 20 }
@@ -70,7 +70,9 @@ Feature: Study plan generation with exam date fallback
     Then status 200
     And match response.data.status == 'PREVIEW'
     And match response.data.planId == '#null'
-    # The active plan must be unchanged
+    # The active plan must be unchanged. Note: the baseline's examDate matches the user-service
+    # WireMock stub's examDate (see karate-config.js), so the reconcile-on-read path detects no
+    # drift and the stored plan is returned as-is.
     Given path '/api/study-plan'
     And param productCode = 'auto-b'
     When method get
@@ -78,3 +80,36 @@ Feature: Study plan generation with exam date fallback
     And match response.data.planId == baselinePlanId
     And match response.data.examDate == baselineExamDate
     And match response.data.status == 'ACTIVE'
+
+  Scenario: GET /api/study-plan reconciles examDate drift from user-service profile
+    # Uses a dedicated test userId with its own deterministic user-service stub
+    # (KarateRunner.configureUserServiceMocks) that returns examDate=2026-05-15.
+    * def driftUserId = '44444444-4444-4444-4444-444444444444'
+    * configure headers = { 'X-Tenant-ID': '#(tenantId)', 'X-Keycloak-User-ID': '#(driftUserId)', 'X-User-Roles': '#(learnerRole)' }
+    # Seed a plan with an examDate that clearly differs from the profile's. On GET the
+    # service must detect the drift, regenerate against the authoritative profile
+    # examDate, and return the fresh plan.
+    Given path '/api/study-plan'
+    And request { productCode: 'auto-b', examDate: '2030-12-31', dailyQuestionTarget: 20 }
+    When method post
+    Then status 200
+    * def stalePlanId = response.data.planId
+    And match response.data.examDate == '2030-12-31'
+
+    Given path '/api/study-plan'
+    And param productCode = 'auto-b'
+    When method get
+    Then status 200
+    And match response.success == true
+    And match response.data.examDate == '2026-05-15'
+    And match response.data.planId != stalePlanId
+    And match response.data.status == 'ACTIVE'
+    * def reconciledPlanId = response.data.planId
+
+    # Second GET is idempotent: stored examDate now matches the profile, no further regeneration.
+    Given path '/api/study-plan'
+    And param productCode = 'auto-b'
+    When method get
+    Then status 200
+    And match response.data.examDate == '2026-05-15'
+    And match response.data.planId == reconciledPlanId


### PR DESCRIPTION
Closes #89

## Changes

- **`StudyPlanService.getActivePlan`** now self-heals on `examDate` drift. It reads the authoritative `examDate` via `UserServiceInternalClient` (5-min Redis cache), and when the stored plan's `examDate` differs from a non-null profile `examDate`, it inline-regenerates the plan via the same `generatePlan(...)` the Kafka consumer uses, then returns the fresh plan. Null/unreachable profile → returns the stored plan unchanged.
- **WARN log + Micrometer counter `passtheo_study_plan_drift_detected_total`** (tagged `productCode`, `tenantId`) on every reconciliation, so drift frequency is observable in Prometheus.
- **`UserEventConsumer.handleExamDateSet`** evicts the user-profile cache before calling `generatePlan` so `computePlan`'s fallback branch cannot read a stale cached profile while the 5-min Redis TTL has not yet expired.
- OpenAPI description of `GET /api/study-plan` updated to document the self-healing behavior.
- 5 new unit tests in `StudyPlanServiceTest` cover: no-drift → no-op, drift → regenerate, profile-unavailable → return stored, profile-examDate-null → conservative no-op, drift → counter increments once.
- 1 new Karate scenario in `study-plan.feature` exercises end-to-end drift reconciliation against a WireMock user-service stub.
- 1 new unit test in `UserEventConsumerTest` verifies the cache-evict-then-regenerate ordering.
- Karate infrastructure: scenario 5 (`POST /preview does not modify the active plan`) now uses `configure headers` for sticky auth (`header` is per-request in Karate; multi-request scenarios needed this). `KarateRunner` registers priority-1 WireMock stubs for the paid user (404) and the drift-test user (200 verified), making per-user profile behavior deterministic regardless of file-stub load order.

## Why this approach

A Kafka-driven sync that must be perfect is fragile. Any failure path (consumer exception without ack, Strapi/readiness transient failure, `productCode` mismatch, seeded plan row from migrations/test fixtures that predates the profile's current value) leaves `content_db.study_plans.exam_date` stale relative to `user_service.user_profiles.exam_date`. Reconcile-on-read makes that drift invisible to users and easy to observe in metrics — without introducing a new admin endpoint, DLQ, or scheduled job.

## Test plan

- [ ] `./gradlew test --tests "com.passtheo.content.unit.StudyPlanServiceTest" --tests "com.passtheo.content.unit.UserEventConsumerTest"` — 18 unit tests pass (including 5 new drift-reconcile tests + 1 new cache-evict test)
- [ ] `./gradlew acceptanceTest` — `karate.study-plan` feature passes all 6 scenarios (including the new `GET /api/study-plan reconciles examDate drift` scenario). Remaining 29 failures across other feature files are pre-existing, not touched by this PR
- [ ] `docker compose build passtheo-content-service && docker compose up -d passtheo-content-service` — service starts cleanly on port 8087 in ~10s; `/actuator/health` returns `UP` for db, redis, livenessState, readinessState
- [ ] Post-deploy manual verification for jawad-en-1@local.com: first `GET /api/study-plan` after deploy produces a `WARN study plan examDate drift detected ... regenerating` log, increments `passtheo_study_plan_drift_detected_total`, and returns a plan with `examDate` matching `UserProfile.examDate`; Flutter home/profile and study-plan screens now show the same days-remaining count; a second GET is a silent no-op

## Out of scope (tracked separately)

- Kafka `DefaultErrorHandler` + DLQ hardening for `UserEventConsumer` — affects all 5 user event types, orthogonal to drift.
- `POST /internal/study-plan/reconcile` admin endpoint — unnecessary once reconcile-on-read is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)